### PR TITLE
[codex] Add governance doc validation

### DIFF
--- a/.github/workflows/prism-atlas-validate.yml
+++ b/.github/workflows/prism-atlas-validate.yml
@@ -12,6 +12,7 @@ on:
       - 'raw/exports/2026-04-30_batch_850k_raw_fuellversion.md'
       - 'raw/exports/fill_850k_raw.sh'
       - 'raw/exports/prism/source-pack/**'
+      - 'tests/test_render_prism_atlas.py'
       - '.github/workflows/prism-atlas-validate.yml'
   push:
     paths:
@@ -24,6 +25,7 @@ on:
       - 'raw/exports/2026-04-30_batch_850k_raw_fuellversion.md'
       - 'raw/exports/fill_850k_raw.sh'
       - 'raw/exports/prism/source-pack/**'
+      - 'tests/test_render_prism_atlas.py'
       - '.github/workflows/prism-atlas-validate.yml'
 
 permissions:
@@ -46,6 +48,9 @@ jobs:
 
       - name: Quick sanity check
         run: python scripts/quick_script_sanity.py scripts/render_prism_atlas.py
+
+      - name: Run atlas unit tests
+        run: python -m unittest tests.test_render_prism_atlas
 
       - name: Regenerate atlas docs
         run: python scripts/render_prism_atlas.py

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,52 @@
+name: Validate Docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'BIZ.md'
+      - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
+      - 'docs/codex/**'
+      - 'docs/governance/**'
+      - 'schemas/artifact_status.schema.json'
+      - 'config/source_registry.json'
+      - 'scripts/validate_docs.py'
+      - 'tests/test_validate_docs.py'
+      - '.github/workflows/validate-docs.yml'
+  push:
+    paths:
+      - 'BIZ.md'
+      - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
+      - 'docs/codex/**'
+      - 'docs/governance/**'
+      - 'schemas/artifact_status.schema.json'
+      - 'config/source_registry.json'
+      - 'scripts/validate_docs.py'
+      - 'tests/test_validate_docs.py'
+      - '.github/workflows/validate-docs.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate BIZ documentation markers
+        run: python scripts/validate_docs.py
+
+      - name: Run validator unit tests
+        run: python -m unittest tests.test_validate_docs
+
+      - name: Validate registry and schema JSON
+        run: |
+          python -m json.tool schemas/artifact_status.schema.json > /dev/null
+          python -m json.tool config/source_registry.json > /dev/null

--- a/BIZ.md
+++ b/BIZ.md
@@ -1,5 +1,13 @@
 # TerraNova `/biz` Brief
 
+Status: BIZ / Business Brief
+Source: GitHub technical mirror for the Notion-driven operations workflow.
+Trace: `scripts/notion_to_github.py`, `NOTION_PROPERTIES.md`, `.github/workflows/tnv_notion_to_github.yml`
+Boundary: Business-facing summary only; not a living rulebook or source-of-record replacement.
+Mode: BIZ
+GitHub sync state: tracked in this repository.
+Notion source awareness: required for operational database schema or rule changes.
+
 ## Business purpose
 TerraNova automates a controlled handoff from a Notion operations database into GitHub Issues.
 This supports auditability, clearer ownership, and consistent incident/change tracking without

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ a separate automation if project backlog state is required.
 ## Business brief
 - See `BIZ.md` for a concise `/biz` business-facing overview, KPI suggestions, and operating cadence.
 
+## Governance and public boundary
+- Public repository boundary: [`docs/governance/public_boundary.md`](docs/governance/public_boundary.md)
+- Repository role vocabulary: [`docs/governance/repo_roles.md`](docs/governance/repo_roles.md)
+- Source-of-record policy: [`docs/governance/source_of_record_policy.md`](docs/governance/source_of_record_policy.md)
+- Repository maturity note: [`docs/governance/repository_maturity.md`](docs/governance/repository_maturity.md)
+- Raw export review gate: [`raw/exports/REVIEW_GATE.md`](raw/exports/REVIEW_GATE.md)
+
 ## Current published release
 
 The current citable Zenodo release is RC01-v12:

--- a/config/source_registry.json
+++ b/config/source_registry.json
@@ -1,0 +1,14 @@
+{
+  "equilibrium": {
+    "source": "notion",
+    "title": "EQUILIBRIUM - Offizielles Regelbuch",
+    "role": "source_of_record",
+    "github_mirror": "docs/architecture/ferrAI_operating_kernel_v0.1.md"
+  },
+  "ferrai_operating_kernel_v0_1": {
+    "source": "github",
+    "title": "FerrAI Operating Kernel v0.1",
+    "role": "technical_mirror",
+    "github_mirror": "docs/architecture/ferrAI_operating_kernel_v0.1.md"
+  }
+}

--- a/docs/architecture/ferrAI_operating_kernel_v0.1.md
+++ b/docs/architecture/ferrAI_operating_kernel_v0.1.md
@@ -1,6 +1,12 @@
 # FerrAI Operating Kernel v0.1
 
 Status: BIZ / Kernel-Scope
+Source: Technical mirror of the Notion page `EQUILIBRIUM - Offizielles Regelbuch`.
+Trace: Source URL below; mirrored into `docs/codex/boot_contract.md`, `docs/codex/task_routing.md`, and `docs/governance/source_of_record_policy.md`.
+Boundary: Minimal startup kernel only; do not duplicate the full Equilibrium rulebook.
+Mode: BIZ
+GitHub sync state: tracked in this repository.
+Notion source awareness: required for living rule, memory and canon changes.
 
 This file is a technical mirror, not the source of record.
 The source of record is the Notion page:

--- a/docs/codex/boot_contract.md
+++ b/docs/codex/boot_contract.md
@@ -1,0 +1,24 @@
+# Codex Boot Contract
+
+Status: BIZ / Codex-Boot
+Source: Technical mirror of the FerrAI Operating Kernel v0.1; Notion remains the source of record for living rules.
+Trace: `docs/architecture/ferrAI_operating_kernel_v0.1.md`
+Boundary: This file is a startup contract, not a duplicate rulebook.
+Mode: BIZ
+GitHub sync state: tracked in this repository; validate through `scripts/validate_docs.py`.
+Notion source awareness: required for rule, memory and canon changes.
+
+## Purpose
+
+Codex starts TerraNova / FerrAI work from a minimal contract:
+
+1. Identify the active mode: PLAY, STUDIO or BIZ.
+2. Check status, trace, boundary and source-of-record awareness.
+3. Keep Notion as living rule and memory source.
+4. Keep GitHub as technical mirror, diff, CI and audit surface.
+5. Execute the smallest coherent next action.
+
+## Operating Limit
+
+Do not load or recreate the full Equilibrium rulebook during normal repo work.
+Use this file only to anchor source, mode, status, boundary and next action.

--- a/docs/codex/task_routing.md
+++ b/docs/codex/task_routing.md
@@ -1,0 +1,34 @@
+# Codex Task Routing
+
+Status: BIZ / Codex-Routing
+Source: Technical mirror of FerrAI Operating Kernel v0.1 routing logic.
+Trace: `docs/architecture/ferrAI_operating_kernel_v0.1.md`
+Boundary: Routing guidance for Codex work; not a replacement for Notion canon.
+Mode: BIZ
+GitHub sync state: tracked in this repository; validate through `scripts/validate_docs.py`.
+Notion source awareness: required when routing changes affect rules, memory or canon.
+
+## Routing Rules
+
+PLAY handles exploration, sketches and low-risk creative probes.
+
+STUDIO handles structured drafting, synthesis, design, composition and iteration.
+
+BIZ handles governance, releases, public boundaries, source policy, validation,
+CI, audit trails and implementation work that affects operational reliability.
+
+## Next Action Rule
+
+For every task, Codex should decide:
+
+1. Which mode applies.
+2. Which source is authoritative.
+3. Which boundary prevents overreach.
+4. Which artifact records the result.
+5. Which validation or sync action proves the result.
+
+## External Systems
+
+External systems may be read for context when available. They are mutated only
+on explicit request. Notion remains the living source of record for rules and
+memory; GitHub records technical mirrors and execution history.

--- a/docs/governance/public_boundary.md
+++ b/docs/governance/public_boundary.md
@@ -1,5 +1,13 @@
 # Public Boundary
 
+Status: BIZ / Governance
+Source: Repository-side governance policy for public-safe publication boundaries.
+Trace: Issue `#25`, `docs/governance/source_of_record_policy.md`, `raw/exports/REVIEW_GATE.md`
+Boundary: Public repository boundary definition only; not a raw storage or canon surface.
+Mode: BIZ
+GitHub sync state: tracked in this repository as a publish-safety contract.
+Notion source awareness: required if this boundary is later mirrored into living governance canon.
+
 ## Purpose
 
 This document defines what may be published in the public TerraNova repository and what must remain private, local, redacted, or patent-sensitive.

--- a/docs/governance/repo_roles.md
+++ b/docs/governance/repo_roles.md
@@ -1,5 +1,13 @@
 # Repository Roles
 
+Status: BIZ / Governance
+Source: Repository-side governance role vocabulary for TerraNova repository surfaces.
+Trace: Issue `#25`, `docs/governance/source_of_record_policy.md`, `docs/governance/public_boundary.md`
+Boundary: Repository role contract only; not a release claim or source-of-record override.
+Mode: BIZ
+GitHub sync state: tracked in this repository as an operational classification guide.
+Notion source awareness: required if repository roles are later aligned with living governance canon.
+
 ## Purpose
 
 This document defines the intended roles of repositories and repository areas in the TerraNova / FerrAI / CIC stack.

--- a/docs/governance/repository_maturity.md
+++ b/docs/governance/repository_maturity.md
@@ -1,0 +1,84 @@
+# Repository Maturity Note
+
+Status: BIZ / Governance
+Source: Repository-side maturity assessment derived from current GitHub, Zenodo and governance state.
+Trace: `docs/governance/public_boundary.md`, `docs/governance/repo_roles.md`, `docs/governance/source_of_record_policy.md`, Zenodo record `10.5281/zenodo.20073579`
+Boundary: Snapshot maturity note only; not a prestige claim, certification or guarantee of completeness.
+Mode: BIZ
+GitHub sync state: tracked in this repository as a public-facing reality check.
+Notion source awareness: required if this note is later aligned with living operating canon or workspace memory.
+
+## Purpose
+
+This note records the current maturity of the public TerraNova repository in a
+sober, source-aware form.
+
+It is meant to prevent two opposite errors:
+
+- understating the real publication and provenance discipline already present
+- overstating the repository as fully institutionalized or fully hardened
+
+## Current Assessment
+
+The current repository is not a beginner-stage scratchpad.
+
+Its maturity is best described as advanced independent / early professional
+research-operations.
+
+That assessment is based on the presence of:
+
+- versioned release artifacts
+- DOI-backed Zenodo publication anchors
+- checksum and provenance tracking
+- public-boundary and governance documents
+- issue-based review gates
+- source-bound documentation and audit history
+
+## Strengths
+
+The repository already demonstrates:
+
+- citable release practice through Zenodo and mirrored repository artifacts
+- explicit boundary-setting for public, private, raw and redact-candidate material
+- reproducible governance around review gates, promotion rules and release state
+- a visible chain between drafts, releases, issues, PRs and publication records
+- technical and documentary separation between working memory, release anchors and public-safe outputs
+
+## Current Limits
+
+The repository is not yet fully institutionalized infrastructure.
+
+Current limits include:
+
+- some review and redaction gates remain manual
+- governance closure still depends on explicit human decisions
+- CI and validation coverage are partial rather than total
+- local/remote sync discipline still depends on operator attention
+- some source-of-record and mirror boundaries are still being hardened
+
+## Public Framing Rule
+
+When this repository is described in public, prefer language such as:
+
+- versioned
+- source-bound
+- citable
+- auditable
+- governance-aware
+- still being hardened
+
+Avoid language such as:
+
+- final
+- fully verified
+- enterprise-grade in every layer
+- state of the art by default
+
+## Operating Stance
+
+The correct stance is:
+
+1. show the real strengths
+2. keep the open gates visible
+3. prefer proof over hype
+4. treat maturity as an operational snapshot, not an ego label

--- a/docs/governance/source_of_record_policy.md
+++ b/docs/governance/source_of_record_policy.md
@@ -1,0 +1,42 @@
+# Source of Record Policy
+
+Status: BIZ / Governance
+Source: Technical mirror of the FerrAI Operating Kernel v0.1 operating split.
+Trace: `docs/architecture/ferrAI_operating_kernel_v0.1.md`
+Boundary: Defines repository-side source roles; does not copy Notion rule content.
+Mode: BIZ
+GitHub sync state: tracked in this repository; validate through `scripts/validate_docs.py`.
+Notion source awareness: required for rule, memory, canon and reference changes.
+
+## Source Roles
+
+Notion is the living source of record for rules, workspace memory, canon,
+reference pages and unresolved operating decisions.
+
+GitHub is the technical mirror for reviewed docs, scripts, schemas, issues, PRs,
+release packages, diffs, CI checks and audit history.
+
+Zenodo is the citable publication anchor for released artifacts.
+
+Chat is the operational decision and correction layer.
+
+Codex skills and boot files are startup hints. They must stay small and must not
+become parallel rulebooks.
+
+## Promotion Rule
+
+A repository artifact may be treated as BIZ-relevant only when it carries:
+
+- Status
+- Source
+- Trace
+- Boundary
+- Mode
+- GitHub sync state when repo-, release- or structure-relevant
+- Notion source awareness when rule-, memory- or canon-relevant
+
+## Conflict Rule
+
+When Notion and GitHub disagree on living rules, Notion wins until a human
+decision updates the mirror. GitHub remains the audit trail for technical
+changes and release history.

--- a/schemas/artifact_status.schema.json
+++ b/schemas/artifact_status.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/TerraNova/Framework/schemas/artifact_status.schema.json",
+  "title": "TerraNova Artifact Status Marker",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "status",
+    "source",
+    "trace",
+    "boundary",
+    "mode"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace": {
+      "type": "string",
+      "minLength": 1
+    },
+    "boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["PLAY", "STUDIO", "BIZ"]
+    },
+    "github_sync_state": {
+      "type": "string"
+    },
+    "notion_source_awareness": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/render_prism_atlas.py
+++ b/scripts/render_prism_atlas.py
@@ -220,6 +220,10 @@ def should_use_manifest_snapshot(source_dir: Path, artifacts: list[SourceArtifac
     return len(artifacts) == 1 and artifacts[0].rel_path.casefold() == "readme.md"
 
 
+def should_fallback_to_manifest_snapshot(requested_source_dir: Path) -> bool:
+    return requested_source_dir.resolve() == DEFAULT_SOURCE_DIR.resolve()
+
+
 def resolve_render_inputs(
     source_dir: Path,
     output_dir: Path,
@@ -229,7 +233,7 @@ def resolve_render_inputs(
         resolved_source_dir = resolve_source_dir(source_dir)
         artifacts = collect_sources(resolved_source_dir)
     except SystemExit:
-        if manifest_path.exists():
+        if manifest_path.exists() and should_fallback_to_manifest_snapshot(source_dir):
             return load_manifest_snapshot(manifest_path)
         raise
 

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate BIZ-grade TerraNova/FerrAI documentation markers.
+
+The check is intentionally small and dependency-free. It enforces the Codex
+boot contract without turning GitHub into a second Notion rulebook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TARGETS = [
+    "BIZ.md",
+    "docs/architecture/ferrAI_operating_kernel_v0.1.md",
+    "docs/codex",
+    "docs/governance",
+]
+REQUIRED_TERMS = {
+    "Status": re.compile(r"(?im)^\s*(?:[-*]\s*)?Status\s*:"),
+    "Source": re.compile(r"(?im)^\s*(?:[-*]\s*)?Source\s*:"),
+    "Trace": re.compile(r"(?im)^\s*(?:[-*]\s*)?Trace\s*:"),
+    "Boundary": re.compile(r"(?im)^\s*(?:[-*]\s*)?Boundary\s*:"),
+    "Mode": re.compile(r"(?im)^\s*(?:[-*]\s*)?Mode\s*:"),
+    "GitHub sync state": re.compile(r"(?im)^\s*(?:[-*]\s*)?GitHub sync state\s*:"),
+    "Notion source awareness": re.compile(r"(?im)^\s*(?:[-*]\s*)?Notion source awareness\s*:"),
+}
+BIZ_MARKER = re.compile(r"(?im)^\s*Status\s*:\s*.*\bBIZ\b|`/biz`|# .*BIZ")
+
+
+def fail(message: str) -> None:
+    print(f"[validate-docs] ERROR: {message}", file=sys.stderr)
+
+
+def iter_markdown(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.md")))
+        elif path.is_file() and path.suffix.lower() == ".md":
+            files.append(path)
+        else:
+            fail(f"target does not exist or is not markdown: {path}")
+            raise SystemExit(2)
+    return files
+
+
+def is_biz_relevant(path: Path, text: str) -> bool:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    if rel.startswith("docs/codex/"):
+        return True
+    if rel == "docs/architecture/ferrAI_operating_kernel_v0.1.md":
+        return True
+    if rel == "docs/governance/source_of_record_policy.md":
+        return True
+    return bool(BIZ_MARKER.search(text))
+
+
+def validate_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    if not is_biz_relevant(path, text):
+        return []
+
+    missing = [term for term, pattern in REQUIRED_TERMS.items() if not pattern.search(text)]
+    if missing:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        return [f"{rel}: missing required marker(s): {', '.join(missing)}"]
+    return []
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate TerraNova/FerrAI BIZ documentation markers.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Markdown files or directories to validate. Defaults to BIZ/Codex/kernel governance targets.",
+    )
+    args = parser.parse_args(argv[1:])
+
+    raw_paths = args.paths or DEFAULT_TARGETS
+    paths = [(REPO_ROOT / raw_path).resolve() for raw_path in raw_paths]
+
+    errors: list[str] = []
+    for path in iter_markdown(paths):
+        errors.extend(validate_file(path))
+
+    if errors:
+        for error in errors:
+            fail(error)
+        return 1
+
+    print("[validate-docs] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_render_prism_atlas.py
+++ b/tests/test_render_prism_atlas.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "render_prism_atlas.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("render_prism_atlas", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class RenderPrismAtlasTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+
+    def write_manifest(self, output_dir: Path):
+        manifest = {
+            "source_dir": str(self.mod.DEFAULT_SOURCE_DIR),
+            "generated_at": "2026-05-07T19:19:00+00:00",
+            "source_files": [
+                {
+                    "source": "README.md",
+                    "title": "Source Pack README",
+                    "type": "md",
+                    "size_bytes": 42,
+                    "sha256": "deadbeef",
+                    "category": "source note",
+                    "sensitivity": [],
+                    "headings": ["Source Pack README"],
+                }
+            ],
+            "diagrams": [],
+        }
+        (output_dir / "source_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    def test_missing_default_source_dir_uses_manifest_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            self.mod.DEFAULT_SOURCE_DIR = output_dir / "default-source-dir"
+            self.write_manifest(output_dir)
+
+            artifacts, diagrams, source_dir, generated_at = self.mod.resolve_render_inputs(
+                self.mod.DEFAULT_SOURCE_DIR,
+                output_dir,
+            )
+
+            self.assertEqual(len(artifacts), 1)
+            self.assertEqual(artifacts[0].title, "Source Pack README")
+            self.assertEqual(diagrams, [])
+            self.assertEqual(source_dir, self.mod.DEFAULT_SOURCE_DIR)
+            self.assertEqual(generated_at, "2026-05-07T19:19:00+00:00")
+
+    def test_missing_explicit_source_dir_raises_instead_of_using_manifest_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            self.write_manifest(output_dir)
+
+            with self.assertRaisesRegex(SystemExit, "Source directory not found"):
+                self.mod.resolve_render_inputs(output_dir / "missing-source-dir", output_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_docs.py
+++ b/tests/test_validate_docs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_docs.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("validate_docs", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidateDocsTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+
+    def test_validate_file_requires_explicit_marker_lines(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.mod.REPO_ROOT = repo_root
+            path = repo_root / "docs" / "codex" / "example.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "# Example\n\n"
+                "This prose mentions Status, Source, Trace, Boundary and Mode,\n"
+                "but it does not define the required marker lines.\n",
+                encoding="utf-8",
+            )
+
+            errors = self.mod.validate_file(path)
+
+            self.assertEqual(
+                errors,
+                [
+                    "docs/codex/example.md: missing required marker(s): "
+                    "Status, Source, Trace, Boundary, Mode, GitHub sync state, Notion source awareness"
+                ],
+            )
+
+    def test_validate_file_accepts_explicit_marker_lines(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.mod.REPO_ROOT = repo_root
+            path = repo_root / "docs" / "codex" / "example.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "# Example\n\n"
+                "Status: BIZ / Example\n"
+                "Source: Notion\n"
+                "Trace: `docs/architecture/example.md`\n"
+                "Boundary: Example boundary.\n"
+                "GitHub sync state: tracked in this repository.\n"
+                "Notion source awareness: required for canonical rule changes.\n"
+                "Mode: BIZ\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(self.mod.validate_file(path), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add BIZ marker validation for governance, Codex boot, and source-of-record docs
- add a Validate Docs workflow, schema, source registry, and unit tests
- link public boundary, repo roles, source policy, maturity note, and raw export gate from the README
- tighten the Prism atlas renderer fallback behavior and cover it with tests

## Validation

- `python scripts/validate_docs.py`
- `python -m unittest tests.test_validate_docs tests.test_render_prism_atlas`
- `python -m json.tool schemas/artifact_status.schema.json`
- `python -m json.tool config/source_registry.json`

## Notes

`tmp_zenodo_main44.pdf` and the line-ending-only `docs/atlas/source_inventory.csv` state were intentionally left out of this PR.