### PR TITLE
[codex] Add FerrAI Operating Kernel v0.1 (superseded draft)

### DIFF
--- a/docs/architecture/ferrAI_operating_kernel_v0.1.md
+++ b/docs/architecture/ferrAI_operating_kernel_v0.1.md
@@ -1,0 +1,56 @@
+# FerrAI Operating Kernel v0.1
+
+Status: BIZ / Kernel-Scope
+
+This file is a technical mirror, not the source of record.
+The source of record is the Notion page:
+`EQUILIBRIUM — Offizielles Regelbuch`.
+
+Source URL:
+https://www.notion.so/EQUILIBRIUM-Offizielles-Regelbuch-a045fc7b60f24b3f9a6c579aff276b16?pvs=21
+
+## Purpose
+
+FerrAI Operating Kernel v0.1 does not explain the whole TerraNova system.
+It defines the minimal startup logic for FerrAI work.
+
+## Poles
+
+- TerraNovaCIC = anarchy / emergence / possibility space
+- Equilibrium = regime / rule edge / coherence enforcement
+- FerrAI = operative world between both poles
+
+## Execution Engine
+
+IPERKA is the digital workflow engine:
+
+- Informieren: gather context and source status
+- Planen: identify the smallest coherent path
+- Entscheiden: apply Equilibrium filters and set go/no-go
+- Realisieren: execute in the correct workspace surface
+- Kontrollieren: verify trace, status, boundary and result
+- Auswerten: feed the outcome back into the reference net
+
+## Mandatory Filters
+
+Every TerraNova/FerrAI action must carry:
+
+- status
+- trace
+- boundary
+- mode: PLAY, STUDIO or BIZ
+- GitHub sync state when repo-, release- or structure-relevant
+- Notion source-of-record awareness when rule- or memory-relevant
+
+## Operating Split
+
+- Notion = living rule, memory and reference source
+- GitHub = technical mirror, diff, issue, PR, release and audit trace
+- Zenodo = citable publication anchor
+- Chat = operational decision and correction layer
+- Codex skill = short boot hint, not a second rulebook
+
+## Boundary
+
+Do not duplicate the full Equilibrium rulebook into GitHub or the Codex skill.
+Keep this kernel short enough for startup use.


### PR DESCRIPTION
Superseded by a non-draft PR because the connector failed while marking this draft ready for review.

Original summary retained in branch `codex/ferrai-operating-kernel-v0.1`.