### PR TITLE
[codex] fix trigger definition scaffold generator

### DIFF
--- a/.github/workflows/prism-atlas-validate.yml
+++ b/.github/workflows/prism-atlas-validate.yml
@@ -3,6 +3,8 @@ name: Validate Prism Atlas
 on:
   pull_request:
     paths:
+      - 'scripts/build_trigger_def_001_scaffold.py'
+      - 'scripts/build_trigger_def_001_draft.py'
       - 'scripts/render_prism_atlas.py'
       - 'scripts/quick_script_sanity.py'
       - 'docs/atlas/**'
@@ -16,6 +18,8 @@ on:
       - '.github/workflows/prism-atlas-validate.yml'
   push:
     paths:
+      - 'scripts/build_trigger_def_001_scaffold.py'
+      - 'scripts/build_trigger_def_001_draft.py'
       - 'scripts/render_prism_atlas.py'
       - 'scripts/quick_script_sanity.py'
       - 'docs/atlas/**'
@@ -51,6 +55,14 @@ jobs:
 
       - name: Run atlas unit tests
         run: python -m unittest tests.test_render_prism_atlas
+
+      - name: Validate trigger definition generators
+        run: python -m py_compile scripts/build_trigger_def_001_scaffold.py scripts/build_trigger_def_001_draft.py
+
+      - name: Regenerate trigger definition docs
+        run: |
+          python scripts/build_trigger_def_001_scaffold.py
+          python scripts/build_trigger_def_001_draft.py
 
       - name: Regenerate atlas docs
         run: python scripts/render_prism_atlas.py

--- a/.github/workflows/prism-atlas-validate.yml
+++ b/.github/workflows/prism-atlas-validate.yml
@@ -68,7 +68,7 @@ jobs:
         run: python scripts/render_prism_atlas.py
 
       - name: Verify generated docs are committed
-        run: git diff --exit-code -- docs/atlas docs/triggers/gap_ledger.md
+        run: git diff --ignore-cr-at-eol --exit-code -- docs/atlas docs/triggers/gap_ledger.md
 
       - name: Validate fill script syntax
         run: bash -n raw/exports/fill_850k_raw.sh

--- a/scripts/build_trigger_def_001_scaffold.py
+++ b/scripts/build_trigger_def_001_scaffold.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import csv
 import json
 from collections import Counter
+from copy import deepcopy
 from pathlib import Path
 
 
@@ -20,6 +21,16 @@ OUT = ROOT / "docs" / "atlas" / "control-tower"
 BATCH = "TRIGGER-DEF-001-SCAFFOLD"
 TODAY = "2026-05-23"
 CREATED_AT = "2026-05-23T19:07:42+02:00"
+
+DEFAULT_TRACK_A = {
+    "status": "public_safe_protection_gate",
+    "protected_trigger_refs": ["205", "206", "207", "208", "209", "210"],
+}
+
+DEFAULT_TRACK_B = {
+    "status": "private_promotion_queue_built",
+    "candidate_trigger_refs": ["176", "182", "202"],
+}
 
 
 def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, object]]) -> None:
@@ -37,8 +48,13 @@ def write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8", newline="\n")
 
 
-def read_json(path: str) -> dict[str, object]:
-    return json.loads((OUT / path).read_text(encoding="utf-8"))
+def read_json(path: str, fallback: dict[str, object] | None = None) -> dict[str, object]:
+    source = OUT / path
+    if source.exists():
+        return json.loads(source.read_text(encoding="utf-8"))
+    if fallback is None:
+        raise FileNotFoundError(source)
+    return deepcopy(fallback)
 
 
 def build_term_rows() -> list[dict[str, object]]:
@@ -543,8 +559,11 @@ def build_causal_log() -> dict[str, object]:
 
 
 def main() -> None:
-    track_a = read_json("tnpx-capii-tokenomics-gate-001.review-summary.json")
-    track_b = read_json("source-174-210.promotion-summary.json")
+    # These upstream review summaries are referenced in the committed scaffold
+    # outputs, but they are not part of the public repo snapshot. Fall back to
+    # the committed summary values so the generator remains reproducible.
+    track_a = read_json("tnpx-capii-tokenomics-gate-001.review-summary.json", DEFAULT_TRACK_A)
+    track_b = read_json("source-174-210.promotion-summary.json", DEFAULT_TRACK_B)
     term_rows = build_term_rows()
     admission_rows = build_admission_rows()
     publication_rows = build_publication_rows()


### PR DESCRIPTION
## Summary

- Makes `scripts/build_trigger_def_001_scaffold.py` reproducible from the public repo snapshot.
- Adds committed fallback summary values for the Track A and Track B review summaries used by the scaffold output.
- Extends `Validate Prism Atlas` so trigger-definition generator changes run the scaffold/draft regeneration checks in CI.
- Keeps the generated-docs verification stable across CRLF/LF line-ending differences while still catching content drift.

## Root Cause

The scaffold generator expected `tnpx-capii-tokenomics-gate-001.review-summary.json` and `source-174-210.promotion-summary.json` to exist in `docs/atlas/control-tower/`, but those source summaries are not present in the public repo snapshot. Running the generator from a clean checkout therefore failed before emitting the committed scaffold artifacts.

The existing Prism Atlas workflow also did not watch the trigger-definition generator scripts, so this class of generator regression was not covered remotely.

## Validation

- `python -m py_compile scripts\render_prism_atlas.py scripts\build_trigger_def_001_scaffold.py scripts\build_trigger_def_001_draft.py`
- `python scripts\quick_script_sanity.py scripts\render_prism_atlas.py`
- `python -m unittest tests.test_render_prism_atlas tests.test_validate_docs`
- `python scripts\build_trigger_def_001_scaffold.py`
- `python scripts\build_trigger_def_001_draft.py`
- `python scripts\render_prism_atlas.py`
- `git diff --ignore-cr-at-eol --exit-code -- docs\atlas docs\triggers\gap_ledger.md`
- `git show HEAD:raw/exports/fill_850k_raw.sh | bash -n -`
- `python scripts\validate_docs.py`
- `git diff --check`
- GitHub Actions `Validate Prism Atlas` run `26369294388`: success
- Netlify deploy preview: success

## Scope

Follow-up fix for the PR #57 generator reproducibility issue plus CI coverage for the trigger-definition generators.