### PR TITLE
docs(sync): remove unsupported Projects v2 claims

### DIFF
--- a/BIZ.md
+++ b/BIZ.md
@@ -9,7 +9,6 @@ manual copy/paste.
 1. A team member flags a Notion row via `Export_to_GitHub`.
 2. The controller creates a GitHub Issue in the configured repository.
 3. The issue URL and export timestamp are written back to Notion.
-4. (Optional) The issue is placed in GitHub Projects v2 with `Status=Todo`.
 
 ## Value delivered
 - **Faster triage:** Operations items appear where engineering already works (GitHub Issues).
@@ -25,7 +24,7 @@ manual copy/paste.
 ## Suggested KPIs
 - Export throughput: number of exported rows/week.
 - Time-to-triage: median duration from Notion creation to first GitHub assignee/comment.
-- Backlog hygiene: percentage of exported issues moved out of `Todo` within SLA.
+- Backlog hygiene: percentage of exported issues triaged or closed within SLA.
 - Data quality: export failures due to missing/invalid Notion properties.
 
 ## Risk and controls
@@ -37,6 +36,6 @@ manual copy/paste.
   - **Control:** Explicit checkbox gate (`Export_to_GitHub`) and optional severity-based triage policy.
 
 ## `/biz` operating cadence
-- Weekly: review KPI dashboard and stale `Todo` items.
+- Weekly: review KPI dashboard and stale exported GitHub Issues.
 - Monthly: verify Notion property compatibility and secret health.
 - Quarterly: review governance fields and escalation rules for incident severity.

--- a/GITHUB_PROJECT_HELP.md
+++ b/GITHUB_PROJECT_HELP.md
@@ -1,4 +1,10 @@
-# Get GitHub ProjectV2 ID (user project #1)
+# GitHub Projects v2 note
+
+The Notion-to-GitHub controller does not currently read `PROJECTV2_ID` or mutate
+GitHub Projects v2. Do not add `PROJECTV2_ID` as part of the sync setup unless a
+separate project automation is implemented.
+
+For manual project administration, this command can still fetch a user project id:
 
 ```bash
 gh api graphql -f query='
@@ -8,5 +14,3 @@ query($login:String!, $number:Int!) {
   }
 }' -f login='q9yx7n64w7-creator' -F number=1
 ```
-
-Copy the returned `id` into repo secret `PROJECTV2_ID`.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ export GITHUB_REPO="owner/repo"
 python scripts/notion_to_github.py
 ```
 
-
-## GitHub Project (Projects v2) – optional
-- Add repo secret `PROJECTV2_ID` (ProjectV2 node id, e.g. `PVT_...`).
-- Exported issues will be added to the project and set `Status=Todo`.
+## GitHub Projects v2
+The controller does not mutate GitHub Projects v2. It creates Issues and writes
+the Issue URL back to Notion. Add exported Issues to a project manually or with
+a separate automation if project backlog state is required.
 
 ## Business brief
 - See `BIZ.md` for a concise `/biz` business-facing overview, KPI suggestions, and operating cadence.

--- a/config/notion_map.json
+++ b/config/notion_map.json
@@ -1,6 +1,5 @@
 {
     "github_repo": "q9yx7n64w7-creator/TerraNova-s-Framework",
-    "projectv2_id": "",
     "export_flag_property": "Export_to_GitHub",
     "url_property": "GitHub_Issue_URL",
     "date_property": "Exported_At",


### PR DESCRIPTION
- Controller does not mutate GitHub Projects v2
- Removes PROJECTV2_ID secret setup from README
- Converts GITHUB_PROJECT_HELP.md to manual admin note
- Drops unused projectv2_id from notion_map.json

Closes #3, closes #4