### PR TITLE
docs(monographie): promote Ferrolingua and Token-Block to Track A

### DIFF
--- a/docs/atlas/control-tower/batch-cluster-2-track-a.md
+++ b/docs/atlas/control-tower/batch-cluster-2-track-a.md
@@ -1,0 +1,11 @@
+# Monographie Ausbau - Cluster 2 (Track A)
+
+Status: planned on 2026-05-18
+
+## Purpose
+Promote Ferrolingua (A.13/A.14) and Token-Block (S26) to Track A (Public Canon).
+
+## Decisions
+1. Ferrolingua (A.13/A.14) is officially promoted to Track A to define the human-machine symbol grammar.
+2. Token-Block (S26) is promoted to Track A to solidify the monetization, CAP-II license, and DAO governance architecture.
+3. This establishes the IP foundation required for the 10'000 CHF/month Meta-Angebot and Genesis Pass sales.

--- a/docs/atlas/control-tower/causal-log.cluster-2-track-a-2026-05-18.json
+++ b/docs/atlas/control-tower/causal-log.cluster-2-track-a-2026-05-18.json
@@ -1,0 +1,7 @@
+{
+  "log_id": "monographie-cluster-2-track-a",
+  "timestamp": "2026-05-18T19:20:00Z",
+  "event_type": "canon_promotion",
+  "target": "Track A",
+  "elements": ["Ferrolingua A.13/A.14", "Token-Block S26"]
+}


### PR DESCRIPTION
## Summary

- Promotes Ferrolingua (A.13/A.14) and Token-Block (S26) to Track A (Public Canon).
- Protects the intellectual property foundation (CAP-II, Tokenization, Human-Machine Grammar) required for the CHF 10'000 / month Meta-Angebot and Genesis Pass.
- Logs the canon promotion in `batch-cluster-2-track-a.md` and `causal-log.cluster-2-track-a-2026-05-18.json`.