### PR TITLE
[codex] Normalize Zenodo metadata draft payload

### DIFF
--- a/.github/workflows/zenodo-rc01-v12-metadata-update.yml
+++ b/.github/workflows/zenodo-rc01-v12-metadata-update.yml
@@ -181,9 +181,19 @@ jobs:
                   raise SystemExit(f"Could not open metadata draft edit: HTTP {status}\n{text}")
 
           update_body = {}
-          for key in ("metadata", "access", "files", "pids", "custom_fields"):
+          for key in ("metadata", "access", "custom_fields"):
               if isinstance(draft, dict) and key in draft:
                   update_body[key] = draft[key]
+
+          # Zenodo's RDM draft response includes read-only file entries and PID
+          # state. For a metadata-only edit, keep only the writable files switch
+          # so the existing file remains enabled without resubmitting file rows.
+          if isinstance(draft, dict) and "files" in draft:
+              draft_files = draft["files"]
+              files_enabled = True
+              if isinstance(draft_files, dict) and "enabled" in draft_files:
+                  files_enabled = bool(draft_files["enabled"])
+              update_body["files"] = {"enabled": files_enabled}
 
           if "metadata" not in update_body:
               raise SystemExit("Draft response did not include metadata.")

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
@@ -26,6 +26,14 @@ Implementation note:
   before opening an edit because Zenodo returned `403 Permission denied`.
 - Attempt 2 uses the current record draft path `/api/records/{id}/draft` for
   metadata-only edit/publish.
+- Attempt 2 opened the record draft after the `ZENODO_API` secret was updated,
+  then failed on `PUT /api/records/{id}/draft` with Zenodo HTTP 500. The
+  workflow attempted to discard the draft and the public record was verified as
+  unchanged.
+- Attempt 3 keeps the same records draft path but normalizes the update payload:
+  it preserves metadata, access, and custom fields, reduces the `files` object
+  to its writable `enabled` switch, and omits PID state. This keeps the existing
+  file in place without resubmitting read-only file rows.
 
 ## Authorized Scope
 


### PR DESCRIPTION
## Summary

Fixes the RC01-v12 Zenodo metadata executor after the records draft path opened successfully but Zenodo returned HTTP 500 on draft PUT.

## Scope

- Keeps the workflow on `/api/records/20073579/draft`.
- Sends only editable draft fields for the metadata-only PUT.
- Preserves `metadata`, `access`, and `custom_fields`.
- Reduces `files` to its writable `enabled` switch so the existing file remains enabled without resubmitting file rows.
- Omits PID state from the update payload.
- Documents attempt 2 and attempt 3 in the authorization note.

## Gates

- No file upload.
- No file deletion or replacement.
- No new version.
- No DOI reservation.
- No GitHub release or tag.
- One-shot execution remains gated by merge commit text `execute-zenodo-z2-metadata-update`.

## Validation

- `python scripts\validate_docs.py`
- `git diff --check`