### PR TITLE
Add quick_script_sanity checker and document argparse NameError quick fix

### DIFF
--- a/scripts/PREFLIGHT_README.md
+++ b/scripts/PREFLIGHT_README.md
@@ -211,3 +211,24 @@ cat .tnv_sync.lock  # Shows PID of running process
 - [`notion_to_github.py`](./notion_to_github.py) – Main sync script
 - [`NOTION_PROPERTIES.md`](../NOTION_PROPERTIES.md) – Property mappings
 - [`.github/instructions/notion_to_github.py.instructions.md`](../.github/instructions/notion_to_github.py.instructions.md) – Development guidelines
+
+## Quick Fix: `NameError: name 'argparse' is not defined`
+
+If a script fails with `NameError: name 'argparse' is not defined`, run:
+
+```bash
+python scripts/quick_script_sanity.py scripts/notion_to_github.py
+```
+
+For any target file, replace the path with the failing script path.
+
+The checker reports:
+
+- `USES_ARGPARSE True` + `IMPORTS_ARGPARSE False` → add `import argparse` at the top.
+- `HAS_LITERAL_N True` with unusual formatting results → script likely got damaged by copy/paste rendering.
+
+You can also run a direct Python smoke check:
+
+```bash
+python -c "import argparse; print('argparse ok')"
+```

--- a/scripts/PREFLIGHT_README.md
+++ b/scripts/PREFLIGHT_README.md
@@ -222,9 +222,16 @@ python scripts/quick_script_sanity.py scripts/notion_to_github.py
 
 For any target file, replace the path with the failing script path.
 
+To apply the fastest auto-fix for that exact error:
+
+```bash
+python scripts/quick_script_sanity.py scripts/notion_to_github.py --fix-missing-argparse
+```
+
 The checker reports:
 
-- `USES_ARGPARSE True` + `IMPORTS_ARGPARSE False` → add `import argparse` at the top.
+- `USES_ARGPARSE True` + `IMPORTS_ARGPARSE False` → missing import detected.
+- `--fix-missing-argparse` inserts `import argparse` near the top automatically.
 - `HAS_LITERAL_N True` with unusual formatting results → script likely got damaged by copy/paste rendering.
 
 You can also run a direct Python smoke check:

--- a/scripts/quick_script_sanity.py
+++ b/scripts/quick_script_sanity.py
@@ -7,7 +7,41 @@ import argparse
 from pathlib import Path
 
 
-def check_script(path: Path) -> int:
+ARGPARSE_IMPORT_LINE = "import argparse\n"
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    return text if text.endswith("\n") else text + "\n"
+
+
+def _autofix_argparse_import(path: Path, text: str) -> bool:
+    """Insert `import argparse` near the top of the file if missing."""
+    lines = text.splitlines(keepends=True)
+
+    insert_at = 0
+    if lines and lines[0].startswith("#!"):
+        insert_at = 1
+
+    # Keep module docstring at file top when present.
+    if insert_at < len(lines) and lines[insert_at].lstrip().startswith(('"""', "'''")):
+        quote = '"""' if '"""' in lines[insert_at] else "'''"
+        insert_at += 1
+        while insert_at < len(lines):
+            if quote in lines[insert_at]:
+                insert_at += 1
+                break
+            insert_at += 1
+
+    # Skip future imports to avoid violating Python rules.
+    while insert_at < len(lines) and lines[insert_at].strip().startswith("from __future__ import"):
+        insert_at += 1
+
+    lines.insert(insert_at, ARGPARSE_IMPORT_LINE)
+    path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def check_script(path: Path, fix_missing_argparse: bool = False) -> int:
     if not path.exists():
         print(f"ERROR: file not found: {path}")
         return 2
@@ -15,7 +49,7 @@ def check_script(path: Path) -> int:
     text = path.read_text(encoding="utf-8")
     has_tabs = "\t" in text
     literal_n_count = text.count("\\n")
-    has_argparse_symbol = "argparse." in text
+    has_argparse_symbol = "argparse." in text or "ArgumentParser(" in text
     has_import_argparse = "import argparse" in text or "from argparse import" in text
 
     print(f"FILE: {path}")
@@ -25,6 +59,11 @@ def check_script(path: Path) -> int:
     print(f"IMPORTS_ARGPARSE {has_import_argparse}")
 
     if has_argparse_symbol and not has_import_argparse:
+        if fix_missing_argparse:
+            changed = _autofix_argparse_import(path, _ensure_trailing_newline(text))
+            if changed:
+                print("AUTO_FIXED inserted `import argparse`")
+                return 0
         print("LIKELY_ERROR missing `import argparse`")
         return 1
 
@@ -39,8 +78,13 @@ def check_script(path: Path) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run quick script sanity checks.")
     parser.add_argument("path", help="Path to a .py file")
+    parser.add_argument(
+        "--fix-missing-argparse",
+        action="store_true",
+        help="Automatically insert `import argparse` when argparse is used but missing.",
+    )
     args = parser.parse_args()
-    return check_script(Path(args.path))
+    return check_script(Path(args.path), fix_missing_argparse=args.fix_missing_argparse)
 
 
 if __name__ == "__main__":

--- a/scripts/quick_script_sanity.py
+++ b/scripts/quick_script_sanity.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Quick sanity checks for Python scripts pasted from chat/notion contexts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def check_script(path: Path) -> int:
+    if not path.exists():
+        print(f"ERROR: file not found: {path}")
+        return 2
+
+    text = path.read_text(encoding="utf-8")
+    has_tabs = "\t" in text
+    literal_n_count = text.count("\\n")
+    has_argparse_symbol = "argparse." in text
+    has_import_argparse = "import argparse" in text or "from argparse import" in text
+
+    print(f"FILE: {path}")
+    print(f"HAS_TAB {has_tabs}")
+    print(f"HAS_LITERAL_N {literal_n_count > 20} (count={literal_n_count})")
+    print(f"USES_ARGPARSE {has_argparse_symbol}")
+    print(f"IMPORTS_ARGPARSE {has_import_argparse}")
+
+    if has_argparse_symbol and not has_import_argparse:
+        print("LIKELY_ERROR missing `import argparse`")
+        return 1
+
+    if literal_n_count > 20 and not has_tabs:
+        print("LIKELY_ERROR file may be copy/paste-rendered with escaped newlines")
+        return 1
+
+    print("OK sanity checks passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run quick script sanity checks.")
+    parser.add_argument("path", help="Path to a .py file")
+    args = parser.parse_args()
+    return check_script(Path(args.path))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a small diagnostic tool to catch common issues when Python scripts are pasted from chat/Notion contexts, such as missing `import argparse` or escaped-newline rendering.  
- Surface a documented quick-fix in the preflight README so contributors can rapidly triage `NameError: name 'argparse' is not defined` failures.

### Description

- Add `scripts/quick_script_sanity.py`, a CLI checker that validates file existence, detects tabs, counts literal `\n` occurrences, and reports use/import of `argparse`, returning non-zero when likely problems are found.  
- Update `scripts/PREFLIGHT_README.md` with a "Quick Fix: `NameError: name 'argparse' is not defined'" section that documents how to run the checker and a direct Python smoke check.  
- The checker prints status flags `HAS_TAB`, `HAS_LITERAL_N`, `USES_ARGPARSE`, and `IMPORTS_ARGPARSE` and recommends adding `import argparse` when needed.  

### Testing

- Ran the Python smoke-check `python -c "import argparse; print('argparse ok')"` which executed successfully.  
- Executed the new checker with `python scripts/quick_script_sanity.py scripts/notion_to_github.py` as a basic automated smoke test and it produced the expected diagnostic output and exit code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6abb2ccc83289de0e295b7454935)