### PR TITLE
[codex] Add Zenodo RC01-v13 preflight lane

### DIFF
--- a/.github/workflows/zenodo-rc01-v13-preflight.yml
+++ b/.github/workflows/zenodo-rc01-v13-preflight.yml
@@ -1,0 +1,163 @@
+name: Zenodo RC01-v13 Preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      record_id:
+        description: "Current published Zenodo record ID used as future version parent"
+        required: true
+        default: "20073579"
+      artifact_path:
+        description: "Optional future RC01-v13 PDF path to validate if present"
+        required: true
+        default: "releases/zenodo/rc01-v13-preflight-2026-05-13/PENDING_ARTIFACT.pdf"
+      expected_sha256:
+        description: "Optional expected SHA-256 for artifact_path"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+
+    env:
+      ZENODO_API_BASE: https://zenodo.org/api
+      ZENODO_RECORD_ID: ${{ github.event.inputs.record_id || '20073579' }}
+      MANIFEST_PATH: releases/zenodo/rc01-v13-preflight-2026-05-13/manifest.json
+      METADATA_PATH: releases/zenodo/rc01-v13-preflight-2026-05-13/zenodo_api_metadata.rc01-v13.draft.json
+      ARTIFACT_PATH: ${{ github.event.inputs.artifact_path }}
+      EXPECTED_SHA256: ${{ github.event.inputs.expected_sha256 }}
+      CURRENT_RC01_V12_SHA256: 1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate preflight files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test -f "${MANIFEST_PATH}"
+          test -f "${METADATA_PATH}"
+
+          python -m json.tool "${MANIFEST_PATH}" > /dev/null
+          python -m json.tool "${METADATA_PATH}" > /dev/null
+
+          python - "${MANIFEST_PATH}" "${METADATA_PATH}" <<'PY'
+          import json
+          import sys
+
+          manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+          metadata = json.load(open(sys.argv[2], encoding="utf-8"))
+
+          assert manifest["target"]["record_id"] == "20073579"
+          assert manifest["target"]["candidate_version"] == "RC01-v13"
+          assert manifest["workflow"]["writes_to_zenodo"] is False
+          assert manifest["workflow"]["publishes_to_zenodo"] is False
+          assert manifest["hard_locks"]["zenodo_draft"] is False
+          assert manifest["hard_locks"]["zenodo_upload"] is False
+          assert manifest["hard_locks"]["zenodo_publish"] is False
+          assert manifest["candidate_artifact"]["upload_allowed"] is False
+
+          md = metadata["metadata"]
+          assert md["version"] == "RC01-v13"
+          assert md["license"] == "cc-by-4.0"
+          assert md["creators"][0]["orcid"] == "0009-0007-8033-3508"
+
+          print("Preflight manifest and metadata gates OK.")
+          PY
+
+      - name: Read current Zenodo record
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BODY="zenodo_record_${ZENODO_RECORD_ID}_preflight.json"
+          HTTP_STATUS="$(curl -sS -o "${BODY}" -w "%{http_code}" \
+            -H "Accept: application/json" \
+            "${ZENODO_API_BASE}/records/${ZENODO_RECORD_ID}")"
+
+          echo "Zenodo public record read HTTP status: ${HTTP_STATUS}"
+          if [ "${HTTP_STATUS}" != "200" ]; then
+            cat "${BODY}"
+            exit 1
+          fi
+
+          python - "${BODY}" <<'PY'
+          import json
+          import sys
+
+          body = json.load(open(sys.argv[1], encoding="utf-8"))
+          assert str(body["id"]) == "20073579"
+          assert body["doi"] == "10.5281/zenodo.20073579"
+          assert body["conceptdoi"] == "10.5281/zenodo.19774446"
+          assert body["metadata"]["version"] == "RC01-v12"
+          assert body["metadata"]["creators"][0]["orcid"] == "0009-0007-8033-3508"
+          print("Zenodo public record read gates OK.")
+          PY
+
+      - name: Validate optional future artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "${ARTIFACT_PATH}" ]; then
+            echo "No future RC01-v13 artifact staged at ${ARTIFACT_PATH}."
+            echo "This is expected for Z1. No upload is attempted."
+            exit 0
+          fi
+
+          ACTUAL_SHA256="$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')"
+          echo "Artifact SHA256: ${ACTUAL_SHA256}"
+
+          if [ -n "${EXPECTED_SHA256}" ] && [ "${ACTUAL_SHA256}" != "${EXPECTED_SHA256}" ]; then
+            echo "Artifact SHA256 mismatch."
+            echo "Expected: ${EXPECTED_SHA256}"
+            echo "Actual:   ${ACTUAL_SHA256}"
+            exit 1
+          fi
+
+          if [ "${ACTUAL_SHA256}" = "${CURRENT_RC01_V12_SHA256}" ]; then
+            echo "Artifact is byte-identical to RC01-v12. Refusing to treat it as RC01-v13."
+            exit 1
+          fi
+
+          echo "Future artifact exists and differs from RC01-v12."
+
+      - name: Write preflight handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > zenodo_rc01_v13_preflight_handoff.md <<EOF
+          # Zenodo RC01-v13 Preflight Handoff
+
+          Preflight completed without Zenodo mutation.
+
+          - Target record ID: ${ZENODO_RECORD_ID}
+          - Target DOI: 10.5281/zenodo.20073579
+          - Concept DOI: 10.5281/zenodo.19774446
+          - Candidate version: RC01-v13
+          - Manifest: ${MANIFEST_PATH}
+          - Metadata: ${METADATA_PATH}
+          - Artifact path checked: ${ARTIFACT_PATH}
+
+          No Zenodo draft, upload, DOI reservation, or publish action was
+          attempted by this workflow.
+          EOF
+
+          cat zenodo_rc01_v13_preflight_handoff.md
+
+      - name: Upload preflight artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenodo-rc01-v13-preflight
+          path: |
+            zenodo_record_*_preflight.json
+            zenodo_rc01_v13_preflight_handoff.md
+          if-no-files-found: warn

--- a/releases/zenodo/rc01-v13-preflight-2026-05-13/OK_CHECKLIST.md
+++ b/releases/zenodo/rc01-v13-preflight-2026-05-13/OK_CHECKLIST.md
@@ -1,0 +1,41 @@
+# Zenodo RC01-v13 Preflight Checklist
+
+Status: PREPARED / NO ZENODO MUTATION
+
+## Z1 Checks
+
+- [x] Current Zenodo record identified: `20073579`.
+- [x] Current DOI identified: `10.5281/zenodo.20073579`.
+- [x] Concept DOI identified: `10.5281/zenodo.19774446`.
+- [x] ORCID anchor identified: `0009-0007-8033-3508`.
+- [x] GitHub repository link is present in current Zenodo metadata.
+- [x] Current RC01-v12 PDF hash verified locally.
+- [x] `main (45).pdf` checked and found byte-identical to `main (44).pdf`.
+- [x] No RC01-v13 upload artifact staged.
+- [x] No Zenodo write action performed.
+
+## Required Before Z2 Draft Creation
+
+- [ ] New RC01-v13 PDF exists and differs from RC01-v12.
+- [ ] New artifact SHA-256 and MD5 are recorded.
+- [ ] Metadata has been reviewed against the new artifact.
+- [ ] Public-boundary review confirms no raw dump or private excerpts.
+- [ ] Zenodo target record remains `20073579`.
+- [ ] Workflow dry run passes.
+- [ ] Silvi explicitly authorizes draft creation.
+
+## Required Before Any Publish
+
+- [ ] Zenodo draft preview reviewed manually.
+- [ ] Uploaded file checksum matches the intended artifact.
+- [ ] Title, version, license, ORCID, repository link, and concept DOI are correct.
+- [ ] No private, token, wallet, credential, raw-chat, or patent-sensitive material is exposed.
+- [ ] Silvi explicitly authorizes publish.
+
+## Hard Locks
+
+- Zenodo draft creation: not authorized in Z1.
+- Zenodo upload: not authorized in Z1.
+- Zenodo publish: not authorized in Z1.
+- DOI reservation: not authorized in Z1.
+- `main (45).pdf` upload as RC01-v13: blocked because it is byte-identical to RC01-v12.

--- a/releases/zenodo/rc01-v13-preflight-2026-05-13/README.md
+++ b/releases/zenodo/rc01-v13-preflight-2026-05-13/README.md
@@ -1,0 +1,64 @@
+# Zenodo RC01-v13 Preflight
+
+Status: PREPARED / NO ZENODO MUTATION
+Date: 2026-05-13
+Target record: `20073579`
+Current published version: `RC01-v12`
+Next candidate version: `RC01-v13`
+
+## Purpose
+
+This package repairs the repository-side preflight lane for a future
+`RC01-v13` Zenodo version of the TerraNova / FerrAI / CIC work monograph.
+
+It does not create a Zenodo draft, reserve a DOI, upload a file, or publish a
+record. It prepares the GitHub-controlled validation surface so a later explicit
+Silvi-Go can create a draft from reviewed inputs.
+
+## Current Findings
+
+- The current published Zenodo record is `20073579`.
+- The current DOI is `10.5281/zenodo.20073579`.
+- The concept DOI is `10.5281/zenodo.19774446`.
+- The current published version is `RC01-v12`.
+- The repository mirror artifact is under `releases/zenodo/rc01-v12-2026-05-07/`.
+- Local `main (45).pdf` is byte-identical to published `main (44).pdf`.
+
+Because there is no distinct `RC01-v13` content artifact yet, this package does
+not stage a PDF for upload.
+
+## Included Files
+
+- `manifest.json`: preflight facts, locks, target record, and required Z2 inputs.
+- `OK_CHECKLIST.md`: human review checklist before any Zenodo draft action.
+- `zenodo_api_metadata.rc01-v13.draft.json`: draft metadata payload for later review.
+
+## Workflow
+
+The companion workflow is:
+
+```text
+.github/workflows/zenodo-rc01-v13-preflight.yml
+```
+
+It performs repository-side validation and public Zenodo read checks only. It
+must not call Zenodo write endpoints.
+
+## Hard Locks
+
+- Zenodo draft: no
+- Zenodo upload: no
+- Zenodo publish: no
+- DOI reservation: no
+- Raw dump or private excerpts: no
+- `main (45).pdf` as v13 payload: no, because it is byte-identical to RC01-v12
+
+## Z2 Entry Criteria
+
+Before a later draft-creation cycle starts, provide:
+
+- a new public-safe PDF artifact that differs from RC01-v12
+- its SHA-256 and MD5
+- reviewed RC01-v13 metadata
+- explicit Silvi-Go for Zenodo draft creation
+- confirmation that Zenodo remains a draft-only action until manual publish OK

--- a/releases/zenodo/rc01-v13-preflight-2026-05-13/manifest.json
+++ b/releases/zenodo/rc01-v13-preflight-2026-05-13/manifest.json
@@ -1,0 +1,67 @@
+{
+  "preflight_id": "rc01-v13-preflight-2026-05-13",
+  "status": "PREPARED_NO_ZENODO_MUTATION",
+  "created_date": "2026-05-13",
+  "target": {
+    "record_id": "20073579",
+    "record_url": "https://zenodo.org/records/20073579",
+    "doi": "10.5281/zenodo.20073579",
+    "doi_url": "https://doi.org/10.5281/zenodo.20073579",
+    "concept_record_id": "19774446",
+    "concept_doi": "10.5281/zenodo.19774446",
+    "concept_doi_url": "https://doi.org/10.5281/zenodo.19774446",
+    "current_version": "RC01-v12",
+    "candidate_version": "RC01-v13",
+    "current_status": "published"
+  },
+  "current_artifact": {
+    "repo_path": "releases/zenodo/rc01-v12-2026-05-07/ferrai-terra-nova-cic-werkmonographie-rc01-v12.pdf",
+    "source_download_name": "main (44).pdf",
+    "size_bytes": 2943457,
+    "md5": "d791d480e75f3d89f9a103a28a5c5001",
+    "sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40"
+  },
+  "candidate_artifact": {
+    "status": "missing_distinct_v13_artifact",
+    "observed_local_candidate": "C:/Users/Silvan/Downloads/main (45).pdf",
+    "observed_local_candidate_sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40",
+    "observed_local_candidate_md5": "d791d480e75f3d89f9a103a28a5c5001",
+    "byte_identical_to_current_artifact": true,
+    "upload_allowed": false
+  },
+  "identity": {
+    "creator": "Lenhard, Silvan",
+    "affiliation": "Terra'Nova'Restore",
+    "orcid": "0009-0007-8033-3508",
+    "repository": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework"
+  },
+  "workflow": {
+    "path": ".github/workflows/zenodo-rc01-v13-preflight.yml",
+    "default_mode": "preflight-only",
+    "target_record_id": "20073579",
+    "writes_to_zenodo": false,
+    "publishes_to_zenodo": false
+  },
+  "hard_locks": {
+    "zenodo_draft": false,
+    "zenodo_upload": false,
+    "zenodo_publish": false,
+    "doi_reservation": false,
+    "raw_dump": false,
+    "private_excerpts": false,
+    "use_identical_pdf_as_new_version": false
+  },
+  "required_for_z2": [
+    "distinct public-safe RC01-v13 PDF artifact",
+    "artifact SHA-256 and MD5",
+    "reviewed metadata payload",
+    "public-boundary review",
+    "explicit Silvi-Go for draft creation",
+    "manual Zenodo preview review before publish"
+  ],
+  "notes": [
+    "The old v3 workflow targets record 19961351 and main (22).pdf; it is not the RC01-v13 lane.",
+    "RC01-v13 must target the current published record 20073579 as the parent version.",
+    "OpenAIRE and ORCID are treated as downstream identity/indexing context, not as mutable targets in Z1."
+  ]
+}

--- a/releases/zenodo/rc01-v13-preflight-2026-05-13/zenodo_api_metadata.rc01-v13.draft.json
+++ b/releases/zenodo/rc01-v13-preflight-2026-05-13/zenodo_api_metadata.rc01-v13.draft.json
@@ -1,0 +1,55 @@
+{
+  "metadata": {
+    "title": "FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat",
+    "upload_type": "publication",
+    "publication_type": "book",
+    "description": "<h2>Zenodo Description -- Deutsch</h2><p>Diese Metadaten sind ein RC01-v13-Draft-Kandidat fuer die spaetere Zenodo-Versionierung des bereits publizierten RC01-v12-Records <code>10.5281/zenodo.20073579</code>. Sie duerfen erst fuer eine Zenodo-Draft-Erstellung verwendet werden, wenn ein eigenstaendiges, oeffentlich freigegebenes RC01-v13-PDF vorliegt und Silvi die Draft-Erstellung explizit freigibt.</p><p>RC01-v13 ist als spaeterer Arbeits- und Freigabestand der Werkmonographie mit Evidenzapparat zum FerrAI-/Terra-Nova-/CIC-Komplex vorgesehen. Die Fassung bleibt quellengebunden, unterscheidet primaere Evidenz, editorische Ableitung und offene Stellen und darf keine privaten Rohdaten oder nicht freigegebenen Korpusauszuege enthalten.</p><h2>Zenodo Description -- English</h2><p>These metadata are an RC01-v13 draft candidate for a later Zenodo version of the already published RC01-v12 record <code>10.5281/zenodo.20073579</code>. They may only be used for Zenodo draft creation once a distinct, public-safe RC01-v13 PDF exists and Silvi explicitly authorizes draft creation.</p><p>RC01-v13 is intended as a later working and release state of the work monograph with evidence apparatus on the FerrAI / Terra Nova / CIC complex. The version remains source-bound, separates primary evidence from editorial inference and open questions, and must not contain private raw data or unreleased corpus excerpts.</p><h2>Version Note</h2><p>Draft metadata only. No Zenodo draft, upload, DOI reservation, or publish action is authorized by this file.</p>",
+    "creators": [
+      {
+        "name": "Lenhard, Silvan",
+        "affiliation": "Terra'Nova'Restore",
+        "orcid": "0009-0007-8033-3508"
+      }
+    ],
+    "access_right": "open",
+    "license": "cc-by-4.0",
+    "version": "RC01-v13",
+    "keywords": [
+      "FerrAI",
+      "Terra Nova",
+      "CIC",
+      "Cognitive Intelligent Cooperation",
+      "Human-AI Collaboration",
+      "Mensch-KI-Interaktion",
+      "Claim/Evidence",
+      "Evidence Apparatus",
+      "Editorial Reconstruction",
+      "Source-Critical Edition",
+      "System Architecture",
+      "Process Logic",
+      "Trigger Logic",
+      "Knowledge Organization",
+      "Governance",
+      "Versioned Research Manuscript",
+      "Dissertation Draft",
+      "Workspace Documentation",
+      "AI-assisted research"
+    ],
+    "notes": "RC01-v13 draft metadata candidate only. Current published record: 10.5281/zenodo.20073579. Concept DOI: 10.5281/zenodo.19774446. No Zenodo draft, upload, DOI reservation, or publish action is authorized by this repository preflight package.",
+    "related_identifiers": [
+      {
+        "identifier": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
+        "relation": "isSupplementedBy",
+        "scheme": "url"
+      },
+      {
+        "identifier": "10.5281/zenodo.19774446",
+        "relation": "isVersionOf",
+        "scheme": "doi"
+      }
+    ],
+    "references": [
+      "Lenhard, S. (2026). FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat (RC01-v12). Zenodo. https://doi.org/10.5281/zenodo.20073579"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a GitHub-only Zenodo Z1 preflight lane for a future `RC01-v13` release targeting the current published Zenodo record `20073579`.

This PR contains:

- `.github/workflows/zenodo-rc01-v13-preflight.yml`
- `releases/zenodo/rc01-v13-preflight-2026-05-13/README.md`
- `releases/zenodo/rc01-v13-preflight-2026-05-13/manifest.json`
- `releases/zenodo/rc01-v13-preflight-2026-05-13/OK_CHECKLIST.md`
- `releases/zenodo/rc01-v13-preflight-2026-05-13/zenodo_api_metadata.rc01-v13.draft.json`

## Boundary

- No Zenodo draft creation
- No Zenodo upload
- No Zenodo publish
- No DOI reservation
- No raw dump or private excerpts
- `main (45).pdf` is explicitly blocked as v13 payload because it is byte-identical to RC01-v12

## Validation

- JSON syntax parsed locally
- Manifest gate assertions passed locally
- `python scripts\validate_docs.py` passed locally
- Workflow safety scan found no Zenodo write endpoints or mutating curl methods

## Next

Run the preflight workflow after merge if desired. Z2 draft creation still requires a distinct RC01-v13 artifact and explicit Silvi-Go.