### PR TITLE
[codex] Add CEI-DATA-04 cycle 2 scaffold

### DIFF
--- a/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04-skeleton.md
+++ b/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04-skeleton.md
@@ -1,0 +1,71 @@
+# CEI-DATA-04 -- Data Note
+
+Status: DRAFT / PAGE-SCAFFOLD
+Cycle: 2
+Boundary: aggregate-only / no raw dump
+Zenodo Target: HOLD / no push
+Target Parent: XXL DatenExport 500k -- Top-5 Quellenfund / Snapshotanalyse
+
+## Purpose
+
+CEI-DATA-04 is the data-note lane for the private `XXL_DatenExport_500_000Zeilen.zip`
+corpus. It records safe metadata, non-claims, citation anchors, and release
+gates without moving raw material into Notion, GitHub, or Zenodo.
+
+## Corpus Anchor
+
+| Field | Value |
+| --- | --- |
+| ZIP | `XXL_DatenExport_500_000Zeilen.zip` |
+| TXT | `XXL_DatenExport_500_000Zeilen.txt` |
+| ZIP SHA-256 | `4e804d279535d273b9363e0171200ca6462fee52fbb75bd5b3ed070d7fb42f81` |
+| TXT SHA-256 | `06bc44cfda1226db6324e5261449b095b0be2bf124e9a5a416af5f3f1fc6df5d` |
+| Lines | `553000` |
+| Bytes | `30957838` (`30.96 MB`) |
+| Characters | `30065300` |
+| Cycle 1 PR | `https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/pull/38` |
+| Cycle 1 Merge SHA | `3d61a6f27ce08573c71b39f979853535793dad9f` |
+| Safe Index Path | `docs/atlas/xxl-dataexport-500k/cycle-01/` |
+| ORCID Anchor | `0009-0007-8033-3508` |
+
+## Boundary
+
+- No raw dump.
+- No raw corpus excerpts.
+- No inline chat export.
+- No Zenodo push.
+- No claim that the corpus is publicly reusable.
+- No merge or phase transition without explicit Silvi-Go.
+
+## Routing Notes
+
+- CEI-DATA-04 is a data-note lane.
+- CEI-DATA-05 remains a workspace index, trigger matrix, and companion reference.
+- CEI-04 / CEI-04A / CEI-04B / CEI-04C remain the sensitive-review and public-gate lane.
+- Corpus home remains `XXL DatenExport 500k -- Top-5 Quellenfund / Snapshotanalyse`
+  plus CEI-00 / CEI-04-family references where appropriate.
+
+## Data Note Fields To Fill
+
+- Summary of aggregate-only corpus scope.
+- Method note for how metrics and hashes were derived.
+- Citation and license posture.
+- Non-claims and known limitations.
+- Cluster-frequency references after GPT Cycle 2 analysis.
+- Trigger-matrix references from CEI-DATA-05.
+- Risk-token aggregate notes without raw lines.
+- Release-gate decision log for R-Phase 3-5.
+
+## Zenodo Hold Gate
+
+Zenodo remains on hold for this data note. A later release decision must be
+recorded separately and must not be inferred from this scaffold.
+
+## Phase Checklist
+
+- [x] B / Codex: schema, metadata instance, and Notion skeleton drafted.
+- [ ] C / FerrAI: create CEI-DATA-04 Notion page from this skeleton.
+- [ ] A / GPT: fill data-note content after the Notion skeleton exists.
+- [ ] R-Phase 3: data-note review.
+- [ ] R-Phase 4: Zenodo release decision.
+- [ ] R-Phase 5: final sync and closure.

--- a/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04-v0.2-normalization-notes.md
+++ b/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04-v0.2-normalization-notes.md
@@ -1,0 +1,59 @@
+# CEI-DATA-04 v0.2 Normalization Notes
+
+Status: R5_SYNC_NOTE
+Cycle: 2
+Boundary: aggregate-only / no raw dump
+Zenodo Target: HOLD / no push
+Notion Page: https://www.notion.so/1cd470f1c9104e2d9b064e9a2830d0f4
+
+## Purpose
+
+This note records the additive Notion reality layers that happened after the
+initial Step B scaffold in PR #39. It keeps the repository branch aligned with
+the review state without rewriting the original skeleton.
+
+The file is a review log and normalization note. It is not a raw-data artifact,
+not a Zenodo payload, and not a release decision.
+
+## Source Chain
+
+1. Codex created PR #39 with three Step B scaffold artifacts.
+2. FerrAI persisted the CEI-DATA-04 Notion skeleton additively.
+3. GPT added the A-v0.1 content fill in Notion.
+4. FerrAI recorded R3 as `CONDITIONAL_PASS`.
+5. GPT added the A-v0.2 normalization patch in Notion.
+6. FerrAI completed R3 re-pass as `PASS`.
+7. FerrAI recorded R4 as `HOLD`.
+8. Codex R5 sync records this note in PR #39.
+
+## R3 Re-Pass Result
+
+R3 re-pass result: `PASS`
+
+The A-v0.2 normalization patch is treated as Notion-persisted review healing.
+The original scaffold remains preserved as the Step B source anchor.
+
+## R4 Result
+
+R4 outcome: `HOLD`
+
+Zenodo remains on hold. No release action is authorized by this cycle.
+
+## Current Locks
+
+- PR #39 remains draft.
+- No PR merge is authorized by this note.
+- No Zenodo action is authorized.
+- No raw dump is included.
+- No raw corpus excerpts are included.
+- No CEI-DATA-05 reciprocal edit is included.
+- CEI-DATA-04 remains the data-note lane.
+- CEI-04 / CEI-04A / CEI-04B / CEI-04C remain the sensitive-review lane.
+
+## R5 Decision
+
+R5 sync decision: amend PR #39 with this additive normalization note, then hold.
+
+Merge remains a separate Silvi-Go decision. If merged later, this PR should
+still be understood as aggregate-only documentation and scaffold material, not
+as corpus publication or Zenodo release authorization.

--- a/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04.metadata.v0.1-draft.json
+++ b/docs/atlas/xxl-dataexport-500k/cycle-02/cei-data-04.metadata.v0.1-draft.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "./metadata.schema.json",
+  "schema_version": "0.1-draft",
+  "artifact_id": "cei-data-04-data-note",
+  "title": "CEI-DATA-04 -- Data Note for XXL DatenExport 500k",
+  "status": "draft",
+  "layer": "data-note",
+  "boundary": "aggregate-only / no raw dump",
+  "zenodo_target": "HOLD / no push",
+  "cycle": 2,
+  "corpus_anchor": {
+    "zip_name": "XXL_DatenExport_500_000Zeilen.zip",
+    "txt_name": "XXL_DatenExport_500_000Zeilen.txt",
+    "zip_sha256": "4e804d279535d273b9363e0171200ca6462fee52fbb75bd5b3ed070d7fb42f81",
+    "txt_sha256": "06bc44cfda1226db6324e5261449b095b0be2bf124e9a5a416af5f3f1fc6df5d",
+    "line_count": 553000,
+    "byte_size_bytes": 30957838,
+    "byte_size_label": "30.96 MB",
+    "char_count": 30065300,
+    "safe_index_path": "docs/atlas/xxl-dataexport-500k/cycle-01/",
+    "cycle_1_pr_number": 38,
+    "cycle_1_merge_sha": "3d61a6f27ce08573c71b39f979853535793dad9f",
+    "cycle_1_merged_at": "2026-05-13T00:56:16Z"
+  },
+  "identity_anchor": {
+    "orcid": "0009-0007-8033-3508",
+    "note": "Zenodo-audit-consistent identity anchor only; this draft does not authorize a Zenodo push."
+  },
+  "notion_routing": {
+    "target_page_title": "CEI-DATA-04 -- Data Note",
+    "target_parent": "XXL DatenExport 500k -- Top-5 Quellenfund / Snapshotanalyse",
+    "cei_data_05_role": "Companion workspace index, trigger matrix, and reference layer; not the corpus home.",
+    "cei_04_family_role": "Sensitive-review and public-gate lane; separate from this data-note lane."
+  },
+  "allowed_repository_material": [
+    "summaries",
+    "manifests",
+    "hash files",
+    "safe indexes",
+    "data-note drafts",
+    "redaction policy",
+    "metrics tables",
+    "schemas",
+    "notion skeletons"
+  ],
+  "non_claims": [
+    "This draft does not publish the raw corpus.",
+    "This draft does not include raw corpus excerpts.",
+    "This draft is not a Zenodo release decision.",
+    "This draft is not CEI-04 Sensitive Review & Public Gate.",
+    "This draft does not assert public reusability beyond aggregate metadata."
+  ],
+  "phase_gate": {
+    "silvi_go_required": true,
+    "current_step": "B / Codex draft PR",
+    "next_step": "C / FerrAI Notion CEI-DATA-04 skeleton",
+    "merge_allowed": false
+  }
+}

--- a/docs/atlas/xxl-dataexport-500k/cycle-02/metadata.schema.json
+++ b/docs/atlas/xxl-dataexport-500k/cycle-02/metadata.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/docs/atlas/xxl-dataexport-500k/cycle-02/metadata.schema.json",
+  "title": "CEI-DATA-04 Data Note Metadata v0.1 Draft",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "title",
+    "status",
+    "layer",
+    "boundary",
+    "zenodo_target",
+    "cycle",
+    "corpus_anchor",
+    "identity_anchor",
+    "notion_routing",
+    "allowed_repository_material",
+    "non_claims",
+    "phase_gate"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1-draft"
+    },
+    "artifact_id": {
+      "type": "string",
+      "const": "cei-data-04-data-note"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "review", "publish-ready", "published"]
+    },
+    "layer": {
+      "type": "string",
+      "const": "data-note"
+    },
+    "boundary": {
+      "type": "string",
+      "const": "aggregate-only / no raw dump"
+    },
+    "zenodo_target": {
+      "type": "string",
+      "enum": ["HOLD / no push"]
+    },
+    "cycle": {
+      "type": "integer",
+      "const": 2
+    },
+    "corpus_anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "zip_name",
+        "txt_name",
+        "zip_sha256",
+        "txt_sha256",
+        "line_count",
+        "byte_size_bytes",
+        "byte_size_label",
+        "char_count",
+        "safe_index_path",
+        "cycle_1_pr_number",
+        "cycle_1_merge_sha",
+        "cycle_1_merged_at"
+      ],
+      "properties": {
+        "zip_name": {
+          "type": "string",
+          "const": "XXL_DatenExport_500_000Zeilen.zip"
+        },
+        "txt_name": {
+          "type": "string",
+          "const": "XXL_DatenExport_500_000Zeilen.txt"
+        },
+        "zip_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "txt_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "line_count": {
+          "type": "integer",
+          "const": 553000
+        },
+        "byte_size_bytes": {
+          "type": "integer",
+          "const": 30957838
+        },
+        "byte_size_label": {
+          "type": "string",
+          "const": "30.96 MB"
+        },
+        "char_count": {
+          "type": "integer",
+          "const": 30065300
+        },
+        "safe_index_path": {
+          "type": "string",
+          "const": "docs/atlas/xxl-dataexport-500k/cycle-01/"
+        },
+        "cycle_1_pr_number": {
+          "type": "integer",
+          "const": 38
+        },
+        "cycle_1_merge_sha": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "cycle_1_merged_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "identity_anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["orcid", "note"],
+      "properties": {
+        "orcid": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "notion_routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_page_title",
+        "target_parent",
+        "cei_data_05_role",
+        "cei_04_family_role"
+      ],
+      "properties": {
+        "target_page_title": {
+          "type": "string",
+          "const": "CEI-DATA-04 -- Data Note"
+        },
+        "target_parent": {
+          "type": "string",
+          "const": "XXL DatenExport 500k -- Top-5 Quellenfund / Snapshotanalyse"
+        },
+        "cei_data_05_role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cei_04_family_role": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "allowed_repository_material": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "summaries",
+          "manifests",
+          "hash files",
+          "safe indexes",
+          "data-note drafts",
+          "redaction policy",
+          "metrics tables",
+          "schemas",
+          "notion skeletons"
+        ]
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "phase_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "silvi_go_required",
+        "current_step",
+        "next_step",
+        "merge_allowed"
+      ],
+      "properties": {
+        "silvi_go_required": {
+          "type": "boolean",
+          "const": true
+        },
+        "current_step": {
+          "type": "string",
+          "const": "B / Codex draft PR"
+        },
+        "next_step": {
+          "type": "string",
+          "const": "C / FerrAI Notion CEI-DATA-04 skeleton"
+        },
+        "merge_allowed": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Cycle 2 artifacts for the CEI-DATA-04 data-note lane under `docs/atlas/xxl-dataexport-500k/cycle-02/`.

This PR now contains four files:

- `metadata.schema.json` for schema and gate constraints
- `cei-data-04.metadata.v0.1-draft.json` for canonical metadata values
- `cei-data-04-skeleton.md` for the Notion page scaffold
- `cei-data-04-v0.2-normalization-notes.md` for the R3/R4/R5 review-state sync

## Boundary

- Draft-only
- No raw dump
- No raw excerpts
- No Zenodo push
- No CEI-04 sensitive-review merge-up
- CEI-DATA-05 remains index / companion only
- CEI-DATA-04 is the data-note lane

## R5 State

- Notion CEI-DATA-04 exists and was filled additively
- R3 re-pass: PASS
- R4 outcome: HOLD
- R5 sync: PR amended with additive normalization note, then hold
- Merge remains gated by a separate explicit Silvi-Go

## Validation

- JSON syntax parsed locally
- Canonical gate assertions passed locally
- `python scripts\validate_docs.py` passed locally after the R5 note

`jsonschema` is not installed in the local runtime, so full draft-2020-12 validation was not run locally.

## Next

Hold unless Silvi explicitly authorizes one of these actions:

- merge PR #39 as aggregate-only scaffold/review documentation
- add a CEI-DATA-05 reciprocal pointer
- continue to a later Zenodo decision path

No Zenodo action is authorized by this PR.