### PR TITLE
[codex] Add RC01-v12 Zenodo metadata patch review

### DIFF
--- a/.github/workflows/zenodo-rc01-v12-metadata-update.yml
+++ b/.github/workflows/zenodo-rc01-v12-metadata-update.yml
@@ -1,0 +1,287 @@
+name: Zenodo Metadata Update - RC01 v12
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/zenodo-rc01-v12-metadata-update.yml"
+      - "releases/zenodo/rc01-v12-metadata-patch-2026-05-13/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-metadata:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'execute-zenodo-z2-metadata-update')
+    runs-on: ubuntu-latest
+
+    env:
+      ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_API }}
+      ZENODO_API_BASE: https://zenodo.org/api
+      ZENODO_RECORD_ID: "20073579"
+      METADATA_PATCH_PATH: releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+      EXPECTED_DOI: 10.5281/zenodo.20073579
+      EXPECTED_CONCEPT_DOI: 10.5281/zenodo.19774446
+      EXPECTED_VERSION: RC01-v12
+      EXPECTED_FILE_NAME: main (44).pdf
+      EXPECTED_FILE_SIZE: "2943457"
+      EXPECTED_FILE_MD5: md5:d791d480e75f3d89f9a103a28a5c5001
+      EXPECTED_REPOSITORY: https://github.com/Terra-Nova-Restore/TerraNova-s-Framework
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Normalize Zenodo token
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ZENODO_ACCESS_TOKEN}" ]; then
+            echo "GitHub secret ZENODO_API is empty or missing."
+            exit 1
+          fi
+
+          TOKEN="${ZENODO_ACCESS_TOKEN//$'\r'/}"
+          TOKEN="${TOKEN//$'\n'/}"
+          TOKEN="$(printf '%s' "${TOKEN}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^[Bb][Ee][Aa][Rr][Ee][Rr][[:space:]]+//')"
+
+          if [ -z "${TOKEN}" ]; then
+            echo "GitHub secret ZENODO_API is empty after normalization."
+            exit 1
+          fi
+
+          echo "::add-mask::${TOKEN}"
+          {
+            echo "ZENODO_BEARER_TOKEN<<EOF"
+            printf '%s\n' "${TOKEN}"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Apply metadata-only update
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.request
+
+          base = os.environ["ZENODO_API_BASE"].rstrip("/")
+          record_id = os.environ["ZENODO_RECORD_ID"]
+          token = os.environ["ZENODO_BEARER_TOKEN"]
+          patch_path = os.environ["METADATA_PATCH_PATH"]
+          expected_repo = os.environ["EXPECTED_REPOSITORY"]
+
+          expected_keywords = [
+              "CIC",
+              "Zenodo",
+              "Github",
+              "Notion",
+              "audit trail",
+              "complex systems",
+              "AI ethics",
+              "FerrAI",
+              "Terra'Nova'Restore",
+              "human-AI interaction",
+          ]
+          expected_related = [
+              {
+                  "identifier": "10.5281/zenodo.19774446",
+                  "relation": "isVersionOf",
+                  "scheme": "doi",
+                  "resource_type": "publication-other",
+              }
+          ]
+          expected_references = [
+              "Lenhard, S. (2026). FerrAI / Terra Nova: Dissertationsentwurf. Zenodo. https://doi.org/10.5281/zenodo.19774446"
+          ]
+
+          with open(patch_path, encoding="utf-8") as f:
+              patch = json.load(f)
+
+          candidate = patch["proposed_api_payload_candidate"]["metadata"]
+          if candidate.get("keywords") != expected_keywords:
+              raise SystemExit("Candidate keywords drifted.")
+          if candidate.get("related_identifiers") != expected_related:
+              raise SystemExit("Candidate related_identifiers drifted.")
+          if candidate.get("references") != expected_references:
+              raise SystemExit("Candidate references drifted.")
+          if candidate.get("custom", {}).get("code:codeRepository") != expected_repo:
+              raise SystemExit("Candidate repository custom field missing.")
+
+          def request(method, url, data=None, auth=False, ok=(200,)):
+              headers = {"Accept": "application/json"}
+              body = None
+              if data is not None:
+                  body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+                  headers["Content-Type"] = "application/json"
+              if auth:
+                  headers["Authorization"] = f"Bearer {token}"
+              req = urllib.request.Request(url, data=body, headers=headers, method=method)
+              try:
+                  with urllib.request.urlopen(req, timeout=60) as resp:
+                      text = resp.read().decode("utf-8")
+                      status = resp.status
+              except urllib.error.HTTPError as exc:
+                  text = exc.read().decode("utf-8", errors="replace")
+                  return exc.code, text, None
+
+              parsed = json.loads(text) if text else None
+              if status not in ok:
+                  return status, text, parsed
+              return status, text, parsed
+
+          def require_public_record_unchanged(record):
+              if str(record.get("id")) != record_id:
+                  raise SystemExit("Unexpected record id.")
+              if record.get("doi") != os.environ["EXPECTED_DOI"]:
+                  raise SystemExit("Unexpected DOI.")
+              if record.get("conceptdoi") != os.environ["EXPECTED_CONCEPT_DOI"]:
+                  raise SystemExit("Unexpected concept DOI.")
+              metadata = record.get("metadata", {})
+              if metadata.get("version") != os.environ["EXPECTED_VERSION"]:
+                  raise SystemExit("Unexpected version.")
+              if metadata.get("custom", {}).get("code:codeRepository") != expected_repo:
+                  raise SystemExit("Repository custom field missing on public record.")
+              if metadata.get("keywords") != expected_keywords:
+                  raise SystemExit("Public keywords drifted.")
+              if metadata.get("related_identifiers") != expected_related:
+                  raise SystemExit("Public related_identifiers drifted.")
+              if metadata.get("references") != expected_references:
+                  raise SystemExit("Public references drifted.")
+              files = record.get("files", [])
+              if len(files) != 1:
+                  raise SystemExit("Unexpected file count.")
+              file0 = files[0]
+              if file0.get("key") != os.environ["EXPECTED_FILE_NAME"]:
+                  raise SystemExit("Unexpected file name.")
+              if str(file0.get("size")) != os.environ["EXPECTED_FILE_SIZE"]:
+                  raise SystemExit("Unexpected file size.")
+              if file0.get("checksum") != os.environ["EXPECTED_FILE_MD5"]:
+                  raise SystemExit("Unexpected file checksum.")
+
+          status, text, public_before = request("GET", f"{base}/records/{record_id}", ok=(200,))
+          if status != 200:
+              raise SystemExit(f"Could not read public record before update: HTTP {status}\n{text}")
+          require_public_record_unchanged(public_before)
+
+          status, text, deposition_before = request("GET", f"{base}/deposit/depositions/{record_id}", auth=True, ok=(200,))
+          if status != 200:
+              raise SystemExit(f"Could not read authenticated deposition before update: HTTP {status}\n{text}")
+
+          status, text, edit_body = request(
+              "POST",
+              f"{base}/deposit/depositions/{record_id}/actions/edit",
+              auth=True,
+              ok=(200, 201, 202),
+          )
+          if status not in (200, 201, 202):
+              raise SystemExit(f"Could not open metadata edit: HTTP {status}\n{text}")
+
+          edit_id = str((edit_body or {}).get("id") or record_id)
+          metadata_payload = dict(candidate)
+          update_body = {"metadata": metadata_payload}
+
+          status, text, update_response = request(
+              "PUT",
+              f"{base}/deposit/depositions/{edit_id}",
+              data=update_body,
+              auth=True,
+              ok=(200,),
+          )
+
+          if status != 200 and "notes" in metadata_payload:
+              metadata_payload = dict(metadata_payload)
+              metadata_payload.pop("notes", None)
+              update_body = {"metadata": metadata_payload}
+              status, text, update_response = request(
+                  "PUT",
+                  f"{base}/deposit/depositions/{edit_id}",
+                  data=update_body,
+                  auth=True,
+                  ok=(200,),
+              )
+
+          if status != 200:
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata PUT failed; edit was discarded. HTTP {status}\n{text}")
+
+          status, text, publish_response = request(
+              "POST",
+              f"{base}/deposit/depositions/{edit_id}/actions/publish",
+              auth=True,
+              ok=(200, 202),
+          )
+          if status not in (200, 202):
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata publish failed; edit discard attempted. HTTP {status}\n{text}")
+
+          public_after = None
+          for _ in range(12):
+              time.sleep(5)
+              status, text, public_after = request("GET", f"{base}/records/{record_id}", ok=(200,))
+              if status == 200 and "notion-selectable" not in public_after.get("metadata", {}).get("description", ""):
+                  break
+          if status != 200:
+              raise SystemExit(f"Could not read public record after update: HTTP {status}\n{text}")
+
+          require_public_record_unchanged(public_after)
+          description = public_after.get("metadata", {}).get("description", "")
+          if "notion-selectable" in description:
+              raise SystemExit("Public description still contains Notion wrapper markup.")
+          if "RC01-v12" not in description:
+              raise SystemExit("Public description does not contain RC01-v12.")
+
+          summary = {
+              "status": "ZENODO_METADATA_UPDATED",
+              "record_id": record_id,
+              "doi": public_after.get("doi"),
+              "conceptdoi": public_after.get("conceptdoi"),
+              "version": public_after.get("metadata", {}).get("version"),
+              "file_count": len(public_after.get("files", [])),
+              "file": public_after.get("files", [{}])[0],
+              "custom": public_after.get("metadata", {}).get("custom"),
+              "keywords": public_after.get("metadata", {}).get("keywords"),
+              "related_identifiers": public_after.get("metadata", {}).get("related_identifiers"),
+              "references": public_after.get("metadata", {}).get("references"),
+              "description_contains_notion_wrapper": "notion-selectable" in description,
+              "description_contains_rc01_v12": "RC01-v12" in description,
+          }
+
+          with open("zenodo_rc01_v12_metadata_update_result.json", "w", encoding="utf-8") as f:
+              json.dump(summary, f, ensure_ascii=False, indent=2)
+
+          with open("zenodo_rc01_v12_metadata_update_result.md", "w", encoding="utf-8") as f:
+              f.write("# Zenodo RC01-v12 Metadata Update Result\n\n")
+              f.write("Status: ZENODO_METADATA_UPDATED\n\n")
+              f.write(f"- Record ID: {summary['record_id']}\n")
+              f.write(f"- DOI: {summary['doi']}\n")
+              f.write(f"- Concept DOI: {summary['conceptdoi']}\n")
+              f.write(f"- Version: {summary['version']}\n")
+              f.write(f"- File count: {summary['file_count']}\n")
+              f.write("- File update: none\n")
+              f.write("- New version: none\n")
+              f.write("- DOI reservation: none\n")
+              f.write("- GitHub release/tag: none\n")
+              f.write("- Description wrapper removed: yes\n")
+              f.write("- Repository custom field preserved: yes\n")
+
+          print(json.dumps(summary, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Upload execution evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenodo-rc01-v12-metadata-update-result
+          path: |
+            zenodo_rc01_v12_metadata_update_result.json
+            zenodo_rc01_v12_metadata_update_result.md
+          if-no-files-found: warn

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/before_after_checklist.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/before_after_checklist.md
@@ -1,0 +1,51 @@
+# RC01-v12 Metadata Patch Before/After Checklist
+
+Status: REVIEW_ONLY_NO_MUTATION
+
+## Before
+
+- [x] Record target is `20073579`.
+- [x] Specific DOI is `10.5281/zenodo.20073579`.
+- [x] Concept DOI is `10.5281/zenodo.19774446`.
+- [x] Version is `RC01-v12`.
+- [x] Status is published.
+- [x] File is `main (44).pdf`.
+- [x] File MD5 is `d791d480e75f3d89f9a103a28a5c5001`.
+- [x] File SHA-256 is `1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40`.
+- [x] ORCID is present: `0009-0007-8033-3508`.
+- [x] GitHub repository link is present in current metadata.
+- [x] Current description includes exported Notion wrapper markup.
+- [x] Current description includes older reference-snapshot wording.
+
+## Proposed After Review
+
+- [ ] Record target remains `20073579`.
+- [ ] Specific DOI remains `10.5281/zenodo.20073579`.
+- [ ] Concept DOI remains `10.5281/zenodo.19774446`.
+- [ ] Version remains `RC01-v12`.
+- [ ] Publication date remains `2026-05-07`.
+- [ ] File remains unchanged.
+- [ ] No new version is created.
+- [ ] No DOI is reserved.
+- [ ] No file is uploaded.
+- [ ] Description is cleaned of Notion wrapper markup.
+- [ ] Description explicitly names `RC01-v12`.
+- [ ] Repository relationship is preserved.
+- [ ] ORCID is preserved.
+- [ ] License remains `cc-by-4.0`.
+- [ ] Language remains `deu`.
+
+## Human Review Questions
+
+- [ ] Is the cleaned German description faithful to the published record?
+- [ ] Is the cleaned English description faithful to the published record?
+- [ ] Should the older `Referenzsnapshot: Zenodo v7 vom 3. Mai 2026` wording be removed, replaced, or retained?
+- [ ] Should the GitHub repository be represented as a related identifier, custom repository field, or both?
+- [ ] Should keywords be expanded to match `CITATION.cff`, or kept closer to the current Zenodo record?
+
+## Decision Gate
+
+- [ ] Silvi approves metadata-only update.
+- [ ] No file update is requested.
+- [ ] No new version is requested.
+- [ ] No publish action is requested.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/before_after_checklist.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/before_after_checklist.md
@@ -13,7 +13,11 @@ Status: REVIEW_ONLY_NO_MUTATION
 - [x] File MD5 is `d791d480e75f3d89f9a103a28a5c5001`.
 - [x] File SHA-256 is `1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40`.
 - [x] ORCID is present: `0009-0007-8033-3508`.
-- [x] GitHub repository link is present in current metadata.
+- [x] GitHub repository link is present in current metadata as
+  `custom.code:codeRepository`.
+- [x] Current keywords are recorded as the conservative v0.2 baseline.
+- [x] Current concept DOI reference is recorded as the conservative v0.2
+  baseline.
 - [x] Current description includes exported Notion wrapper markup.
 - [x] Current description includes older reference-snapshot wording.
 
@@ -31,6 +35,12 @@ Status: REVIEW_ONLY_NO_MUTATION
 - [ ] Description is cleaned of Notion wrapper markup.
 - [ ] Description explicitly names `RC01-v12`.
 - [ ] Repository relationship is preserved.
+- [ ] `custom.code:codeRepository` is preserved.
+- [ ] Current keywords are preserved without broad expansion.
+- [ ] Current concept DOI reference is preserved.
+- [ ] No self-DOI reference is added as a normal reference.
+- [ ] No GitHub related identifier is added without separate Zenodo relation
+  validation.
 - [ ] ORCID is preserved.
 - [ ] License remains `cc-by-4.0`.
 - [ ] Language remains `deu`.
@@ -41,7 +51,8 @@ Status: REVIEW_ONLY_NO_MUTATION
 - [ ] Is the cleaned English description faithful to the published record?
 - [ ] Should the older `Referenzsnapshot: Zenodo v7 vom 3. Mai 2026` wording be removed, replaced, or retained?
 - [ ] Should the GitHub repository be represented as a related identifier, custom repository field, or both?
-- [ ] Should keywords be expanded to match `CITATION.cff`, or kept closer to the current Zenodo record?
+- [x] v0.2 decision: keep GitHub primarily in `custom.code:codeRepository`.
+- [x] v0.2 decision: keep keywords close to the current Zenodo record.
 
 ## Decision Gate
 

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_edit_instructions.rc01-v12.v0.2.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_edit_instructions.rc01-v12.v0.2.md
@@ -1,0 +1,108 @@
+# RC01-v12 Metadata Edit Instructions v0.2
+
+Status: REVIEW_ONLY_NO_MUTATION
+Target record: `20073579`
+Specific DOI: `10.5281/zenodo.20073579`
+Concept DOI: `10.5281/zenodo.19774446`
+Current version: `RC01-v12`
+
+## Gate
+
+These instructions are a review artifact only. They do not authorize or perform
+any Zenodo mutation.
+
+Explicitly not authorized in this package:
+
+- Zenodo API write request
+- file upload
+- file deletion
+- file modification
+- new version creation
+- DOI reservation
+- publish action
+- GitHub release
+- Git tag
+
+## Official Rule Used
+
+Published Zenodo record metadata may be edited. Files and persistent
+identifiers are not normal metadata-edit fields. File/content changes require a
+separate file or version workflow and are out of scope here.
+
+## UI Path, If Later Authorized
+
+1. Open `https://zenodo.org/records/20073579`.
+2. Use the Zenodo record edit control for the published record.
+3. Edit metadata only.
+4. Preserve all file settings and files unchanged.
+5. Preserve DOI and concept DOI unchanged.
+6. Apply only the metadata-field changes from the v0.2 payload.
+7. Publish/save the metadata edit only after a separate explicit Silvi-Go for
+   the visible metadata update.
+
+## API Path, If Later Authorized
+
+Use only after a separate explicit Silvi-Go and with a token scoped for deposit
+metadata editing. Do not execute from this review package.
+
+Conceptual flow:
+
+```text
+POST /api/deposit/depositions/20073579/actions/edit
+PUT  /api/deposit/depositions/20073579
+POST /api/deposit/depositions/20073579/actions/publish
+```
+
+The API path must be rechecked against the authenticated Zenodo deposition
+response before execution, because published-record edit flows expose edit and
+publish links in the deposition resource.
+
+## Fields To Preserve
+
+- `title`
+- `upload_type`
+- `publication_type`
+- `creators`
+- `access_right`
+- `license`
+- `version`
+- `language`
+- `keywords`
+- `related_identifiers`
+- `references`
+- `custom.code:codeRepository`
+- DOI and concept DOI
+- all files and file visibility
+
+## Fields To Edit
+
+- `description` only, replacing exported Notion wrapper markup and older
+  reference-snapshot wording with the clean v0.2 Zenodo-facing description.
+- `notes` only if Zenodo accepts the notes field for the authenticated edit
+  payload. If unsupported, omit it rather than forcing a schema change.
+
+## Final Payload Candidate
+
+Use the `proposed_api_payload_candidate.metadata` object in
+`zenodo_metadata_patch.rc01-v12.review.json`.
+
+The v0.2 payload intentionally:
+
+- preserves `custom.code:codeRepository`;
+- preserves the current keyword list;
+- preserves the current concept DOI reference;
+- preserves the current concept DOI `isVersionOf` relation;
+- does not use the record's own DOI as a normal reference;
+- does not add a GitHub related identifier.
+
+## Write-Readiness
+
+The v0.2 package is write-ready as a metadata-only instruction package after
+human review. It is not execution-authorized.
+
+Required before execution:
+
+- explicit Silvi-Go for Zenodo metadata edit;
+- authenticated Zenodo deposition readback;
+- pre-write comparison of target record `20073579`;
+- confirmation that no file/version/publish-new-version path is opened.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
@@ -1,0 +1,51 @@
+# RC01-v12 Metadata Execution Authorization
+
+Status: AUTHORIZED_METADATA_ONLY
+Authorized by: Silvi
+Authorization date: 2026-05-13
+Target record: `20073579`
+Specific DOI: `10.5281/zenodo.20073579`
+Concept DOI: `10.5281/zenodo.19774446`
+Current version: `RC01-v12`
+
+## Authorization
+
+Silvi explicitly authorized execution of the Zenodo metadata update after v0.2
+review.
+
+Execution route:
+
+- GitHub Actions;
+- repository secret `ZENODO_API`;
+- workflow `.github/workflows/zenodo-rc01-v12-metadata-update.yml`;
+- one-shot merge-commit gate `execute-zenodo-z2-metadata-update`.
+
+## Authorized Scope
+
+- update published record metadata only;
+- preserve record ID `20073579`;
+- preserve DOI `10.5281/zenodo.20073579`;
+- preserve concept DOI `10.5281/zenodo.19774446`;
+- preserve version `RC01-v12`;
+- preserve file `main (44).pdf`;
+- preserve `custom.code:codeRepository`;
+- preserve current keywords;
+- preserve current concept DOI reference;
+- preserve current `isVersionOf` relation.
+
+## Still Forbidden
+
+- file upload;
+- file deletion;
+- file modification;
+- new version creation;
+- DOI reservation;
+- GitHub release;
+- Git tag;
+- raw dump or private excerpt publication.
+
+## Expected Result
+
+The public Zenodo description is replaced by the clean v0.2 description while
+the file, DOI, concept DOI, version, repository link, keywords, references, and
+related identifier remain unchanged.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_patch_notes.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_patch_notes.md
@@ -1,6 +1,6 @@
 # RC01-v12 Zenodo Metadata Patch Notes
 
-Status: REVIEW_ONLY_NO_MUTATION
+Status: REVIEW_ONLY_NO_MUTATION v0.2
 Target record: `20073579`
 Specific DOI: `10.5281/zenodo.20073579`
 Concept DOI: `10.5281/zenodo.19774446`
@@ -37,6 +37,19 @@ MD5:    d791d480e75f3d89f9a103a28a5c5001
 
 Therefore there is no v13 artifact and no file update path in this package.
 
+## v0.2 Review Decision
+
+Codex review and GPT semantic review found that the v0.1 package was a valid
+review surface but not write-ready. The v0.2 package keeps the metadata update
+strictly conservative:
+
+- preserve `custom.code:codeRepository`;
+- preserve the current keyword list exactly;
+- preserve the current concept DOI reference;
+- preserve the concept DOI `isVersionOf` related identifier;
+- do not add a GitHub related identifier unless it is separately validated and
+  approved later.
+
 ## Proposed Metadata Behavior
 
 - Keep the record title unchanged.
@@ -45,7 +58,9 @@ Therefore there is no v13 artifact and no file update path in this package.
 - Keep ORCID `0009-0007-8033-3508`.
 - Keep license `cc-by-4.0`.
 - Keep language `deu`.
-- Keep repository relationship to `Terra-Nova-Restore/TerraNova-s-Framework`.
+- Keep repository relationship via `custom.code:codeRepository`.
+- Keep current keywords unchanged.
+- Keep current concept DOI reference unchanged.
 - Replace only the review-targeted metadata text with cleaner HTML if later
   approved.
 

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_patch_notes.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_patch_notes.md
@@ -1,0 +1,55 @@
+# RC01-v12 Zenodo Metadata Patch Notes
+
+Status: REVIEW_ONLY_NO_MUTATION
+Target record: `20073579`
+Specific DOI: `10.5281/zenodo.20073579`
+Concept DOI: `10.5281/zenodo.19774446`
+Current version: `RC01-v12`
+
+## Purpose
+
+This package prepares a reviewable metadata-only patch candidate for the
+existing published Zenodo record `20073579`.
+
+It does not update Zenodo. It does not create a new version. It does not change
+the published PDF.
+
+## Why This Patch Exists
+
+The current public metadata is fundamentally correct: title, DOI, concept DOI,
+version, ORCID, repository link, license, language, and file checksum all match
+the repository-side RC01-v12 anchors.
+
+The main improvement candidate is the description field. The current Zenodo
+description contains exported Notion wrapper markup and an older
+reference-snapshot wording. The proposed patch keeps the substance but turns it
+into clean Zenodo-facing HTML and names `RC01-v12` explicitly.
+
+## No File Update
+
+`main (45).pdf` was checked and is byte-identical to the published
+`main (44).pdf`:
+
+```text
+SHA256: 1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40
+MD5:    d791d480e75f3d89f9a103a28a5c5001
+```
+
+Therefore there is no v13 artifact and no file update path in this package.
+
+## Proposed Metadata Behavior
+
+- Keep the record title unchanged.
+- Keep `RC01-v12` unchanged.
+- Keep DOI and concept DOI unchanged.
+- Keep ORCID `0009-0007-8033-3508`.
+- Keep license `cc-by-4.0`.
+- Keep language `deu`.
+- Keep repository relationship to `Terra-Nova-Restore/TerraNova-s-Framework`.
+- Replace only the review-targeted metadata text with cleaner HTML if later
+  approved.
+
+## Execution Boundary
+
+This package is a review surface only. Any actual Zenodo metadata update
+requires a later explicit Silvi-Go and a separate execution step.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/no-mutation-gate.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/no-mutation-gate.md
@@ -1,22 +1,29 @@
 # No-Mutation Gate Statement
 
-Status: ACTIVE
+Status: SUPERSEDED_FOR_METADATA_EXECUTION
 Scope: RC01-v12 Zenodo metadata patch review package
 
 ## Gate
 
-This package does not authorize any Zenodo mutation.
+This package originally did not authorize any Zenodo mutation. That review gate
+was superseded by explicit Silvi authorization on 2026-05-13 to execute the
+metadata-only update for record `20073579`.
+
+The remaining gate is still active for every non-metadata action.
+
+Authorized now:
+
+- metadata-only update on Zenodo record `20073579`;
+- no file, DOI, version, release, or tag action.
 
 ## Explicitly Not Authorized
 
-- Zenodo API write request
-- metadata update on Zenodo
 - file upload
 - file deletion
 - file modification
 - new version creation
 - DOI reservation
-- publish action
+- publish action for a new record or new version
 - GitHub release
 - Git tag
 
@@ -26,6 +33,8 @@ This package does not authorize any Zenodo mutation.
 - local documentation review
 - public read-only Zenodo record checks
 - GitHub draft PR review
+- GitHub Actions execution using repository secret `ZENODO_API`, restricted to
+  the metadata-only update described in v0.2
 
 ## Current Artifact Boundary
 
@@ -36,4 +45,6 @@ artifact and is not part of this metadata-only patch path.
 
 ## Next Authorization Required
 
-A later explicit Silvi-Go is required before any metadata write is attempted.
+The explicit Silvi-Go for metadata execution has been received. A separate
+explicit Silvi-Go is still required for any future file, version, DOI, release,
+or tag action.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/no-mutation-gate.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/no-mutation-gate.md
@@ -1,0 +1,39 @@
+# No-Mutation Gate Statement
+
+Status: ACTIVE
+Scope: RC01-v12 Zenodo metadata patch review package
+
+## Gate
+
+This package does not authorize any Zenodo mutation.
+
+## Explicitly Not Authorized
+
+- Zenodo API write request
+- metadata update on Zenodo
+- file upload
+- file deletion
+- file modification
+- new version creation
+- DOI reservation
+- publish action
+- GitHub release
+- Git tag
+
+## Allowed In This Package
+
+- local JSON review
+- local documentation review
+- public read-only Zenodo record checks
+- GitHub draft PR review
+
+## Current Artifact Boundary
+
+The published artifact is still `main (44).pdf` on Zenodo record `20073579`.
+
+`main (45).pdf` is byte-identical to `main (44).pdf`, so it is not a v13
+artifact and is not part of this metadata-only patch path.
+
+## Next Authorization Required
+
+A later explicit Silvi-Go is required before any metadata write is attempted.

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
@@ -31,7 +31,7 @@
     "file_sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40"
   },
   "review_findings": [
-    "The current public Zenodo metadata already has the correct DOI, concept DOI, version, ORCID, repository link, license, and file checksum.",
+    "The current public Zenodo metadata already has the correct DOI, concept DOI, version, ORCID, custom code repository link, license, and file checksum.",
     "The current description contains exported Notion wrapper markup and an older reference-snapshot wording that should be reviewed before any metadata edit.",
     "main (45).pdf is byte-identical to main (44).pdf and must not be used as a new file update or RC01-v13 payload."
   ],
@@ -53,26 +53,16 @@
       "version": "RC01-v12",
       "language": "deu",
       "keywords": [
-        "FerrAI",
-        "Terra Nova",
-        "TerraNova",
         "CIC",
-        "Cognitive Intelligent Cooperation",
-        "Human-AI Collaboration",
-        "Mensch-KI-Interaktion",
-        "Claim/Evidence",
-        "Evidence Apparatus",
-        "Editorial Reconstruction",
-        "Source-Critical Edition",
-        "System Architecture",
-        "Process Logic",
-        "Trigger Logic",
-        "Knowledge Organization",
-        "Governance",
-        "Versioned Research Manuscript",
-        "Dissertation Draft",
-        "Workspace Documentation",
-        "AI-assisted research"
+        "Zenodo",
+        "Github",
+        "Notion",
+        "audit trail",
+        "complex systems",
+        "AI ethics",
+        "FerrAI",
+        "Terra'Nova'Restore",
+        "human-AI interaction"
       ],
       "related_identifiers": [
         {
@@ -80,18 +70,15 @@
           "relation": "isVersionOf",
           "scheme": "doi",
           "resource_type": "publication-other"
-        },
-        {
-          "identifier": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
-          "relation": "isSupplementedBy",
-          "scheme": "url"
         }
       ],
+      "custom": {
+        "code:codeRepository": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework"
+      },
       "references": [
-        "Lenhard, S. (2026). FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat (RC01-v12). Zenodo. https://doi.org/10.5281/zenodo.20073579",
-        "Lenhard, S. (2026). TerraNova-s-Framework. GitHub. https://github.com/Terra-Nova-Restore/TerraNova-s-Framework"
+        "Lenhard, S. (2026). FerrAI / Terra Nova: Dissertationsentwurf. Zenodo. https://doi.org/10.5281/zenodo.19774446"
       ],
-      "notes": "Metadata-only review candidate for the existing RC01-v12 record. No file update, new version, DOI reservation, upload, or publish action is authorized by this file."
+      "notes": "Metadata-only v0.2 review candidate for the existing RC01-v12 record. It preserves the current custom code repository field, current keywords, current concept DOI reference, and current isVersionOf relation. No file update, new version, DOI reservation, upload, or publish action is authorized by this file."
     }
   }
 }

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
@@ -1,0 +1,97 @@
+{
+  "review_package": {
+    "id": "rc01-v12-metadata-patch-2026-05-13",
+    "status": "REVIEW_ONLY_NO_MUTATION",
+    "created_date": "2026-05-13",
+    "target_record_id": "20073579",
+    "target_record_url": "https://zenodo.org/records/20073579",
+    "specific_doi": "10.5281/zenodo.20073579",
+    "concept_doi": "10.5281/zenodo.19774446",
+    "current_version": "RC01-v12",
+    "patch_type": "metadata-only review candidate",
+    "file_update": false,
+    "new_version": false,
+    "doi_reservation": false,
+    "zenodo_mutation_authorized": false
+  },
+  "current_record_facts": {
+    "title": "FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat",
+    "publication_date": "2026-05-07",
+    "status": "published",
+    "resource_type": "Book",
+    "access_right": "open",
+    "license": "cc-by-4.0",
+    "language": "deu",
+    "creator": "Lenhard, Silvan",
+    "orcid": "0009-0007-8033-3508",
+    "repository": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
+    "file_name": "main (44).pdf",
+    "file_size_bytes": 2943457,
+    "file_md5": "d791d480e75f3d89f9a103a28a5c5001",
+    "file_sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40"
+  },
+  "review_findings": [
+    "The current public Zenodo metadata already has the correct DOI, concept DOI, version, ORCID, repository link, license, and file checksum.",
+    "The current description contains exported Notion wrapper markup and an older reference-snapshot wording that should be reviewed before any metadata edit.",
+    "main (45).pdf is byte-identical to main (44).pdf and must not be used as a new file update or RC01-v13 payload."
+  ],
+  "proposed_api_payload_candidate": {
+    "metadata": {
+      "title": "FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat",
+      "upload_type": "publication",
+      "publication_type": "book",
+      "description": "<h2>Zenodo Description -- Deutsch</h2><p><strong>FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat</strong></p><p>Diese Veröffentlichung dokumentiert den zitierfähigen Release Candidate <code>RC01-v12</code> einer Werkmonographie mit Evidenzapparat zum FerrAI-/Terra-Nova-/CIC-Komplex. Die Schrift rekonstruiert Terra Nova im sichtbaren lokalen Korpus nicht als einzelnen Prompt, isoliertes Modell oder bloßes Whitepaper, sondern als mehrschichtigen Verbund aus Systemarchitektur, operativer Prozesslogik, Claim/Evidence-Governance, Triggerordnung, dokumentierten Patent- und Rechtsspuren sowie Tokenisierungs- und Verwertungslogik.</p><p>Im Zentrum steht eine quellengebundene editorische Rekonstruktion des gezählten Terra-Nova-/FerrAI-Korpus und der sichtbaren CIC-Dokumentfamilie. Der gezählte Kernkorpus umfasst in dieser Fassung 67 HTML- und CSV-Exporte; Supplemente, Workspace-Spuren, Uploads, Arbeitsnotizen und spätere Rückführungen werden ausdrücklich mitgeführt, aber nicht unmarkiert mit dem Kernkorpus vermischt. Dadurch bleiben Belegbasis, editorische Ableitung und offene Stellen nachvollziehbar getrennt.</p><p>CIC wird in dieser Fassung als <code>Cognitive Intelligent Cooperation</code> normiert, zugleich aber als sichtbare Dokument- und Frameworkschicht vom engeren Primärbegriff der Kooperationslogik unterschieden. Methodisch arbeitet das Manuskript mit expliziten Statusmarkern und einer textbasierten Claim/Evidence-Logik. Die Arbeit ist bewusst als textorientierte Hauptschrift angelegt; ein größerer visueller Diagramm-, Tabellen- und Bildkörper wird methodisch zurückgestellt, bis Begriffe, Mapping-Schichten und Evidenzgrenzen weiter gehärtet sind.</p><p>Das Dokument ist keine abgeschlossene peer-reviewte Dissertation. Es ist ein versioniertes Forschungsmanuskript, eine Werkmonographie mit Evidenzapparat und ein bewusst offen gehaltener Release Candidate, der Haupttext, Appendix, Registerräume und Ausbaukorridor transparent zusammenführt.</p><h2>Zenodo Description -- English</h2><p>This release documents the citable release candidate <code>RC01-v12</code> of a work monograph with evidence apparatus on the FerrAI / Terra Nova / CIC complex. Rather than treating Terra Nova as a single prompt, an isolated model, or a standalone white paper, the manuscript reconstructs it from the visible local corpus as a layered assemblage of system architecture, operational process logic, claim/evidence governance, trigger order, documented patent and rights traces, and tokenization and utilization logic.</p><p>At its core, the work offers a source-bound editorial reconstruction of the counted Terra Nova / FerrAI corpus and the visible CIC document family. In this version, the counted core corpus comprises 67 HTML and CSV exports; supplementary workspace traces, uploads, working notes, and later reintegrations are explicitly retained, but not silently merged with the core corpus. This keeps primary evidence, editorial inference, and open questions clearly distinct.</p><p>In this edition, CIC is normalized as <code>Cognitive Intelligent Cooperation</code> while also being distinguished, as a visible document and framework layer, from the narrower primary term of cooperative logic. Methodologically, the manuscript relies on explicit status markers and a text-based claim/evidence regime. The work is intentionally designed as a text-first main edition; a larger visual body of diagrams, tables, and rendered graphics is deliberately postponed until terminology, mapping layers, and evidence boundaries have been further stabilized.</p><p>This document is not a completed peer-reviewed dissertation. It is a versioned research manuscript, a work monograph with evidence apparatus, and a deliberately open release candidate that transparently brings together the main text, appendices, registers, and an expansion corridor.</p><h2>Version Note</h2><p>Versionierter Forschungsstand / zitierfähiger Release Candidate <code>RC01-v12</code>.</p><p>Publication date: <code>2026-05-07</code>. Current record DOI: <code>10.5281/zenodo.20073579</code>. Concept DOI: <code>10.5281/zenodo.19774446</code>.</p><h2>Additional Notes</h2><p><strong>English:</strong> This release represents a citable RC state within a versioned publication chain. Later releases may include expanded source registers, revised matrices, additional chapters, a broadened visual apparatus, and further hardened terminology and evidence boundaries.</p><p><strong>Deutsch:</strong> Diese Veröffentlichung markiert einen zitierfähigen RC-Stand innerhalb einer versionierten Publikationskette. Spätere Releases können erweiterte Quellenregister, überarbeitete Matrizen, zusätzliche Kapitel, einen ausgebauten visuellen Apparat sowie weiter gehärtete Terminologie- und Evidenzgrenzen enthalten.</p>",
+      "creators": [
+        {
+          "name": "Lenhard, Silvan",
+          "affiliation": "Terra'Nova'Restore",
+          "orcid": "0009-0007-8033-3508"
+        }
+      ],
+      "access_right": "open",
+      "license": "cc-by-4.0",
+      "version": "RC01-v12",
+      "language": "deu",
+      "keywords": [
+        "FerrAI",
+        "Terra Nova",
+        "TerraNova",
+        "CIC",
+        "Cognitive Intelligent Cooperation",
+        "Human-AI Collaboration",
+        "Mensch-KI-Interaktion",
+        "Claim/Evidence",
+        "Evidence Apparatus",
+        "Editorial Reconstruction",
+        "Source-Critical Edition",
+        "System Architecture",
+        "Process Logic",
+        "Trigger Logic",
+        "Knowledge Organization",
+        "Governance",
+        "Versioned Research Manuscript",
+        "Dissertation Draft",
+        "Workspace Documentation",
+        "AI-assisted research"
+      ],
+      "related_identifiers": [
+        {
+          "identifier": "10.5281/zenodo.19774446",
+          "relation": "isVersionOf",
+          "scheme": "doi",
+          "resource_type": "publication-other"
+        },
+        {
+          "identifier": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
+          "relation": "isSupplementedBy",
+          "scheme": "url"
+        }
+      ],
+      "references": [
+        "Lenhard, S. (2026). FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat (RC01-v12). Zenodo. https://doi.org/10.5281/zenodo.20073579",
+        "Lenhard, S. (2026). TerraNova-s-Framework. GitHub. https://github.com/Terra-Nova-Restore/TerraNova-s-Framework"
+      ],
+      "notes": "Metadata-only review candidate for the existing RC01-v12 record. No file update, new version, DOI reservation, upload, or publish action is authorized by this file."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Executes the approved RC01-v12 Zenodo metadata-only update through GitHub Actions using the repository secret `ZENODO_API`.

Target:
- Record: 20073579
- Specific DOI: 10.5281/zenodo.20073579
- Concept DOI: 10.5281/zenodo.19774446
- Current version: RC01-v12

## Execution Route

- Workflow: `.github/workflows/zenodo-rc01-v12-metadata-update.yml`
- Trigger: merge commit message containing `execute-zenodo-z2-metadata-update`
- Credential source: GitHub Actions secret `ZENODO_API`
- Scope: metadata-only update on published record `20073579`

## Files

- `.github/workflows/zenodo-rc01-v12-metadata-update.yml`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_patch_notes.md`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/before_after_checklist.md`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/no-mutation-gate.md`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_edit_instructions.rc01-v12.v0.2.md`
- `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md`

## Authorized Scope

- Replace Zenodo description with the clean v0.2 description.
- Preserve `custom.code:codeRepository`.
- Preserve current keywords.
- Preserve current concept DOI reference.
- Preserve current concept DOI `isVersionOf` related identifier.

## Hard Locks Still Active

- No file upload
- No file deletion/modification
- No new version
- No DOI reservation
- No GitHub release/tag
- No raw dump/private excerpts

## Validation

- `python scripts/validate_docs.py` OK
- JSON parsed successfully
- v0.2 gate assertions OK for target record, custom repo field, keyword preservation, concept relation, concept reference, and no self-DOI reference

## Expected Evidence

The workflow uploads `zenodo-rc01-v12-metadata-update-result` containing JSON/Markdown evidence if the update succeeds.