### PR TITLE
docs(governance): implement public boundary, repo roles, and review gate

### DIFF
--- a/docs/atlas/control-tower/causal-log.issue-25-governance-2026-05-18.json
+++ b/docs/atlas/control-tower/causal-log.issue-25-governance-2026-05-18.json
@@ -1,0 +1,6 @@
+{
+  "log_id": "issue-25-governance-hardening",
+  "timestamp": "2026-05-18T18:25:00Z",
+  "event_type": "governance_update",
+  "decision": "create_public_boundary_and_roles"
+}

--- a/docs/governance/public_boundary.md
+++ b/docs/governance/public_boundary.md
@@ -1,69 +1,24 @@
-# Public Boundary
-
-Status: BIZ / Governance
-Source: Repository-side governance policy for public-safe publication boundaries.
-Trace: Issue `#25`, `docs/governance/source_of_record_policy.md`, `raw/exports/REVIEW_GATE.md`
-Boundary: Public repository boundary definition only; not a raw storage or canon surface.
-Mode: BIZ
-GitHub sync state: tracked in this repository as a publish-safety contract.
-Notion source awareness: required if this boundary is later mirrored into living governance canon.
+# Public Boundary Governance
 
 ## Purpose
+Defines the absolute boundary of what can be committed to the public `TerraNova-s-Framework` repository.
 
-This document defines what may be published in the public TerraNova repository and what must remain private, local, redacted, or patent-sensitive.
+## Allowed in Public (Public-OK)
+- Synthesized framework documentation (Track A).
+- Hardened control tower metrics, matrices, and gates.
+- Redacted architecture artifacts.
+- Abstracted CIC procedures.
 
-GitHub is the versioned engineering and research-operations layer. It is not the unrestricted raw memory layer.
+## Strictly Private / Local (Blocked)
+- Raw Notion ID links (`collection://`, workspace internals).
+- Unredacted `XXL_DatenExport` files.
+- Wallet secrets, API keys, or raw token deployment artifacts.
+- Patent-sensitive (TNPX-01) internal draft documents.
+- `GODFATHER_LOCK` flagged personal/intimate logs.
+- Internal triggers and private Metarotik (Track C) content not cleared for public release.
 
-## Allowed in the public repository
+## The `redact-candidate` Class
+Items classified as `redact-candidate` hold structural value but currently contain PII, private IDs, or sensitive paths. They must undergo the Sensitive Review Gate (e.g., DASH-VIEW-02) and be fully sanitized before pushing.
 
-Public-safe material may include:
-
-- reviewed architecture summaries
-- reproducible scripts without secrets
-- governance notes and review checklists
-- citation, Zenodo, ORCID and provenance anchors
-- dissertation/publication drafts after review
-- curated atlas outputs with source status
-- defensive security notes without exploit instructions
-- high-level trigger or CIC concepts when not private, intimate, token-sensitive, or patent-sensitive
-
-## Not allowed in the public repository
-
-Do not commit:
-
-- API keys, passwords, tokens, private keys, seed phrases, wallet secrets or credentials
-- private contact data or personally identifying raw logs
-- raw intimate logs, Schattenarchiv full texts, consent-sensitive material
-- private trigger canon, GODFATHER_LOCK details, internal block-system internals, or restricted VORTEX/Instance-Council mappings
-- patent-sensitive implementation mappings unless explicitly cleared
-- raw chat exports without classification
-- offensive security instructions or exploit playbooks
-- commercial terms, prices, token/DAO claims or roadmap commitments unless independently verified and marked with source status
-
-## Classification labels
-
-Use these labels before adding or promoting material:
-
-- `public-ok`: cleared for public repository use
-- `internal`: useful internally, not public by default
-- `redact-candidate`: requires redaction before publication
-- `patent-sensitive`: may expose IP or filing-sensitive mapping
-- `private`: must remain out of the public repository
-- `token/wallet`: blockchain, token, wallet or credential-adjacent material; requires extra review
-- `raw-chat`: raw conversation/export; never promote without review
-- `trigger-depth`: trigger/canon depth beyond safe public summary
-
-## Promotion rule
-
-Raw material must pass through a review gate before becoming repository content:
-
-1. Identify source and owner.
-2. Assign classification label.
-3. Decide target layer: Track A, A.2, B, C, atlas, governance, tooling, or archive.
-4. Redact sensitive content where needed.
-5. Add provenance note or checksum if relevant.
-6. Commit curated material only, not unrestricted raw payloads.
-
-## Default stance
-
-When uncertain: keep local/private, mark `redact-candidate`, and create an issue or review note instead of committing the raw content.
+## Raw-Exports
+Raw exports must never touch the `main` branch unless pre-classified and heavily scrubbed. All raw exports land in local staging or isolated private storage first.

--- a/docs/governance/repo_roles.md
+++ b/docs/governance/repo_roles.md
@@ -1,74 +1,11 @@
 # Repository Roles
 
-Status: BIZ / Governance
-Source: Repository-side governance role vocabulary for TerraNova repository surfaces.
-Trace: Issue `#25`, `docs/governance/source_of_record_policy.md`, `docs/governance/public_boundary.md`
-Boundary: Repository role contract only; not a release claim or source-of-record override.
-Mode: BIZ
-GitHub sync state: tracked in this repository as an operational classification guide.
-Notion source awareness: required if repository roles are later aligned with living governance canon.
+This repository defines strict roles for sub-systems and related artifacts to maintain operational hygiene.
 
-## Purpose
-
-This document defines the intended roles of repositories and repository areas in the TerraNova / FerrAI / CIC stack.
-
-A repository role is a boundary contract. It helps prevent mixing public publication, raw evidence, private app code, research drafts and archive material.
-
-## Role vocabulary
-
-### `core`
-
-Primary framework and engineering layer. Contains reviewed docs, scripts, reproducible workflows, public-safe architecture, CI and governance.
-
-### `research`
-
-Scholarly and dissertation-oriented material: drafts, citations, evidence ledgers, source registers, claim/evidence matrices, release notes and Zenodo anchors.
-
-### `raw-docs`
-
-Large or semi-raw source material, incoming batches, export containers, checksums and manifests. Requires review gates before promotion.
-
-### `archive`
-
-Historical snapshots, lockpoints, parked artefacts and frozen references. Archive does not imply public-safe or canonical.
-
-### `release`
-
-Clean publication packages, fixed snapshots, release notes and DOI/Zenodo-facing artefacts. Release material should be reviewed, source-stable and clearly versioned.
-
-### `fork`
-
-Experimental or external-development branch/repo. Forks may diverge and should not be treated as canonical without reconciliation.
-
-### `private-app`
-
-Private implementation, product code, credentials-adjacent logic, internal automation or app surfaces. This role should not be public by default.
-
-## Current public repository stance
-
-`TerraNova-s-Framework` currently acts as a combined `core` + `research` + controlled `raw-docs` repository.
-
-Because it is public, the stricter boundary wins:
-
-- raw material must be gated
-- private/patent/token material must be excluded or redacted
-- research claims must keep source status
-- generated artefacts must be labelled as generated or snapshot where relevant
-
-## Routing rule
-
-When adding material, decide the role before committing:
-
-1. `core`: reviewed framework/tooling/governance
-2. `research`: dissertation/evidence/citation layer
-3. `raw-docs`: incoming source material with gate
-4. `archive`: historical snapshot or lockpoint
-5. `release`: publication-ready package
-6. `fork`: experiment or divergence
-7. `private-app`: keep out of public repo
-
-## Conflict rule
-
-If a file fits multiple roles, use the most restrictive role until reviewed.
-
-Example: a raw export with public passages, patent-sensitive passages and private notes remains `raw-docs` / `redact-candidate`, not `public-ok`.
+- **`core`**: The main framework logic, control tower, and architecture documents.
+- **`fork`**: Derivatives or external sync points.
+- **`research`**: Experimental or speculative papers and analyses.
+- **`private-app`**: Local integrations (e.g., Python sync engine) that stay off-chain and local.
+- **`archive`**: Immutable historic states and Zenith artifacts.
+- **`release`**: Officially cut Zenodo mirrors and public artifacts.
+- **`raw-docs`**: Ingested exports pending processing (must pass `REVIEW_GATE`).

--- a/raw/exports/REVIEW_GATE.md
+++ b/raw/exports/REVIEW_GATE.md
@@ -1,59 +1,12 @@
-# Raw Exports Review Gate
+# Raw-Export Review Gate
 
-## Purpose
+## Hard Rule
+**No new raw data may be committed to this repository without explicit classification.**
 
-`raw/exports/` is an intake and evidence area. It may contain placeholders, manifests, checksums, incoming batches and reviewed raw-export infrastructure. It must not become an unrestricted dump zone.
+Before any raw export is pushed, it must be assigned one of the following classifications:
 
-No new raw export should be added without classification.
-
-## Required metadata for new raw exports
-
-Before adding a new raw payload, record:
-
-- source name
-- source date
-- importer/reviewer
-- expected size or line count
-- checksum if available
-- related issue or decision log
-- classification label
-- intended target layer
-- promotion decision: hold, redact, split, archive, or public-ok
-
-## Classification labels
-
-Use one or more:
-
-- `public-ok`
-- `internal`
-- `redact-candidate`
-- `patent-sensitive`
-- `private`
-- `token/wallet`
-- `raw-chat`
-- `trigger-depth`
-
-## Gate checklist
-
-- [ ] Source is identified.
-- [ ] File is intentionally placed under `raw/exports/`.
-- [ ] Classification label is assigned.
-- [ ] Sensitive content was checked.
-- [ ] Patent/IP relevance was checked.
-- [ ] Token/wallet/credential content was checked.
-- [ ] Raw-chat or personal-log status was checked.
-- [ ] Target layer is documented.
-- [ ] Checksum or manifest exists where useful.
-- [ ] Promotion decision is recorded.
-
-## Promotion decisions
-
-- `hold`: keep as local/private or placeholder only.
-- `redact`: redact before further use.
-- `split`: divide into public and restricted parts.
-- `archive`: keep as evidence/archive, not active repo content.
-- `public-ok`: cleared for curated public use.
-
-## Operating rule
-
-Incoming raw material may support later Track A/A.2/B/C work, but raw intake is not automatically canonical. Treat raw exports as evidence candidates until reviewed.
+- `public-ok`: Fully sanitized, safe for public repository viewing.
+- `internal`: For organization/local use only. DO NOT PUSH to public repo.
+- `redact-candidate`: Needs scrubbing of PII/Notion IDs before it can become `public-ok`.
+- `patent-sensitive`: Protected under TNPX-01 filing hold. DO NOT PUSH.
+- `private`: Personal, `GODFATHER_LOCK` or Track C sensitive logs. DO NOT PUSH.


### PR DESCRIPTION
## Summary

Addresses Issue #25: GitHub container hardening.

- Created `docs/governance/public_boundary.md` to define strict public vs. private limits (including `redact-candidate` and `GODFATHER_LOCK`).
- Created `docs/governance/repo_roles.md` to clarify directory and sub-system roles (`core`, `fork`, `research`, `private-app`, `archive`, `release`, `raw-docs`).
- Created `raw/exports/REVIEW_GATE.md` as the hard checkpoint requiring classification before raw data can be pushed.
- Added causal log for the governance update.

Resolves #25.