### PR TITLE
[codex] Add FerrAI Operating Kernel v0.1

### DIFF
--- a/docs/architecture/ferrAI_operating_kernel_v0.1.md
+++ b/docs/architecture/ferrAI_operating_kernel_v0.1.md
@@ -1,0 +1,56 @@
+# FerrAI Operating Kernel v0.1
+
+Status: BIZ / Kernel-Scope
+
+This file is a technical mirror, not the source of record.
+The source of record is the Notion page:
+`EQUILIBRIUM — Offizielles Regelbuch`.
+
+Source URL:
+https://www.notion.so/EQUILIBRIUM-Offizielles-Regelbuch-a045fc7b60f24b3f9a6c579aff276b16?pvs=21
+
+## Purpose
+
+FerrAI Operating Kernel v0.1 does not explain the whole TerraNova system.
+It defines the minimal startup logic for FerrAI work.
+
+## Poles
+
+- TerraNovaCIC = anarchy / emergence / possibility space
+- Equilibrium = regime / rule edge / coherence enforcement
+- FerrAI = operative world between both poles
+
+## Execution Engine
+
+IPERKA is the digital workflow engine:
+
+- Informieren: gather context and source status
+- Planen: identify the smallest coherent path
+- Entscheiden: apply Equilibrium filters and set go/no-go
+- Realisieren: execute in the correct workspace surface
+- Kontrollieren: verify trace, status, boundary and result
+- Auswerten: feed the outcome back into the reference net
+
+## Mandatory Filters
+
+Every TerraNova/FerrAI action must carry:
+
+- status
+- trace
+- boundary
+- mode: PLAY, STUDIO or BIZ
+- GitHub sync state when repo-, release- or structure-relevant
+- Notion source-of-record awareness when rule- or memory-relevant
+
+## Operating Split
+
+- Notion = living rule, memory and reference source
+- GitHub = technical mirror, diff, issue, PR, release and audit trace
+- Zenodo = citable publication anchor
+- Chat = operational decision and correction layer
+- Codex skill = short boot hint, not a second rulebook
+
+## Boundary
+
+Do not duplicate the full Equilibrium rulebook into GitHub or the Codex skill.
+Keep this kernel short enough for startup use.


### PR DESCRIPTION
## Summary

Adds a minimal FerrAI Operating Kernel v0.1 as a technical GitHub mirror for the Notion Equilibrium rule source.

- adds `docs/architecture/ferrAI_operating_kernel_v0.1.md`
- states Notion is the source of record
- keeps the kernel short enough for startup use
- defines the TerraNovaCIC / Equilibrium / FerrAI poles
- maps IPERKA as the digital execution engine
- lists mandatory filters: status, trace, boundary, mode, GitHub sync, Notion source awareness

Closes #29 after merge.

Supersedes draft PR #30.

## Verification

- Kept the document to a short startup surface.
- Ran `git diff --check HEAD~1 HEAD`.
- Kept unrelated local `docs/atlas/index.md` changes out of this branch.

## Local note

The local Codex TerraNova skill was patched with the minimal Equilibrium boot hint. That file is local Codex configuration, not a repository artifact.