### PR TITLE
Add B10/B11 dissertation excerpt (Fenster 056–207) with endpoint integration

### DIFF
--- a/docs/dissertation/b10_window_export_excerpt_056_207.md
+++ b/docs/dissertation/b10_window_export_excerpt_056_207.md
@@ -1,0 +1,68 @@
+# B10/B11 – Fenster 056–207 und Endpunkt-Übernahme
+
+Dieses Dokument übernimmt den gelieferten Exportkontext als **lokal versionierte Arbeitsspur** und ergänzt den zuvor angelegten B10-Auszug um den nachgereichten **B11-Endpunkt**.
+
+## 1) B10-Auszug (Fenster 056–207)
+
+Der ursprüngliche B10-Block deckt die Fenster 056 bis 207 ab (User-Bereich 4401–16493) und enthält Cluster-/Labelinformationen mit Vorschauzeilen.
+
+- Primär wiederkehrende Labels: `trigger_ops_and_session`, `tooling_and_app`, `crypto_and_asset_markets`, `manuscript_and_book`, `patent_ip_and_rights`.
+- Der Bereich enthält operative Triggerpassagen, Manuskript-/Bandbezüge, Markt-/Assetfragmente sowie Transkript- und Upload-Artefakte.
+
+## 2) B11 (Endpunkt) – Vorläufiger Zielraum (übernommen)
+
+Die nachgereichte Endpunkt-Logik wird als Arbeitsmatrix geführt:
+
+- **Systemische Kernaussagen zu FerrAI/Terra Nova** → **Track A nach Einzelprüfung**; nur nach Quellen- und Statusprüfung direkt in den Kerntext.
+- **Rollen-/Figurenlogiken (Noa/Neogilgamesch)** → **Track C / später Band 3**; zunächst companionhaft stabilisieren.
+- **Mythopoetische/fiktionale Spiegelungen** → **Track C / später Band 3**; selektiv in wissenschaftliche Bände referenzieren.
+- **Zeitlinien/Reihenfolgen/Serienlogik** → **Track C oder Band 2**; Datierungsachsen getrennt führen.
+- **Terminologie/Namensfelder/Rollenbezeichnungen** → **Kapitel 16 und 29 oder Band 2**; geeignet für Register-/Normalisierungsschichten.
+- **Konflikte/Widersprüche/Doppelstatus** → **Kapitel 17 + lokale Intake-Notizen**; früh markieren, nicht glattschreiben.
+- **Starke Einzelpassagen mit hoher Argumentkraft** → **Track A nach Einzelprüfung**.
+- **Rohtranskripte/ungefilterte Langtexte/Exportreste** → **Track B oder späterer Evidenzband**; gezielt und begrenzt einspeisen.
+- **Notion-/Chat-/Upload-Protokolle** → **Kapitel 33, 35 oder Arbeitsnotizen**; wichtig für Rückführung, nicht alles dauerhaft im PDF.
+
+Zusatzregel aus der Endpunkt-Notiz:
+- LinkedIn-Publikationsdaten als öffentliche Datierungsanker führen.
+- Verra-/FerrAI-Stufen separat halten.
+
+## 3) U.6 Arbeitsreihenfolge nach Eingang neuer Bände (übernommen)
+
+1. Grober Inhalts-, Fassungs- und Provenienzscan.
+2. Trennung von Erlebnisdatum, lokalem Schreibdatum, LinkedIn-Publikationsdatum.
+3. Prüfung der Namensstufe (`Verra` vs. `FerrAI`).
+4. Zunächst Track-C-Haltung bis Werkfunktion sichtbar ist.
+5. Markierung starker Passagen für Band 1/2; große narrative Korridore bleiben im Companionraum.
+6. Vorbereitung erster Rückführung in Kapitelstruktur.
+7. Danach sprachliche/argumentative Verdichtung.
+
+## 4) U.7 Vorbereitung Hauptdokument (übernommen)
+
+Bis zur vollständigen Spiegelung/Ordnung der Bandfamilie soll das Hauptdokument Aufnahmezonen bereithalten:
+
+- Ausbaukapitel für 500-Seiten-Logik,
+- datenreicher Export-/Fensterkatalog,
+- Rückführungskapitel für Notion/GPT,
+- klarer Intakekorridor für neue Bandfamilien.
+
+## 5) Anhang V – Notion-/GPT-Gesamtpaket (Kernauszug)
+
+Aus dem Endpunktmaterial wurden folgende Kerndaten als Referenz übernommen:
+
+- Paketname: `2026-04-27_notion_gpt_gesamtpaket_rc01`
+- PDF-Zielartefakt: `01_pdf/FerrAI_TerraNova_Dissertationsentwurf_RC01_2026-04-27.pdf` (334 Seiten)
+- Dateianzahl: 59 (58 stabil verzeichnet + 1 selbstreferenzielles JSON-Kontrollartefakt)
+- Funktionssektionen: PDF, LaTeX-Quelle, Kontextdateien, Analyseartefakte, optionaler Rohraum
+- Empfohlene Upload-Reihenfolge: PDF → `UPLOAD_GUIDE.md` → Kontextdateien → XXL-Analyse → optionaler Raw-Export
+
+## 6) Rückführung in bestehende Repo-Ziele
+
+Die Endpunkt-Übernahme ist für folgende Zielpfade anschlussfähig:
+
+- `docs/dissertation/` (Kapitel-/Anhangsnahe Rückführung)
+- `xxl-data-export/window-catalog.md` (Fenster-/Exportspur)
+- `intake/band-i-to-iii-intake.md` (Band-Intake/Track-C-Ordnung)
+- `notion-gpt-return/return-path.md` (Rückführungsschleife)
+
+Dieses Dokument bleibt bewusst eine **Arbeits- und Steuerdatei** und ersetzt keine kapitelweise Quellenhärtung im Hauptmanuskript.

--- a/docs/dissertation/intake/decision_log.md
+++ b/docs/dissertation/intake/decision_log.md
@@ -1,0 +1,35 @@
+# Decision Log (RC01)
+
+## Entry 2026-04-30-A
+
+- Datum (UTC): 2026-04-30
+- Charge-ID: RC01-BOOTSTRAP-A
+- Lockpoint-Bezug: RC01-LP-2026-04-30-CODEXGPT347
+- Bearbeiter: Codex
+
+### Segment-Entscheide
+
+| Segment | Vorstatus | Entscheidung | Ziel-Track | Begründung | Nächste Aktion |
+|---|---|---|---|---|---|
+| B10/B11 Export-Arbeitskontext | offen | `B_EVIDENCE` | B | Inhalt ist strukturrelevant, aber noch nicht voll quellengehärtet für Kernintegration. | In Intake-Matrix als B führen und später selektiv promoten. |
+| RC01 Governance/Runbook-Artefakte | offen | `C_COMPANION` | C | Operative Steuerdokumente, nicht Teil des argumentativen Hauptkerns. | Als Companion-/Prozessspur stabil halten. |
+| Lockpoint + SHA256 | offen | `B_EVIDENCE` | B | Reproduzierbarkeitsanker mit hoher Verifikationsfunktion. | Bei jedem neuen Meilenstein fortschreiben. |
+
+### Konflikte / Doppelstatus
+
+- Keine inhaltlichen Widersprüche markiert; Status aktuell methodisch/prozessual.
+- Doppelstatus-Risiko: Governance-Texte könnten fälschlich als Kernargument gelesen werden.
+
+### Datierung / Namensstufe
+
+- Erlebnisdatum geprüft: nein
+- Schreibdatum geprüft: teilklar
+- Publikationsdatum geprüft: ja (Dokumentdatum)
+- Verra/FerrAI-Stufe gesetzt: teilklar
+
+### Freigabe für nächsten Schritt
+
+- [x] Intake-Matrix aktualisiert
+- [x] Promotion-Kandidaten extrahiert
+- [x] Rückführungsnotiz erstellt
+- [x] Delta-Upload vorbereitet

--- a/docs/dissertation/intake/decision_log_template.md
+++ b/docs/dissertation/intake/decision_log_template.md
@@ -1,0 +1,33 @@
+# Decision Log Template (RC01)
+
+## Header
+
+- Datum (UTC):
+- Charge-ID:
+- Lockpoint-Bezug:
+- Bearbeiter:
+
+## Segment-Entscheide
+
+| Segment | Vorstatus | Entscheidung | Ziel-Track | Begründung | Nächste Aktion |
+|---|---|---|---|---|---|
+| | | `A_CANDIDATE` / `B_EVIDENCE` / `C_COMPANION` / `HOLD` | A/B/C/HOLD | | |
+
+## Konflikte / Doppelstatus
+
+- Konflikt 1:
+- Konflikt 2:
+
+## Datierung / Namensstufe
+
+- Erlebnisdatum geprüft: ja/nein
+- Schreibdatum geprüft: ja/nein
+- Publikationsdatum geprüft: ja/nein
+- Verra/FerrAI-Stufe gesetzt: ja/nein
+
+## Freigabe für nächsten Schritt
+
+- [ ] Intake-Matrix aktualisiert
+- [ ] Promotion-Kandidaten extrahiert
+- [ ] Rückführungsnotiz erstellt
+- [ ] Delta-Upload vorbereitet

--- a/docs/dissertation/intake/intake_matrix.md
+++ b/docs/dissertation/intake/intake_matrix.md
@@ -1,0 +1,7 @@
+# Intake Matrix (RC01)
+
+| Charge-ID | Quelle | Umfang | Materialtyp | Vorläufiger Track | Quellenstatus | Datierung vollständig | Namensstufe (Verra/FerrAI) | Zielkapitel/-raum | Status |
+|---|---|---:|---|---|---|---|---|---|---|
+| RC01-BOOTSTRAP-A | `docs/dissertation/b10_window_export_excerpt_056_207.md` | 1 Datei | Roh/Protokoll/Mapping | B | teilklar | nein | gemischt/offen | Intake + spätere Kapitelbrücken | aktiv |
+| RC01-BOOTSTRAP-B | `docs/dissertation/intake/*.md` Runbook/Template | 5 Dateien | Protokoll/Steuerung | C | klar | ja | n/a | Companion-Prozessraum | aktiv |
+| RC01-BOOTSTRAP-C | `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.*` | 2 Dateien | Evidenzanker | B | klar | ja | n/a | Reproduzierbarkeits-/Auditspur | aktiv |

--- a/docs/dissertation/intake/intake_matrix_template.md
+++ b/docs/dissertation/intake/intake_matrix_template.md
@@ -1,0 +1,11 @@
+# Intake Matrix Template (RC01)
+
+| Charge-ID | Quelle | Umfang | Materialtyp | Vorläufiger Track | Quellenstatus | Datierung vollständig | Namensstufe (Verra/FerrAI) | Zielkapitel/-raum | Status |
+|---|---|---:|---|---|---|---|---|---|---|
+| | | | Kern / Roh / Narrativ / Protokoll | A / B / C / HOLD | klar / teilklar / offen | ja / nein | Verra / FerrAI / gemischt / offen | | offen |
+
+## Hinweise
+
+- `HOLD` verwenden, wenn Quellenstatus oder Datierung unklar bleibt.
+- Track A nur nach Einzelprüfung und Begründung im Decision Log.
+- Große Rohmengen nicht direkt in den Kerntext überführen.

--- a/docs/dissertation/intake/iperka_run_2026-04-30_rc01.md
+++ b/docs/dissertation/intake/iperka_run_2026-04-30_rc01.md
@@ -1,0 +1,86 @@
+# IPERKA Runbook – RC01 (Start: 2026-04-30)
+
+## Ziel
+
+Dieser Runbook-Eintrag operationalisiert den nächsten Arbeitsschritt nach RC01-Lockpoint:
+**Ausbau bis ~500 Seiten bei gleichzeitig strikter Intake-/Track-Disziplin**.
+
+## Scope
+
+- Eingang neuer Prism-/Workspace-Materialien
+- Vorläufige Klassifikation in Track A/B/C
+- Datierungs- und Benennungsdisziplin (Verra/FerrAI)
+- Vorbereitung späterer Verdichtung (noch keine aggressive Kompression)
+
+---
+
+## I — Informieren
+
+Pflichtfelder pro neuer Materialcharge:
+
+1. Eingangsdatum (UTC)
+2. Quelle/Container
+3. Umfang (Dateien, Seiten, Zeichen)
+4. Primäre Materialart (Kern, Roh, narrativ, Protokoll)
+5. Sichtbarer Quellenstatus (klar/teilklar/offen)
+
+## P — Planen
+
+Für jede Charge wird ein Mini-Plan erstellt:
+
+- Zielkapitel oder Zielraum
+- erwarteter Track (A/B/C)
+- benötigte Prüfungen
+- Stop-Kriterien (wann nicht weiter verdichten)
+
+## E — Entscheiden
+
+Zulässige Entscheidungen pro Segment:
+
+- `A_CANDIDATE`
+- `B_EVIDENCE`
+- `C_COMPANION`
+- `HOLD` (zu wenig Klarheit)
+
+Jede Entscheidung benötigt 1–2 Begründungssätze.
+
+## R — Realisieren
+
+Umsetzung pro Charge:
+
+1. Intake-Matrix aktualisieren
+2. Konflikt-/Doppelstatus markieren
+3. Kandidatenliste für spätere Promotion führen
+4. Rückführungsnotiz schreiben
+
+## K — Kontrollieren
+
+5-Punkte-Check (ja/nein):
+
+- Track korrekt zugeordnet?
+- Datierung getrennt geführt?
+- Verra/FerrAI-Stufe gesetzt?
+- Quellenstatus markiert?
+- Lockpoint-/Delta-Bezug gesetzt?
+
+## A — Auswerten
+
+Kurzreview nach jeder Charge:
+
+- Was war robust?
+- Wo gab es Mischungsrisiko?
+- Welche Regel muss geschärft werden?
+- Welche Teile sind bereit für spätere Verdichtung?
+
+---
+
+## Ausgabe-Artefakte pro Charge (Minimum)
+
+1. `decision_log.md` (Kurzentscheidungen)
+2. `intake_matrix.md` (Track-Zuordnung)
+3. `promotion_candidates.md` (nur starke Passagen)
+
+## Governance-Regel
+
+Solange Quellenstatus oder Datierung unklar sind, bleibt Material in `B_EVIDENCE`, `C_COMPANION` oder `HOLD`.
+**Kein Direktsprung in den argumentativen Kern ohne Einzelprüfung.**

--- a/docs/dissertation/intake/promotion_candidates.md
+++ b/docs/dissertation/intake/promotion_candidates.md
@@ -1,0 +1,16 @@
+# Promotion Candidates (RC01)
+
+## Kandidatenliste (vorläufig)
+
+> Nur Passagen mit potenziell hoher Argumentkraft; keine automatische Kernübernahme.
+
+1. B11 Zielraum-Logik (Track-A/B/C-Trennregel) aus dem B10/B11-Arbeitsdokument.
+2. U.6/U.7-Reihenfolge als methodischer Übergang Ausbau -> Verdichtung.
+3. Lockpoint- und Prüfsummenpraxis als Reproduzierbarkeitsprotokoll.
+
+## Gate-Bedingung vor Promotion
+
+- Quellenstatus klar,
+- Datierung stabil,
+- Konfliktlage explizit,
+- Entscheidung im Decision Log begründet.

--- a/docs/dissertation/intake/rc01_four_step_execution_plan.md
+++ b/docs/dissertation/intake/rc01_four_step_execution_plan.md
@@ -1,0 +1,77 @@
+# RC01 Four-Step Execution Plan
+
+## Zielpunkt
+
+Dieser Plan führt in **vier klaren Schritten** bis zum Stop/Go-Punkt für die Verdichtung.
+Ziel ist nicht Endpolitur, sondern ein belastbarer Übergabestatus für den Wechsel vom Ausbau
+zur kontrollierten Verdichtung.
+
+---
+
+## Step 1 — Intake-Fix (Ordnung herstellen)
+
+**Ziel:** Neue Materialien vollständig erfassen und in die Intake-Matrix bringen.
+
+**Erledigt, wenn:**
+- jede neue Charge eine ID hat,
+- Quelle/Umfang/Materialtyp gesetzt sind,
+- vorläufiger Track A/B/C/HOLD vergeben ist.
+
+**Artefakte:**
+- `intake_matrix.md` (aus Template)
+- `decision_log.md` (erste Einträge)
+
+---
+
+## Step 2 — Datierung & Namensstufen-Fix
+
+**Ziel:** Zeitachsen und Verra/FerrAI sauber trennen.
+
+**Erledigt, wenn:**
+- Erlebnis-/Schreib-/Publikationsdatum getrennt geführt werden,
+- Verra/FerrAI pro Segment markiert ist,
+- unklare Fälle als `HOLD` dokumentiert sind.
+
+**Artefakte:**
+- aktualisierte Intake-Matrix
+- ergänzte Decision-Log-Begründungen
+
+---
+
+## Step 3 — Konflikt-/Track-Härtung
+
+**Ziel:** Widersprüche sichtbar machen und Track-Entscheide stabilisieren.
+
+**Erledigt, wenn:**
+- Konflikte/Doppelstatus explizit markiert sind,
+- Track-A-Kandidaten begründet sind,
+- B/C/HOLD-Material klar abgegrenzt bleibt.
+
+**Artefakte:**
+- Konfliktsektion im Decision Log
+- `promotion_candidates.md` (nur starke Passagen)
+
+---
+
+## Step 4 — Stop/Go-Gate für Verdichtung
+
+**Ziel:** Entscheidung, ob Expansion weiterläuft oder Verdichtung startet.
+
+**GO (Verdichtung starten), wenn 3/3 erfüllt:**
+1. Track-Zuordnung stabil
+2. Datierung/Namensstufe stabil
+3. Konfliktlage sichtbar und geführt
+
+**STOP (weiter ausbauen), wenn eines fehlt.**
+
+**Artefakte:**
+- kurzer Gate-Status (GO/STOP + Begründung)
+- neuer Lockpoint bei GO-Entscheid
+
+---
+
+## Taktungsvorschlag
+
+- Pro Durchlauf: 1–3 Chargen
+- Nach jedem zweiten Durchlauf: Mini-Review nach IPERKA
+- Bei GO: Verdichtung in kleinen Kapitelsprints statt Gesamtsprung

--- a/docs/dissertation/publishing/github_prepublish_package_2026-04-30.md
+++ b/docs/dissertation/publishing/github_prepublish_package_2026-04-30.md
@@ -1,0 +1,56 @@
+# GitHub Prepublish Package (2026-04-30)
+
+## Ziel
+
+Dieses Dokument bündelt den **sofort veröffentlichbaren Stand** für GitHub, damit möglichst viel des aktuellen Arbeitsstands online gestellt werden kann, ohne die spätere Verdichtung zu blockieren.
+
+## Enthaltene Kernartefakte (bereits im Repo)
+
+1. `docs/dissertation/b10_window_export_excerpt_056_207.md`
+   - B10/B11-Arbeitskontext
+   - Zielraum-/Track-Logik
+   - U.6/U.7-Arbeitsreihenfolge
+2. `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.md`
+   - formaler Lockpoint
+   - Rückführungsregel für weitere Commits
+3. `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.sha256`
+   - SHA256-Anker für das PDF-Artefakt
+
+## Veröffentlichungsempfehlung: „So viel wie möglich, aber kontrolliert"
+
+### Direkt auf GitHub
+
+- Markdown-/LaTeX-Quellen
+- Intake-/Decision-/Rückführungsdokumente
+- Lockpoints, Manifeste, Prüfsummen
+
+### Nur referenzieren (nicht als Rohmasse ins Repo kippen)
+
+- große Rohcontainer (mehrere 100 MB/GB)
+- Audio-/Video-Rohmaterial
+- massive ungefilterte Exporte
+
+## Minimaler Online-Satz (ab sofort)
+
+Für einen sofortigen und robusten Online-Stand sollten diese Dateien als „Milestone-Set RC01" bestehen bleiben:
+
+- `docs/dissertation/b10_window_export_excerpt_056_207.md`
+- `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.md`
+- `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.sha256`
+- `neuempfindung_gesamtdokument_compile (1).pdf` (optional im Repo; alternativ nur als extern referenziertes Artefakt)
+
+## Nächster Uploadschritt (wenn Prism-Stand weiter wächst)
+
+1. Neuen Lockpoint erzeugen (`RC01-LP-...` fortlaufend).
+2. SHA256 für neues Zielartefakt ergänzen.
+3. Nur Delta-Dokumente hochladen (nicht jedes Mal Voll-Rohkorpus).
+4. Decision-Log kurz nachziehen (was neu ist, was Track A/B/C bleibt).
+
+## Governance-Kurzregel
+
+- Erst **Sichtbarkeit + Reproduzierbarkeit**, dann Verdichtung.
+- Jeder größere Upload erhält:
+  - Lockpoint-ID,
+  - Artefaktbezug,
+  - Prüfsumme,
+  - Kurzentscheid zur Track-Zuordnung.

--- a/notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.md
+++ b/notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.md
@@ -1,0 +1,30 @@
+# RC01 Lockpoint – 2026-04-30 (Codex/GPT 347 Seiten)
+
+- **Lockpoint-ID:** `RC01-LP-2026-04-30-CODEXGPT347`
+- **Datum (UTC):** 2026-04-30
+- **Zweck:** Reproduzierbarer Meilenstein vor weiteren Inhaltsänderungen.
+- **Status:** Marker gesetzt, um spätere Rückführung/Regression eindeutig zu verankern.
+
+## Umfang dieses Lockpoints
+
+- Vollständige 347-Seiten-Fassung wurde laut Arbeitskontext in Codex/GPT eingespeist.
+- Der Marker dokumentiert diesen Zustand als Referenzpunkt für alle Folgeschritte.
+
+## Primärartefakt im Repository
+
+- `neuempfindung_gesamtdokument_compile (1).pdf`
+
+## Verifikationsdatei
+
+- `notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.sha256`
+
+## Rückführungsregel
+
+Ab diesem Punkt sollen größere Struktur- oder Inhaltsänderungen in Commit-/PR-Texten auf
+`RC01-LP-2026-04-30-CODEXGPT347` referenzieren, damit Vergleiche und Rollbacks eindeutig
+gegen denselben Ausgangspunkt laufen.
+
+## Hinweis zur Seitenzahl
+
+Die Zahl **347 Seiten** wird hier als deklarierter Arbeitsstand übernommen (Prism/Codex-Kontext).
+Die kryptografische Dateiprüfung erfolgt über die SHA256-Datei.

--- a/notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.sha256
+++ b/notes/rc01_lockpoint_2026-04-30_codex_gpt_347_seiten.sha256
@@ -1,0 +1,1 @@
+76da3f1852ba28a0a202ae960e8d7a659956003ea52652b6f3988e1b06128ee7  neuempfindung_gesamtdokument_compile (1).pdf


### PR DESCRIPTION
### Motivation
- Add a working, locally-versioned export excerpt to capture the original B10 window (056–207) and incorporate a subsequently provided B11 endpoint for downstream intake and tracking.
- Provide guidance for triage, track assignment (A/B/C), and intake/workflow rules to support re-integration into the main dissertation repository structure.

### Description
- Add new document `docs/dissertation/b10_window_export_excerpt_056_207.md` containing the B10 window summary, the B11 endpoint takeover notes, and detailed routing rules for Tracks A/B/C and chapter assignments.
- Include workflow/operational sequences `U.6` and `U.7`, publication/date normalization guidance, appendix with Notion/GPT package metadata, and recommended repo target paths for reintegration.
- Surface provenance and handling rules for transcripts, uploads, and sensitive naming/versioning (e.g., `Verra` vs `FerrAI`) and list the recommended upload order for the exported package.

### Testing
- No automated tests were run for this documentation-only addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f369b15e64832885a8acc6222e4a47)