### PR TITLE
Add /biz business brief documentation

### DIFF
--- a/BIZ.md
+++ b/BIZ.md
@@ -1,0 +1,42 @@
+# TerraNova `/biz` Brief
+
+## Business purpose
+TerraNova automates a controlled handoff from a Notion operations database into GitHub Issues.
+This supports auditability, clearer ownership, and consistent incident/change tracking without
+manual copy/paste.
+
+## Core workflow (business view)
+1. A team member flags a Notion row via `Export_to_GitHub`.
+2. The controller creates a GitHub Issue in the configured repository.
+3. The issue URL and export timestamp are written back to Notion.
+4. (Optional) The issue is placed in GitHub Projects v2 with `Status=Todo`.
+
+## Value delivered
+- **Faster triage:** Operations items appear where engineering already works (GitHub Issues).
+- **Governance by default:** Only explicitly flagged rows are exported.
+- **Traceability:** Bidirectional linkage (`GitHub_Issue_URL`) for audits and postmortems.
+- **Low operational overhead:** Runs from GitHub Actions on a schedule.
+
+## Required operating inputs
+- Notion integration token and database id.
+- GitHub token and target `owner/repo`.
+- Stable Notion property schema documented in `NOTION_PROPERTIES.md`.
+
+## Suggested KPIs
+- Export throughput: number of exported rows/week.
+- Time-to-triage: median duration from Notion creation to first GitHub assignee/comment.
+- Backlog hygiene: percentage of exported issues moved out of `Todo` within SLA.
+- Data quality: export failures due to missing/invalid Notion properties.
+
+## Risk and controls
+- **Risk:** Schema drift in Notion property names.
+  - **Control:** Keep mapping centralized in `scripts/notion_to_github.py` and review on schema changes.
+- **Risk:** Token misconfiguration or expiration.
+  - **Control:** Secrets managed in GitHub repository settings with periodic rotation.
+- **Risk:** Over-exporting noisy items.
+  - **Control:** Explicit checkbox gate (`Export_to_GitHub`) and optional severity-based triage policy.
+
+## `/biz` operating cadence
+- Weekly: review KPI dashboard and stale `Todo` items.
+- Monthly: verify Notion property compatibility and secret health.
+- Quarterly: review governance fields and escalation rules for incident severity.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ python scripts/notion_to_github.py
 ## GitHub Project (Projects v2) – optional
 - Add repo secret `PROJECTV2_ID` (ProjectV2 node id, e.g. `PVT_...`).
 - Exported issues will be added to the project and set `Status=Todo`.
+
+## Business brief
+- See `BIZ.md` for a concise `/biz` business-facing overview, KPI suggestions, and operating cadence.


### PR DESCRIPTION
### Motivation
- Provide a concise business-facing brief describing the purpose, value, core workflow, KPIs, risks, and operating cadence for the Notion → GitHub controller so non-technical stakeholders can quickly understand the initiative.

### Description
- Add `BIZ.md` containing the `/biz` brief and add a `Business brief` link in `README.md` that points to `BIZ.md` for discoverability.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a1147f7c832898d56c428452491c)