### PR TITLE
[codex] Retry Zenodo metadata edit via deposit API

### DIFF
--- a/.github/workflows/zenodo-rc01-v12-metadata-update.yml
+++ b/.github/workflows/zenodo-rc01-v12-metadata-update.yml
@@ -172,78 +172,66 @@ jobs:
               raise SystemExit(f"Could not read public record before update: HTTP {status}\n{text}")
           require_public_record_unchanged(public_before)
 
-          draft_url = f"{base}/records/{record_id}/draft"
-          status, text, draft = request("POST", draft_url, auth=True, ok=(200, 201))
-          if status not in (200, 201):
-              if status in (400, 409):
-                  status, text, draft = request("GET", draft_url, auth=True, ok=(200,))
-              if status != 200:
-                  raise SystemExit(f"Could not open metadata draft edit: HTTP {status}\n{text}")
+          status, text, deposition_before = request("GET", f"{base}/deposit/depositions/{record_id}", auth=True, ok=(200,))
+          if status != 200:
+              raise SystemExit(f"Could not read authenticated deposition before update: HTTP {status}\n{text}")
 
-          update_body = {}
-          for key in ("metadata", "custom_fields"):
-              if isinstance(draft, dict) and key in draft:
-                  update_body[key] = draft[key]
+          status, text, edit_body = request(
+              "POST",
+              f"{base}/deposit/depositions/{record_id}/actions/edit",
+              auth=True,
+              ok=(200, 201, 202),
+          )
+          if status not in (200, 201, 202):
+              raise SystemExit(f"Could not open metadata edit: HTTP {status}\n{text}")
 
-          if isinstance(draft, dict) and "access" in draft:
-              draft_access = draft["access"]
-              if not isinstance(draft_access, dict):
-                  raise SystemExit("Draft access field is not an object.")
-              access = {}
-              for key in ("record", "files"):
-                  if key in draft_access:
-                      access[key] = draft_access[key]
-              if set(access) != {"record", "files"}:
-                  raise SystemExit("Draft access field did not include record/files visibility.")
-              update_body["access"] = access
-
-          # Zenodo's RDM draft response includes read-only file entries and PID
-          # state. For a metadata-only edit, keep only the writable files switch
-          # so the existing file remains enabled without resubmitting file rows.
-          if isinstance(draft, dict) and "files" in draft:
-              draft_files = draft["files"]
-              files_enabled = True
-              if isinstance(draft_files, dict) and "enabled" in draft_files:
-                  files_enabled = bool(draft_files["enabled"])
-              update_body["files"] = {"enabled": files_enabled}
-
-          if "metadata" not in update_body:
-              raise SystemExit("Draft response did not include metadata.")
-
-          update_body["metadata"] = dict(update_body["metadata"])
-          update_body["metadata"]["description"] = candidate["description"]
+          edit_id = str((edit_body or {}).get("id") or record_id)
+          metadata_payload = dict(candidate)
+          update_body = {"metadata": metadata_payload}
 
           print(json.dumps({
-              "zenodo_update_body_shape": {
-                  "top_level_keys": sorted(update_body),
-                  "access": update_body.get("access"),
-                  "files": update_body.get("files"),
-                  "metadata_keys": sorted(update_body["metadata"]),
-                  "custom_field_keys": sorted(update_body.get("custom_fields", {})),
-                  "pids_included": "pids" in update_body,
+              "zenodo_legacy_deposit_edit_shape": {
+                  "edit_id": edit_id,
+                  "metadata_keys": sorted(metadata_payload),
+                  "has_notes": "notes" in metadata_payload,
+                  "file_payload_included": False,
+                  "new_version_requested": False,
               }
           }, ensure_ascii=False, indent=2))
 
           status, text, update_response = request(
               "PUT",
-              draft_url,
+              f"{base}/deposit/depositions/{edit_id}",
               data=update_body,
               auth=True,
               ok=(200,),
           )
+
+          if status != 200 and "notes" in metadata_payload:
+              metadata_payload = dict(metadata_payload)
+              metadata_payload.pop("notes", None)
+              update_body = {"metadata": metadata_payload}
+              status, text, update_response = request(
+                  "PUT",
+                  f"{base}/deposit/depositions/{edit_id}",
+                  data=update_body,
+                  auth=True,
+                  ok=(200,),
+              )
+
           if status != 200:
-              request("DELETE", draft_url, auth=True, ok=(200, 202, 204))
-              raise SystemExit(f"Metadata PUT failed; draft discard attempted. HTTP {status}\n{text}")
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata PUT failed; edit was discarded. HTTP {status}\n{text}")
 
           status, text, publish_response = request(
               "POST",
-              f"{draft_url}/actions/publish",
+              f"{base}/deposit/depositions/{edit_id}/actions/publish",
               auth=True,
               ok=(200, 202),
           )
           if status not in (200, 202):
-              request("DELETE", draft_url, auth=True, ok=(200, 202, 204))
-              raise SystemExit(f"Metadata publish failed; draft discard attempted. HTTP {status}\n{text}")
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata publish failed; edit discard attempted. HTTP {status}\n{text}")
 
           public_after = None
           for _ in range(12):

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/metadata_execution_authorization.rc01-v12.2026-05-13.md
@@ -41,6 +41,13 @@ Implementation note:
   to only the writable `record` and `files` visibility fields shown in the
   InvenioRDM draft update API. It also emits a sanitized update-body shape in
   the workflow log without printing the replacement description or token.
+- Attempt 4 still failed on `PUT /api/records/{id}/draft` with Zenodo HTTP 500.
+  The sanitized shape showed that Zenodo returned legacy deposit-style metadata
+  through the records draft route, making that route unstable for this record.
+- Attempt 5 returns to the classic deposit edit flow
+  `/api/deposit/depositions/{id}/actions/edit` with the updated owner token.
+  This path matches the metadata schema in the patch package and still sends no
+  file payload, no new-version action, and no DOI action.
 
 ## Authorized Scope
 


### PR DESCRIPTION
## Summary

Follows up PR #44 after the records draft route continued to return Zenodo HTTP 500 on draft PUT.

## Root cause signal

The sanitized log from PR #44 showed that Zenodo exposed legacy deposit-style metadata fields through the records draft route for this record. The records draft `PUT` path is therefore unstable for this RC01-v12 metadata-only correction.

## Scope

- Returns execution to the classic deposit edit flow with the updated owner token:
  - `GET /api/deposit/depositions/20073579`
  - `POST /api/deposit/depositions/20073579/actions/edit`
  - `PUT /api/deposit/depositions/{edit_id}` with metadata only
  - `POST /api/deposit/depositions/{edit_id}/actions/publish`
- Sends no file payload.
- Does not create a new version.
- Does not reserve or mutate DOI state.
- Keeps discard-on-failure behavior.
- Documents attempt 4 and attempt 5 in the authorization note.

## Gates

- No file upload.
- No file deletion or replacement.
- No new version.
- No DOI reservation.
- No GitHub release or tag.
- One-shot execution remains gated by merge commit text `execute-zenodo-z2-metadata-update`.

## Validation

- `python scripts\validate_docs.py`
- `git diff --check`