### PR TITLE
docs: migrate atlas naming from Prism to CIC

### DIFF
--- a/docs/ai/cic_atlas_usage.md
+++ b/docs/ai/cic_atlas_usage.md
@@ -1,0 +1,119 @@
+# CIC Atlas Usage
+
+Status: working architecture note
+
+## Purpose
+
+This note defines how the CIC atlas material should be used inside the repository and agent workflow.
+
+OpenAI Prism may remain a source/editor context where it produced exports, but the TerraNova framework and atlas layer use **CIC** as the project-facing name.
+
+The source pack is not only a visual export. It should become a controlled navigation, validation and publishing layer for TerraNova / FerrAI.
+
+## Source roles
+
+Use the current material in four roles:
+
+| Role | Source artifact | Use |
+| --- | --- | --- |
+| Payload bundle | `TerraNova_AllInOne` | Archiveable full export for graph, Mermaid and README material. |
+| Landing atlas | `TerraNova System Atlas - CIC Framework Overview` | Human-readable start page and onboarding map. |
+| Trigger register | `Trigger-System - Deep Reference (1-992)` | Internal trigger index, gap tracking and agent routing reference. |
+| Diagram registry | `Mermaid Code Library - Complete Collection` plus CSV registry | Renderable graph source and metadata truth for diagram status. |
+
+## Internal use
+
+1. Treat the atlas as the first orientation layer for TerraNova/CIC work.
+2. Feed only reviewed extracts into Codex skills, AGENTS notes or automation prompts.
+3. Keep sensitive trigger, token, wallet, private archive and Schattenarchiv details out of public exports.
+4. Use the diagram registry to identify active vs legacy Mermaid diagrams before copying any graph into docs or presentations.
+5. Track undocumented trigger ranges as gaps, not as invented content.
+
+## Repository use
+
+Recommended local structure:
+
+```text
+raw/exports/prism/
+  source-pack/              # raw OpenAI Prism/Notion exports, unchanged for provenance
+docs/ai/
+  cic_atlas_usage.md        # this routing note
+  prism_atlas_usage.md      # legacy compatibility note
+  full_sync_terra_nova_mcp_sequence.md
+docs/atlas/
+  index.md                  # curated human-facing atlas, generated later
+  diagrams.md               # reviewed Mermaid registry, generated later
+docs/triggers/
+  trigger_reference.md      # reviewed trigger subset, generated later
+```
+
+The raw source pack stays archival. Curated docs are derived from it and should state their source and review status.
+
+## Agent use
+
+Use the atlas as a routing surface:
+
+```text
+User intent
+  -> CIC atlas area
+  -> source artifact
+  -> reviewed extract
+  -> Codex action / OpenAI Prism edit / GitHub doc update
+```
+
+This prevents raw chat exports from becoming system truth while still making the workspace map useful for agents.
+
+## Public use
+
+The public-facing slice is:
+
+- Mermaid as living trigger system
+- TerraNova atlas as visual system navigation
+- CIC as coordination and consistency framework
+- OpenAI Prism only as an external/editor source context where explicitly needed
+
+Do not publish private trigger canon, deep Schattenarchiv material, wallet/token operations, patent-sensitive mappings or raw personal logs without a separate review decision.
+
+## Local renderer
+
+Preferred entry point:
+
+```text
+scripts/render_cic_atlas.py
+```
+
+Legacy compatibility entry point:
+
+```text
+scripts/render_prism_atlas.py
+```
+
+Current source-pack location:
+
+```text
+raw/exports/prism/source-pack/2026-05-02/
+```
+
+Generated outputs:
+
+```text
+docs/atlas/index.md
+docs/atlas/diagrams.md
+docs/atlas/public_overview.md
+docs/atlas/operator_map.md
+docs/atlas/source_inventory.csv
+docs/atlas/source_manifest.json
+docs/triggers/gap_ledger.md
+```
+
+Run it with:
+
+```powershell
+python scripts/render_cic_atlas.py
+```
+
+Or pin a source pack explicitly:
+
+```powershell
+python scripts/render_cic_atlas.py --source-dir raw\exports\prism\source-pack\2026-05-02 --output-dir docs\atlas
+```

--- a/docs/ai/prism_atlas_usage.md
+++ b/docs/ai/prism_atlas_usage.md
@@ -1,122 +1,31 @@
-# Prism Atlas Usage
+# Legacy: Prism Atlas Usage
 
-Status: working architecture note
+Status: legacy compatibility note
 
-## Purpose
+The TerraNova framework naming has moved from **PRISM** to **CIC** to avoid confusion with OpenAI Prism.
 
-This note defines how the Prism editor implementation of the TerraNova atlas
-material should be used inside the repository and agent workflow.
-
-The source pack is not only a visual export. It should become a controlled
-navigation, validation and publishing layer for TerraNova / FerrAI.
-
-## Source roles
-
-Use the current material in four roles:
-
-| Role | Source artifact | Use |
-| --- | --- | --- |
-| Payload bundle | `TerraNova_AllInOne` | Archiveable full export for graph, Mermaid and README material. |
-| Landing atlas | `TerraNova System Atlas - CIC Framework Overview` | Human-readable start page and onboarding map. |
-| Trigger register | `Trigger-System - Deep Reference (1-992)` | Internal trigger index, gap tracking and agent routing reference. |
-| Diagram registry | `Mermaid Code Library - Complete Collection` plus CSV registry | Renderable graph source and metadata truth for diagram status. |
-
-## Internal use
-
-1. Treat the atlas as the first orientation layer for TerraNova/CIC work.
-2. Feed only reviewed extracts into Codex skills, AGENTS notes or automation
-   prompts.
-3. Keep sensitive trigger, token, wallet, private archive and Schattenarchiv
-   details out of public exports.
-4. Use the diagram registry to identify active vs legacy Mermaid diagrams before
-   copying any graph into docs or presentations.
-5. Track undocumented trigger ranges as gaps, not as invented content.
-
-## Repository use
-
-Recommended local structure:
+Use the active note instead:
 
 ```text
-raw/exports/prism/
-  source-pack/              # raw Prism/Notion exports, unchanged
-docs/ai/
-  prism_atlas_usage.md      # this routing note
-  full_sync_terra_nova_mcp_sequence.md
-docs/atlas/
-  index.md                  # curated human-facing atlas, generated later
-  diagrams.md               # reviewed Mermaid registry, generated later
-docs/triggers/
-  trigger_reference.md      # reviewed trigger subset, generated later
+docs/ai/cic_atlas_usage.md
 ```
 
-The raw source pack stays archival. Curated docs are derived from it and should
-state their source and review status.
+## Naming rule
 
-## Agent use
+- **CIC** = TerraNova framework / atlas / consistency layer.
+- **OpenAI Prism** = external editor/source context, only where explicitly meant.
+- Raw source paths under `raw/exports/prism/` remain unchanged for provenance unless a separate migration explicitly moves them.
 
-Use the atlas as a routing surface:
+## Renderer
 
-```text
-User intent
-  -> atlas area
-  -> source artifact
-  -> reviewed extract
-  -> Codex action / Prism edit / GitHub doc update
+Preferred:
+
+```powershell
+python scripts/render_cic_atlas.py
 ```
 
-This prevents raw chat exports from becoming system truth while still making the
-workspace map useful for agents.
-
-## Public use
-
-The public-facing slice is:
-
-- Mermaid as living trigger system
-- TerraNova atlas as visual system navigation
-- CIC as coordination and consistency framework
-- Prism as internal authoring/editor layer unless naming is reviewed
-
-Do not publish private trigger canon, deep Schattenarchiv material, wallet/token
-operations, patent-sensitive mappings or raw personal logs without a separate
-review decision.
-
-## Local renderer
-
-The local renderer is implemented at:
-
-```text
-scripts/render_prism_atlas.py
-```
-
-Current source-pack location:
-
-```text
-raw/exports/prism/source-pack/2026-05-02/
-```
-
-Generated outputs:
-
-```text
-docs/atlas/index.md
-docs/atlas/diagrams.md
-docs/atlas/public_overview.md
-docs/atlas/operator_map.md
-docs/atlas/source_inventory.csv
-docs/atlas/source_manifest.json
-docs/triggers/gap_ledger.md
-```
-
-This gives Prism, Codex and GitHub the same map without requiring a new Notion
-page or external system mutation.
-
-Run it with:
+Legacy compatibility:
 
 ```powershell
 python scripts/render_prism_atlas.py
-```
-
-Or pin a source pack explicitly:
-
-```powershell
-python scripts/render_prism_atlas.py --source-dir raw\exports\prism\source-pack\2026-05-02 --output-dir docs\atlas
 ```

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -1,14 +1,14 @@
 # TerraNova Atlas Docs
 
-Status: local reviewed atlas workspace
+Status: local reviewed CIC atlas workspace
 
 ## Entry Points
 
 | File | Use |
 | --- | --- |
-| `index.md` | Main local atlas start page and source-pack orientation. |
+| `index.md` | Main local CIC atlas start page and source-pack orientation. |
 | `public_overview.md` | Public-candidate slice for Mermaid/CIC/Systemnavigation material. |
-| `operator_map.md` | Internal routing map for Codex, Prism and future agents. |
+| `operator_map.md` | Internal routing map for Codex, OpenAI Prism source context and future agents. |
 | `diagrams.md` | Active/legacy/unknown Mermaid diagram registry. |
 | `source_inventory.csv` | Machine-readable source file inventory. |
 | `source_manifest.json` | Full generated source and diagram manifest. |
@@ -18,14 +18,23 @@ Status: local reviewed atlas workspace
 From the repository root:
 
 ```powershell
+python scripts/render_cic_atlas.py
+```
+
+Legacy compatibility remains available:
+
+```powershell
 python scripts/render_prism_atlas.py
 ```
 
 The renderer picks the latest local dated source pack under
 `raw/exports/prism/source-pack/` when no explicit `--source-dir` is provided.
+That raw path is kept for provenance because the exports came from OpenAI Prism / Notion context.
 
-## Boundary
+## Naming boundary
 
-Raw source exports remain archival and are git-ignored by default because they
-can contain private or sensitive material. Edit the renderer or local source
-pack, then regenerate these docs instead of hand-editing generated files.
+- TerraNova framework / atlas name: **CIC**.
+- External/editor source context: **OpenAI Prism**.
+- Raw source exports remain archival and can contain private or sensitive material.
+
+Edit the renderer or local source pack, then regenerate these docs instead of hand-editing generated files.

--- a/docs/atlas/index.md
+++ b/docs/atlas/index.md
@@ -1,4 +1,4 @@
-# TerraNova Prism Atlas
+# TerraNova CIC Atlas
 
 Status: generated local atlas start page
 
@@ -7,9 +7,14 @@ Source directory: `raw/exports/prism/source-pack/2026-05-02`
 
 ## Purpose
 
-This page is the reviewed navigation layer for the Prism source pack.
-Raw exports stay in `raw/exports/prism/source-pack/`; curated working
-surfaces live here in `docs/atlas/`.
+This page is the reviewed navigation layer for the CIC source pack.
+Raw exports stay in `raw/exports/prism/source-pack/` for provenance; curated working surfaces live here in `docs/atlas/`.
+
+## Naming boundary
+
+- **CIC** is the TerraNova framework, consistency and atlas layer.
+- **OpenAI Prism** is an external/editor source context only where explicitly meant.
+- Historical paths containing `prism` are not automatically renamed when they serve as raw provenance.
 
 ## Snapshot
 
@@ -57,62 +62,15 @@ surfaces live here in `docs/atlas/`.
 | Bucket | Use | Review rule |
 | --- | --- | --- |
 | Public candidate | Mermaid manifesto, high-level atlas, selected ACTIVE diagrams. | Redact private, wallet/token and patent-sensitive material first. |
-| Internal operating map | All source categories, source manifest and trigger reference. | Allowed for Codex/Prism work under reviewed-source discipline. |
+| Internal operating map | All source categories, source manifest and trigger reference. | Allowed for Codex/CIC work under reviewed-source discipline. |
 | Archive only | Raw chat provenance and All-in-One payload. | Do not promote as canonical truth without extracted review notes. |
 | Decision required | Token/blockchain, patent/IP and deep trigger material. | Needs explicit human review before external use. |
-
-## Category Counts
-
-| Category | Files |
-| --- | --- |
-| source note | 5 |
-| technical documentation | 4 |
-| diagram registry | 4 |
-| sync architecture | 3 |
-| master overview | 3 |
-| trigger register | 3 |
-| token/blockchain | 3 |
-| mermaid manifesto | 2 |
-| routing | 2 |
-| product/service | 2 |
-| outreach | 2 |
-| chat provenance | 1 |
-| research review | 1 |
-| landing atlas | 1 |
-| all-in-one bundle | 1 |
-| framework reference | 1 |
-
-## Sensitivity Flags
-
-| Flag | Files |
-| --- | --- |
-| patent/ip | 23 |
-| private | 14 |
-| token/wallet | 14 |
-| external/public | 12 |
-| trigger-depth | 11 |
-| raw-chat | 8 |
-
-## High-Value Sources
-
-| Title | Category | Size | Flags | Source |
-| --- | --- | --- | --- | --- |
-| TerraNova / FerrAI – All-in-One Export | all-in-one bundle | 184.3 KB | external/public, patent/ip, private, raw-chat, token/wallet, trigger-depth | TerraNova_AllInOne (2).md |
-| TerraNova System Atlas — CIC Framework Overview | landing atlas | 12.4 KB | external/public, patent/ip, private, raw-chat, token/wallet, trigger-depth | TerraNova System Atlas — CIC Framework Overview fcd6cce055c843069b46ec82b2e99bac (2).md |
-| ⚡ Trigger-System — Deep Reference (1–992) | trigger register | 8.9 KB | patent/ip, private, token/wallet, trigger-depth | ⚡ Trigger-System — Deep Reference (1–992) 76520fbd9e7842a086abd8623caa0bea (2).md |
-| Mermaid Code Library – Complete Collection | diagram registry | 67.0 KB | external/public, patent/ip, private, raw-chat, token/wallet, trigger-depth | Mermaid Code Library – Complete Collection 999ce78e7102420cbf7a2a4385c28603 (2).md |
-| Mermaid-Diagramme als lebende Systeme: Von der Visualisierung zur ausführbaren Architektur | mermaid manifesto | 29.7 KB | external/public, patent/ip, raw-chat, trigger-depth | Mermaid-Diagramme als lebende Systeme Von der Visu e0ca072cf0224d16b558dcec5132f81d (2).md |
-| Chatverlauf (Quelle) | chat provenance | 104.4 KB | external/public, patent/ip, private, raw-chat, token/wallet, trigger-depth | Chatverlauf (Quelle) a62a25945fc74eedbcd6929ff04e09fb (2).md |
 
 ## Full Inventory
 
 - Machine-readable source list: `source_inventory.csv`.
 - Full generated manifest: `source_manifest.json`.
 - Diagram selection and replacement view: `diagrams.md`.
-
-## Duplicate Payloads
-
-- `b20b0af3d6e8`: `Unbenannt 2e6f7297de7e80548267f794947d60bd (2).md`, `Unbenannt 2e6f7297de7e8097a0bcf131a71920c8 (2).md`
 
 ## Operating Rule
 

--- a/scripts/render_cic_atlas.py
+++ b/scripts/render_cic_atlas.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Preferred CIC-named entry point for the TerraNova atlas renderer.
+
+The implementation currently lives in render_prism_atlas.py for backward compatibility
+with historical scripts and raw OpenAI Prism export paths.
+"""
+
+from render_prism_atlas import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds CIC-named atlas usage documentation.
- Adds `scripts/render_cic_atlas.py` as the preferred entry point.
- Keeps `scripts/render_prism_atlas.py` and `raw/exports/prism/` for backward compatibility and provenance.
- Updates active atlas docs to separate TerraNova CIC from OpenAI Prism source/editor context.

## Naming decision

- `CIC` = TerraNova framework / atlas / consistency layer.
- `OpenAI Prism` = external editor/source context only where explicitly meant.
- Historical raw Prism export paths remain archival.

Related: #13