### PR TITLE
[codex] Normalize Zenodo draft access payload

### DIFF
--- a/.github/workflows/zenodo-rc01-v12-metadata-update.yml
+++ b/.github/workflows/zenodo-rc01-v12-metadata-update.yml
@@ -181,9 +181,21 @@ jobs:
                   raise SystemExit(f"Could not open metadata draft edit: HTTP {status}\n{text}")
 
           update_body = {}
-          for key in ("metadata", "access", "custom_fields"):
+          for key in ("metadata", "custom_fields"):
               if isinstance(draft, dict) and key in draft:
                   update_body[key] = draft[key]
+
+          if isinstance(draft, dict) and "access" in draft:
+              draft_access = draft["access"]
+              if not isinstance(draft_access, dict):
+                  raise SystemExit("Draft access field is not an object.")
+              access = {}
+              for key in ("record", "files"):
+                  if key in draft_access:
+                      access[key] = draft_access[key]
+              if set(access) != {"record", "files"}:
+                  raise SystemExit("Draft access field did not include record/files visibility.")
+              update_body["access"] = access
 
           # Zenodo's RDM draft response includes read-only file entries and PID
           # state. For a metadata-only edit, keep only the writable files switch
@@ -200,6 +212,17 @@ jobs:
 
           update_body["metadata"] = dict(update_body["metadata"])
           update_body["metadata"]["description"] = candidate["description"]
+
+          print(json.dumps({
+              "zenodo_update_body_shape": {
+                  "top_level_keys": sorted(update_body),
+                  "access": update_body.get("access"),
+                  "files": update_body.get("files"),
+                  "metadata_keys": sorted(update_body["metadata"]),
+                  "custom_field_keys": sorted(update_body.get("custom_fields", {})),
+                  "pids_included": "pids" in update_body,
+              }
+          }, ensure_ascii=False, indent=2))
 
           status, text, update_response = request(
               "PUT",

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
@@ -34,6 +34,13 @@ Implementation note:
   it preserves metadata, access, and custom fields, reduces the `files` object
   to its writable `enabled` switch, and omits PID state. This keeps the existing
   file in place without resubmitting read-only file rows.
+- Attempt 3 still failed on `PUT /api/records/{id}/draft` with Zenodo HTTP 500.
+  The workflow attempted to discard the draft and no public-record change was
+  recorded.
+- Attempt 4 keeps the same records draft path and further normalizes `access`
+  to only the writable `record` and `files` visibility fields shown in the
+  InvenioRDM draft update API. It also emits a sanitized update-body shape in
+  the workflow log without printing the replacement description or token.
 
 ## Authorized Scope
 


### PR DESCRIPTION
## Summary

Follows up PR #43 after Zenodo still returned HTTP 500 on `PUT /api/records/20073579/draft`.

## Scope

- Keeps the metadata-only records draft route.
- Normalizes `access` to only writable `record` and `files` visibility fields.
- Keeps `files` normalized to the writable `enabled` switch.
- Keeps PID state omitted.
- Emits a sanitized update-body shape in the workflow log without printing the replacement description or token.
- Documents attempt 3 and attempt 4 in the authorization note.

## Gates

- No file upload.
- No file deletion or replacement.
- No new version.
- No DOI reservation.
- No GitHub release or tag.
- One-shot execution remains gated by merge commit text `execute-zenodo-z2-metadata-update`.

## Validation

- `python scripts\validate_docs.py`
- `git diff --check`