### PR TITLE
[codex] Fix RC01-v12 Zenodo metadata executor

### DIFF
--- a/.github/workflows/zenodo-rc01-v12-metadata-update.yml
+++ b/.github/workflows/zenodo-rc01-v12-metadata-update.yml
@@ -172,56 +172,45 @@ jobs:
               raise SystemExit(f"Could not read public record before update: HTTP {status}\n{text}")
           require_public_record_unchanged(public_before)
 
-          status, text, deposition_before = request("GET", f"{base}/deposit/depositions/{record_id}", auth=True, ok=(200,))
-          if status != 200:
-              raise SystemExit(f"Could not read authenticated deposition before update: HTTP {status}\n{text}")
+          draft_url = f"{base}/records/{record_id}/draft"
+          status, text, draft = request("POST", draft_url, auth=True, ok=(200, 201))
+          if status not in (200, 201):
+              if status in (400, 409):
+                  status, text, draft = request("GET", draft_url, auth=True, ok=(200,))
+              if status != 200:
+                  raise SystemExit(f"Could not open metadata draft edit: HTTP {status}\n{text}")
 
-          status, text, edit_body = request(
-              "POST",
-              f"{base}/deposit/depositions/{record_id}/actions/edit",
-              auth=True,
-              ok=(200, 201, 202),
-          )
-          if status not in (200, 201, 202):
-              raise SystemExit(f"Could not open metadata edit: HTTP {status}\n{text}")
+          update_body = {}
+          for key in ("metadata", "access", "files", "pids", "custom_fields"):
+              if isinstance(draft, dict) and key in draft:
+                  update_body[key] = draft[key]
 
-          edit_id = str((edit_body or {}).get("id") or record_id)
-          metadata_payload = dict(candidate)
-          update_body = {"metadata": metadata_payload}
+          if "metadata" not in update_body:
+              raise SystemExit("Draft response did not include metadata.")
+
+          update_body["metadata"] = dict(update_body["metadata"])
+          update_body["metadata"]["description"] = candidate["description"]
 
           status, text, update_response = request(
               "PUT",
-              f"{base}/deposit/depositions/{edit_id}",
+              draft_url,
               data=update_body,
               auth=True,
               ok=(200,),
           )
-
-          if status != 200 and "notes" in metadata_payload:
-              metadata_payload = dict(metadata_payload)
-              metadata_payload.pop("notes", None)
-              update_body = {"metadata": metadata_payload}
-              status, text, update_response = request(
-                  "PUT",
-                  f"{base}/deposit/depositions/{edit_id}",
-                  data=update_body,
-                  auth=True,
-                  ok=(200,),
-              )
-
           if status != 200:
-              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
-              raise SystemExit(f"Metadata PUT failed; edit was discarded. HTTP {status}\n{text}")
+              request("DELETE", draft_url, auth=True, ok=(200, 202, 204))
+              raise SystemExit(f"Metadata PUT failed; draft discard attempted. HTTP {status}\n{text}")
 
           status, text, publish_response = request(
               "POST",
-              f"{base}/deposit/depositions/{edit_id}/actions/publish",
+              f"{draft_url}/actions/publish",
               auth=True,
               ok=(200, 202),
           )
           if status not in (200, 202):
-              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
-              raise SystemExit(f"Metadata publish failed; edit discard attempted. HTTP {status}\n{text}")
+              request("DELETE", draft_url, auth=True, ok=(200, 202, 204))
+              raise SystemExit(f"Metadata publish failed; draft discard attempted. HTTP {status}\n{text}")
 
           public_after = None
           for _ in range(12):

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
@@ -20,6 +20,13 @@ Execution route:
 - workflow `.github/workflows/zenodo-rc01-v12-metadata-update.yml`;
 - one-shot merge-commit gate `execute-zenodo-z2-metadata-update`.
 
+Implementation note:
+
+- Attempt 1 used the legacy `/api/deposit/depositions/{id}` path and failed
+  before opening an edit because Zenodo returned `403 Permission denied`.
+- Attempt 2 uses the current record draft path `/api/records/{id}/draft` for
+  metadata-only edit/publish.
+
 ## Authorized Scope
 
 - update published record metadata only;


### PR DESCRIPTION
## Summary

Fixes the RC01-v12 metadata-only Zenodo executor after the first run failed before mutation on the legacy deposit endpoint with HTTP 403.

## Change

- Switches from legacy `/api/deposit/depositions/{id}` metadata edit path to current `/api/records/{id}/draft` record metadata edit path.
- Keeps the one-shot merge commit gate `execute-zenodo-z2-metadata-update`.
- Keeps all file/version/DOI/release locks.

## Safety

The first workflow run failed before opening a metadata edit. This fix still:

- only edits metadata description;
- preserves file, DOI, concept DOI, version, repository custom field, keywords, references, and related identifier;
- does not call file upload endpoints;
- does not call new-version endpoints;
- does not create a GitHub release or tag.

## Validation

- `python scripts/validate_docs.py` OK
- `git diff --check` OK
- Workflow scan confirms no legacy deposit endpoint, no `/files`, and no `newversion` path.