### PR TITLE
docs(control-tower): add post-merge snapshot

### DIFF
--- a/docs/atlas/control-tower/README.md
+++ b/docs/atlas/control-tower/README.md
@@ -120,6 +120,10 @@ This folder defines the first implementation layer for **CAP 0.1.0 - Cognitive A
 | `trigger-def-001.draft-open-items.csv` | Human-review items before finalization or canon work. |
 | `trigger-def-001.draft-gates.csv` | Gates before final public rulebook, public canon or TRG assignment. |
 | `trigger-def-001.draft-summary.json` | Machine-readable TRIGGER-DEF-001 draft summary and boundary flags. |
+| `batch-post-merge-snapshot-001.md` | Post-merge closure record for PR #57 and the merged trigger/equilibrium release lane. |
+| `post-merge-snapshot-001.review-summary.json` | Machine-readable POST-MERGE-SNAPSHOT-001 summary. |
+| `local-worktree-cleanup-001.md` | Local worktree operating rule after PR #57 merge; documents active worktree roles without deletion. |
+| `local-worktree-cleanup-001.review-summary.json` | Machine-readable LOCAL-WORKTREE-CLEANUP-001 summary. |
 | `causal-log.schema.json` | Machine-readable causal coherence log schema. |
 | `causal-log.cap-creation-2026-05-17.json` | First causal log event for the CAP Notion page creation. |
 | `causal-log.registry-creation-2026-05-17.json` | Causal log event for the live registry creation. |
@@ -153,6 +157,8 @@ This folder defines the first implementation layer for **CAP 0.1.0 - Cognitive A
 | `causal-log.trigger-001-plan-2026-05-17.json` | Causal log event for TRIGGER-001 command-surface hardening. |
 | `causal-log.trigger-def-001-scaffold-2026-05-23.json` | Causal log event for TRIGGER-DEF-001 scaffold creation. |
 | `causal-log.trigger-def-001-draft-2026-05-23.json` | Causal log event for TRIGGER-DEF-001 draft creation. |
+| `causal-log.post-merge-snapshot-001-2026-05-24.json` | Causal log event for PR #57 post-merge closure. |
+| `causal-log.local-worktree-cleanup-001-2026-05-24.json` | Causal log event for the local worktree inventory and cleanup rule. |
 | `causal-log.cap-0.3-iperka-2026-05-17.json` | Causal log event for the CAP 0.3 operational-control IPERKA creation. |
 | `causal-log.cap-0.4-iperka-2026-05-17.json` | Causal log event for the CAP 0.4 canon admission IPERKA creation. |
 | `causal-log.ninf-001-readpass-2026-05-17.json` | Causal log event for the NINF-001 Notion read-only infiltration pass. |

--- a/docs/atlas/control-tower/batch-post-merge-snapshot-001.md
+++ b/docs/atlas/control-tower/batch-post-merge-snapshot-001.md
@@ -1,0 +1,62 @@
+# POST-MERGE-SNAPSHOT-001
+
+Status: local control-tower snapshot
+Date: 2026-05-24
+Scope: PR #57 merge closure and next-lane readiness
+
+## Purpose
+
+This snapshot records the state after PR #57 was merged into `main`.
+It is a GitHub-side closure record only. It does not imply a Notion write,
+Notion verification, branch deletion, or release publication.
+
+## Source State
+
+| Item | Value |
+| --- | --- |
+| Repository | `Terra-Nova-Restore/TerraNova-s-Framework` |
+| PR | `#57` |
+| PR URL | `https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/pull/57` |
+| PR title | `docs: add trigger map and equilibrium policy updates` |
+| PR source branch | `release/trigger-map-001` |
+| Base branch | `main` |
+| PR head before merge | `145533ee7c613ee3248a23db769a56cba8ea8804` |
+| Merge commit | `5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e` |
+| Merged at | `2026-05-24T12:07:02Z` |
+| Local main sync | fast-forwarded to merge commit in the main worktree |
+
+## Merged Scope
+
+| Lane | Result |
+| --- | --- |
+| TRIGGER-DEF-001 scaffold | Merged |
+| TRIGGER-DEF-001 draft | Merged |
+| TRIGGER-MAP 174-210 | Merged |
+| EQUILIBRIUM weight policy mirror | Merged and synced to `WEIGHT-PASS-001` |
+| Dissertation main(16) clarification | Merged |
+
+## Boundary Notes
+
+- No rule text was migrated from Notion into GitHub.
+- No Notion write was performed by the merge.
+- `R9` remains a high-risk global gate without broad linked-rule dependencies.
+- `R13` remains a narrow GitHub sync boundary / allowlist candidate.
+- `R5=220`, `R15.1=300`, and `R13=240` are the merged policy mirror values.
+
+## Post-Merge Checks
+
+| Check | Status |
+| --- | --- |
+| PR merged | `true` |
+| Merge commit visible on `origin/main` | `true` |
+| GitHub checks before merge | `success` |
+| Netlify preview before merge | `success` |
+| Local main fast-forward | `success` |
+| Local content drift after merge | none observed |
+
+## Next Lane
+
+The next safe local lane is `LOCAL-WORKTREE-CLEANUP-001`, followed by a
+small, reviewable PR for this post-merge control-tower closure if Silvan
+explicitly asks to publish it.
+

--- a/docs/atlas/control-tower/batch-post-merge-snapshot-001.md
+++ b/docs/atlas/control-tower/batch-post-merge-snapshot-001.md
@@ -59,4 +59,3 @@ Notion verification, branch deletion, or release publication.
 The next safe local lane is `LOCAL-WORKTREE-CLEANUP-001`, followed by a
 small, reviewable PR for this post-merge control-tower closure if Silvan
 explicitly asks to publish it.
-

--- a/docs/atlas/control-tower/causal-log.local-worktree-cleanup-001-2026-05-24.json
+++ b/docs/atlas/control-tower/causal-log.local-worktree-cleanup-001-2026-05-24.json
@@ -1,0 +1,23 @@
+{
+  "id": "causal-log.local-worktree-cleanup-001-2026-05-24",
+  "date": "2026-05-24",
+  "lane": "LOCAL-WORKTREE-CLEANUP-001",
+  "event_type": "local_worktree_inventory",
+  "input_state": {
+    "main_merge_commit": "5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e",
+    "worktree_count_observed": 8
+  },
+  "output_state": {
+    "active_branch": "codex/post-merge-snapshot-001",
+    "cleanup_policy_documented": true,
+    "worktrees_deleted": 0,
+    "branches_deleted": 0
+  },
+  "boundaries": {
+    "destructive_local_operation": false,
+    "github_write": false,
+    "notion_write": false
+  },
+  "next_action": "publish via normal PR only after explicit GO"
+}
+

--- a/docs/atlas/control-tower/causal-log.local-worktree-cleanup-001-2026-05-24.json
+++ b/docs/atlas/control-tower/causal-log.local-worktree-cleanup-001-2026-05-24.json
@@ -20,4 +20,3 @@
   },
   "next_action": "publish via normal PR only after explicit GO"
 }
-

--- a/docs/atlas/control-tower/causal-log.post-merge-snapshot-001-2026-05-24.json
+++ b/docs/atlas/control-tower/causal-log.post-merge-snapshot-001-2026-05-24.json
@@ -21,4 +21,3 @@
   },
   "next_action": "LOCAL-WORKTREE-CLEANUP-001"
 }
-

--- a/docs/atlas/control-tower/causal-log.post-merge-snapshot-001-2026-05-24.json
+++ b/docs/atlas/control-tower/causal-log.post-merge-snapshot-001-2026-05-24.json
@@ -1,0 +1,24 @@
+{
+  "id": "causal-log.post-merge-snapshot-001-2026-05-24",
+  "date": "2026-05-24",
+  "lane": "POST-MERGE-SNAPSHOT-001",
+  "event_type": "github_merge_closure",
+  "input_state": {
+    "pr": 57,
+    "head_branch": "release/trigger-map-001",
+    "head_sha": "145533ee7c613ee3248a23db769a56cba8ea8804",
+    "base_branch": "main"
+  },
+  "output_state": {
+    "merged": true,
+    "merge_commit": "5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e",
+    "local_snapshot_created": true
+  },
+  "boundaries": {
+    "notion_write": false,
+    "push": false,
+    "branch_delete": false
+  },
+  "next_action": "LOCAL-WORKTREE-CLEANUP-001"
+}
+

--- a/docs/atlas/control-tower/local-worktree-cleanup-001.md
+++ b/docs/atlas/control-tower/local-worktree-cleanup-001.md
@@ -54,4 +54,3 @@ for that specific worktree or branch.
 
 If this local documentation lane should be published later, use a normal PR
 flow from `codex/post-merge-snapshot-001`. Do not push directly to `main`.
-

--- a/docs/atlas/control-tower/local-worktree-cleanup-001.md
+++ b/docs/atlas/control-tower/local-worktree-cleanup-001.md
@@ -1,0 +1,57 @@
+# LOCAL-WORKTREE-CLEANUP-001
+
+Status: local worktree operating rule
+Date: 2026-05-24
+Scope: local Git worktree roles after PR #57 merge
+
+## Purpose
+
+This document prevents confusion between several local working folders.
+It does not delete branches, delete worktrees, force-reset anything, or push
+anything to GitHub.
+
+## Current Worktree Roles
+
+| Path label | Current role | Branch / state | Action |
+| --- | --- | --- | --- |
+| `TerraNova-s-Framework-z3` | main-derived execution lane | `codex/post-merge-snapshot-001` | Use for the current post-merge documentation lane. |
+| `TerraNova-s-Framework` | completed release lane | `release/trigger-map-001` at merge commit | Keep as archive until explicit delete/cleanup GO. |
+| `TerraNova-s-Framework-cycle03` | existing feature lane | `codex/cei-data-04-v0-3-cycle03` | Leave untouched. |
+| `TerraNova-s-Framework-sessionstart-mainline` | existing control-tower runtime lane | `codex/cap-rt-001-control-tower-runtime` | Leave untouched. |
+| `TerraNova-s-Framework-z2-worktree` | existing Zenodo lane | `codex/zenodo-z2-legacy-deposit-retry` | Leave untouched. |
+| `TerraNova-s-Framework-zenodo-v3-main22` | existing Zenodo v3 lane | `codex/zenodo-v3-main22` | Leave untouched. |
+| Codex detached worktrees | tool/cache lanes | detached HEAD | Leave untouched unless a separate cleanup pass is requested. |
+
+## Operating Rule
+
+New repo work should start from the clean main-derived worktree and use a
+short-lived `codex/...` branch unless Silvan explicitly requests a release
+branch or a direct main operation.
+
+For this lane, the active local branch is:
+
+`codex/post-merge-snapshot-001`
+
+## Safe Cleanup Decision
+
+No local worktree was deleted in this pass.
+
+Reason: multiple worktrees represent active or historical lanes, and deleting
+them would be a destructive local operation. The correct next step is to keep
+them visible and only remove one after Silvan gives an explicit cleanup command
+for that specific worktree or branch.
+
+## Verified Facts
+
+| Fact | Result |
+| --- | --- |
+| `main` was fast-forwarded to PR #57 merge commit before this lane started | `true` |
+| `origin/main` merge commit | `5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e` |
+| Stale worktree metadata dry-run | no stale entries reported |
+| External systems mutated | `none` |
+
+## Next Safe Command
+
+If this local documentation lane should be published later, use a normal PR
+flow from `codex/post-merge-snapshot-001`. Do not push directly to `main`.
+

--- a/docs/atlas/control-tower/local-worktree-cleanup-001.review-summary.json
+++ b/docs/atlas/control-tower/local-worktree-cleanup-001.review-summary.json
@@ -1,0 +1,22 @@
+{
+  "id": "LOCAL-WORKTREE-CLEANUP-001",
+  "status": "local_operating_rule",
+  "date": "2026-05-24",
+  "active_branch": "codex/post-merge-snapshot-001",
+  "main_merge_commit": "5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e",
+  "worktree_policy": {
+    "main_derived_execution_lane": "TerraNova-s-Framework-z3",
+    "completed_release_lane": "TerraNova-s-Framework",
+    "delete_worktrees_without_explicit_go": false,
+    "push_directly_to_main": false,
+    "use_short_lived_codex_branch_for_new_work": true
+  },
+  "dry_run": {
+    "git_worktree_prune_reported_stale_entries": false
+  },
+  "external_mutations": {
+    "github": false,
+    "notion": false
+  }
+}
+

--- a/docs/atlas/control-tower/local-worktree-cleanup-001.review-summary.json
+++ b/docs/atlas/control-tower/local-worktree-cleanup-001.review-summary.json
@@ -19,4 +19,3 @@
     "notion": false
   }
 }
-

--- a/docs/atlas/control-tower/post-merge-snapshot-001.review-summary.json
+++ b/docs/atlas/control-tower/post-merge-snapshot-001.review-summary.json
@@ -33,4 +33,3 @@
   },
   "next_lane": "LOCAL-WORKTREE-CLEANUP-001"
 }
-

--- a/docs/atlas/control-tower/post-merge-snapshot-001.review-summary.json
+++ b/docs/atlas/control-tower/post-merge-snapshot-001.review-summary.json
@@ -1,0 +1,36 @@
+{
+  "id": "POST-MERGE-SNAPSHOT-001",
+  "status": "local_snapshot",
+  "date": "2026-05-24",
+  "repository": "Terra-Nova-Restore/TerraNova-s-Framework",
+  "pull_request": {
+    "number": 57,
+    "url": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/pull/57",
+    "title": "docs: add trigger map and equilibrium policy updates",
+    "merged": true,
+    "merged_at": "2026-05-24T12:07:02Z",
+    "head_branch": "release/trigger-map-001",
+    "head_sha": "145533ee7c613ee3248a23db769a56cba8ea8804",
+    "merge_commit": "5b6c30118ec8edb3a0e26bb6cab7d4283a78db6e"
+  },
+  "merged_lanes": [
+    "TRIGGER-DEF-001 scaffold",
+    "TRIGGER-DEF-001 draft",
+    "TRIGGER-MAP 174-210",
+    "EQUILIBRIUM weight policy mirror",
+    "dissertation main(16) clarification"
+  ],
+  "boundaries": {
+    "notion_write": false,
+    "rule_text_migration": false,
+    "direct_main_push": false,
+    "branch_deletion": false
+  },
+  "current_policy_values": {
+    "R5": 220,
+    "R15.1": 300,
+    "R13": 240
+  },
+  "next_lane": "LOCAL-WORKTREE-CLEANUP-001"
+}
+


### PR DESCRIPTION
## Summary

- Adds `POST-MERGE-SNAPSHOT-001` as the closure record for PR #57 after merge into `main`.
- Adds `LOCAL-WORKTREE-CLEANUP-001` to document local worktree roles after the merge without deleting anything.
- Adds machine-readable review summaries and causal logs for both closure steps.
- Indexes the new records in the Control Tower README.

## Boundaries

- No Notion write.
- No branch deletion or worktree deletion.
- No direct push to `main`.
- This PR only records post-merge state and local operating rules.

## Checks

- Local `validate_docs` passed.
- Local `git diff --check origin/main..HEAD` passed.
- JSON summaries and causal logs parsed successfully.

## Review Notes

- `TerraNova-s-Framework-z3` is the current main-derived execution lane.
- `TerraNova-s-Framework` remains the completed `release/trigger-map-001` lane and is intentionally kept until explicit cleanup GO.
