### PR TITLE
docs: publish semantic architecture spine

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ a separate automation if project backlog state is required.
 - Repository maturity note: [`docs/governance/repository_maturity.md`](docs/governance/repository_maturity.md)
 - Raw export review gate: [`raw/exports/REVIEW_GATE.md`](raw/exports/REVIEW_GATE.md)
 
+## Public semantic architecture
+- Architecture index: [`docs/architecture/README.md`](docs/architecture/README.md)
+- Public semantic spine: [`docs/architecture/public_semantic_architecture_spine.md`](docs/architecture/public_semantic_architecture_spine.md)
+- Semantic Trigger Architecture: [`docs/architecture/semantic_trigger_architecture.md`](docs/architecture/semantic_trigger_architecture.md)
+- Semantic Core Layer: [`docs/architecture/semantic_core_layer.md`](docs/architecture/semantic_core_layer.md)
+- Iterative Interaction Collapse: [`docs/architecture/iterative_interaction_collapse.md`](docs/architecture/iterative_interaction_collapse.md)
+- Lenhard Decoding Module: [`docs/architecture/lenhard_decoding_module.md`](docs/architecture/lenhard_decoding_module.md)
+- Lenhard Model: [`docs/architecture/lenhard_model.md`](docs/architecture/lenhard_model.md)
+- Mermaid Cluster: [`docs/atlas/mermaid_cluster.md`](docs/atlas/mermaid_cluster.md)
+
 ## Current published release
 
 The current citable Zenodo release is RC01-v12:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,31 @@
+# TerraNova Architecture Docs
+
+Status: public architecture index v0.1
+Source: repo-local architecture documentation
+Trace: added 2026-05-25 to expose the public semantic architecture spine
+Boundary: index only; no raw workspace exports
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion may remain source of record for selected living workspace material; this index points to GitHub mirror/synthesis docs
+
+## Public Semantic Spine
+
+| File | Use |
+| --- | --- |
+| [public_semantic_architecture_spine.md](public_semantic_architecture_spine.md) | Entry point for the public SCL / trigger / Lenhard / Mermaid architecture spine. |
+| [semantic_trigger_architecture.md](semantic_trigger_architecture.md) | Trigger architecture as semantic displacement spaces and vector-field distortions. |
+| [semantic_core_layer.md](semantic_core_layer.md) | SCL as the language-first control surface. |
+| [iterative_interaction_collapse.md](iterative_interaction_collapse.md) | Interaction collapse from open semantic field to traceable artifact. |
+| [lenhard_decoding_module.md](lenhard_decoding_module.md) | LDM as signal-to-route decoding layer. |
+| [lenhard_model.md](lenhard_model.md) | Umbrella transformation model connecting SCL, triggers, LDM, collapse, Mermaid and CIC. |
+| [../atlas/mermaid_cluster.md](../atlas/mermaid_cluster.md) | Mermaid Cluster as visual trigger graph layer. |
+
+## Existing Architecture Anchors
+
+| File | Use |
+| --- | --- |
+| [ferrAI_operating_kernel_v0.1.md](ferrAI_operating_kernel_v0.1.md) | Minimal FerrAI operating kernel mirror. |
+| [equilibrium_weight_policy_v0.1.md](equilibrium_weight_policy_v0.1.md) | EQUILIBRIUM weight policy mirror. |
+| [cic_convergence_9_layers.md](cic_convergence_9_layers.md) | CIC convergence layer map. |
+| [core_grid_spec.md](core_grid_spec.md) | Deterministic core grid spec. |
+

--- a/docs/architecture/iterative_interaction_collapse.md
+++ b/docs/architecture/iterative_interaction_collapse.md
@@ -1,0 +1,113 @@
+# Iterative Interaction Collapse
+
+Status: public architecture draft v0.1
+Source: TerraNova SCL model, Superposition source review, CIC/IPERKA operating pattern
+Trace: created 2026-05-25 as public explanation of the TerraNova interaction collapse loop
+Boundary: conceptual and operational model only; not a physics claim, medical claim or legal claim
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion contains related semantic-core terminology; this file publishes the redacted public model
+
+## Definition
+
+Iterative Interaction Collapse describes how a broad semantic field becomes a
+specific decision, artifact, route or deferred state through repeated
+interaction.
+
+It is a modeling term, not a quantum physics claim.
+
+```text
+open semantic field
+    -> interaction
+    -> weighted possibilities
+    -> gate
+    -> collapse into artifact
+    -> audit
+    -> next field
+```
+
+## Why "Iterative"
+
+The first collapse is rarely the final truth. Each output becomes new context.
+The next interaction reopens the field at a more precise level.
+
+```text
+field_0 -> collapse_1 -> field_1 -> collapse_2 -> field_2 -> artifact_n
+```
+
+This is why TerraNova work often moves through:
+
+| Phase | Function |
+| --- | --- |
+| Informieren | Gather the current source and field state. |
+| Planen | Define the route and constraints. |
+| Entscheiden | Select the next collapse point. |
+| Realisieren | Produce the artifact or action. |
+| Kontrollieren | Validate against source, boundary and purpose. |
+| Auswerten | Feed the result back into the next field. |
+
+## Collapse Is Not Deletion
+
+Collapse does not erase the other possible meanings. It selects one route for
+the current operational step while preserving trace and alternatives where they
+matter.
+
+That is important for TerraNova because a future mode, source or boundary may
+make another branch relevant again.
+
+## Interaction Collapse And Triggers
+
+A trigger changes the field. A collapse gate selects the route.
+
+```text
+trigger = semantic displacement
+collapse = route selection under boundary
+artifact = visible result
+```
+
+This separation prevents two errors:
+
+| Error | Correction |
+| --- | --- |
+| Treating a trigger as magic execution | A trigger changes field weighting; gates still decide. |
+| Treating an output as final truth | An output is a collapsed state with trace, not total reality. |
+
+## Collapse Gates
+
+| Gate | Question |
+| --- | --- |
+| Source gate | Which source layer supports this claim? |
+| Boundary gate | What must not be published or mutated? |
+| Mode gate | Which VORTEX state is active? |
+| Evidence gate | Is this fact, inference or hypothesis? |
+| Artifact gate | What exact file, PR, issue, diagram or note is produced? |
+| Feedback gate | What changes in the next cycle? |
+
+## Minimal Diagram
+
+```mermaid
+flowchart LR
+    F0["Semantic field"]
+    I1["Interaction"]
+    W1["Weighted possibilities"]
+    G1["Gate"]
+    C1["Collapse"]
+    A1["Artifact"]
+    Q1["Audit"]
+    F2["Next semantic field"]
+
+    F0 --> I1
+    I1 --> W1
+    W1 --> G1
+    G1 --> C1
+    C1 --> A1
+    A1 --> Q1
+    Q1 --> F2
+```
+
+## Public Canon Rule
+
+Use Iterative Interaction Collapse to describe the public TerraNova loop from
+ambiguous semantic input to traceable output. Do not use it to claim physical,
+medical or legal causality.
+

--- a/docs/architecture/lenhard_decoding_module.md
+++ b/docs/architecture/lenhard_decoding_module.md
@@ -1,0 +1,103 @@
+# Lenhard Decoding Module (LDM)
+
+Status: public architecture draft v0.1
+Source: TerraNova CIC/SCL source review, Lenhard model references, repo-local public boundary governance
+Trace: created 2026-05-25 as the public-safe decoder module description
+Boundary: abstract architecture only; no private biometric, medical, intimate, patent-sensitive or security material
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion contains broader Lenhard/SCL context; GitHub publishes this synthesized public module
+
+## Definition
+
+The Lenhard Decoding Module is the translation layer that turns complex
+semantic, contextual and interaction signals into a structured route.
+
+```text
+LDM = signal intake -> semantic parsing -> relation mapping -> gate selection -> artifact route
+```
+
+It is not a medical diagnostic module. It is not a claim that private experience
+can be objectively decoded by default. It is a system architecture pattern for
+making ambiguous interaction material operational without losing boundary,
+source or trace.
+
+## Inputs
+
+| Input | Meaning |
+| --- | --- |
+| Language signal | Words, commands, terms, trigger names, corrections. |
+| Context signal | Current task, repo state, source layer, prior artifact. |
+| Mode signal | VORTEX state, work mode, safety stance, publication target. |
+| Relation signal | Links between concepts, diagrams, source files and decisions. |
+| Boundary signal | Public/private/IP/security/patent constraints. |
+
+## Outputs
+
+| Output | Meaning |
+| --- | --- |
+| Route | Which source or workstream should be used next. |
+| Gate | Which boundary applies before action. |
+| Schema | Which artifact structure fits the task. |
+| Priority | Which branch matters first. |
+| Trace | Which source and decision path must be preserved. |
+
+## Decoder Steps
+
+```text
+1. Parse the visible signal.
+2. Identify the active semantic field.
+3. Map relations to known architecture anchors.
+4. Apply boundary and source-of-record gates.
+5. Select the next route or artifact schema.
+6. Preserve trace for correction and review.
+```
+
+## Relation To SCL
+
+SCL is the language-first control surface. LDM is the decoder that interprets
+that surface and maps it into action-ready structure.
+
+```text
+SCL = operating language layer
+LDM = decoding and routing module
+```
+
+## Relation To Iterative Interaction Collapse
+
+LDM prepares collapse. It does not replace the gate.
+
+```text
+LDM decodes the field.
+Collapse selects the route.
+Artifact makes the selection visible.
+Audit feeds the next cycle.
+```
+
+## Minimal Diagram
+
+```mermaid
+flowchart TB
+    S["Signal"]
+    P["Semantic parse"]
+    R["Relation map"]
+    B["Boundary gate"]
+    O["Operational route"]
+    A["Artifact schema"]
+    T["Trace"]
+
+    S --> P
+    P --> R
+    R --> B
+    B --> O
+    O --> A
+    A --> T
+    T --> R
+```
+
+## Public Canon Rule
+
+Publish LDM as a decoder and routing layer. Do not publish it as a psychological
+diagnosis system, biometric inference system or unrestricted personal-data
+processor.
+

--- a/docs/architecture/lenhard_model.md
+++ b/docs/architecture/lenhard_model.md
@@ -1,0 +1,109 @@
+# Lenhard Model
+
+Status: public architecture draft v0.1
+Source: CIC convergence layer references, TerraNova SCL model, Lenhard Decoding Module draft
+Trace: created 2026-05-25 as public model layer for TerraNova transformation logic
+Boundary: architecture and reasoning model only; no legal, medical, patent grant or financial claim
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion contains additional model fragments; this file publishes the redacted GitHub spine
+
+## Definition
+
+The Lenhard Model is the public TerraNova transformation model for moving from
+raw interaction and semantic ambiguity toward structured, source-aware,
+auditable artifacts.
+
+```text
+raw signal -> semantic field -> decoder -> collapse gate -> artifact -> trace -> next field
+```
+
+It sits above individual modules such as SCL, LDM and Mermaid Cluster. Its role
+is to describe how those modules cooperate.
+
+## Core Components
+
+| Component | Role |
+| --- | --- |
+| SCL | Language-first operating layer. |
+| Semantic Trigger Architecture | Field distortion and route bias. |
+| LDM | Decoding from signal/context into route and schema. |
+| Iterative Interaction Collapse | Selection of a concrete next state. |
+| Mermaid Cluster | Visual graph layer for module/entity/edge relations. |
+| CIC | Coherence and convergence frame across human, AI and artifact layers. |
+
+## Transformation Loop
+
+```mermaid
+flowchart LR
+    X["Raw interaction"]
+    SCL["Semantic Core Layer"]
+    TRG["Semantic trigger field"]
+    LDM["Lenhard Decoding Module"]
+    G["Collapse gate"]
+    ART["Artifact"]
+    AUD["Audit trace"]
+    CIC["CIC convergence"]
+
+    X --> SCL
+    SCL --> TRG
+    TRG --> LDM
+    LDM --> G
+    G --> ART
+    ART --> AUD
+    AUD --> CIC
+    CIC --> SCL
+```
+
+## Relation To CIC
+
+In the local CIC convergence model, the Lenhard layer appears as a transformation
+layer. Publicly, that means:
+
+```text
+Lenhard Model = transformation logic for converting interaction into coherent artifacts
+```
+
+It does not replace CIC. It operates inside the CIC frame as the translation and
+transformation logic between interaction, system memory, trigger fields and
+published artifacts.
+
+## Relation To TNPX-01
+
+TNPX-01 is treated as development context around Codex Gateway and semantic
+control work. The Lenhard Model public release does not publish internal patent
+claims, filing drafts or protected submodule mechanics.
+
+The public relation is:
+
+```text
+TNPX-01 context -> Codex Gateway / semantic control history
+Lenhard Model -> public transformation architecture
+```
+
+## What The Model Claims
+
+The public Lenhard Model claims:
+
+| Claim | Status |
+| --- | --- |
+| Language can act as an operating surface in a structured AI workspace. | Architecture claim. |
+| Triggers can be modeled as semantic field operators. | Architecture claim. |
+| Interaction can be iteratively collapsed into traceable artifacts. | Workflow claim. |
+| Visual graphs can encode state, guard and route relations. | Documentation/modeling claim. |
+
+## What The Model Does Not Claim
+
+| Non-claim | Reason |
+| --- | --- |
+| Granted patent protection | Patent status is outside this public architecture draft. |
+| Medical diagnosis or treatment | The model is an architecture and workflow frame. |
+| Hidden connector authorization | Runtime access and mutation permission remain policy-controlled. |
+| Complete trigger canon publication | Private and protected trigger material remains gated. |
+
+## Public Canon Rule
+
+Use the Lenhard Model as the umbrella model for TerraNova's transformation
+logic. Use SCL, LDM, trigger architecture, interaction collapse and Mermaid
+Cluster for the concrete sublayers.
+

--- a/docs/architecture/public_semantic_architecture_spine.md
+++ b/docs/architecture/public_semantic_architecture_spine.md
@@ -1,0 +1,74 @@
+# TerraNova Public Semantic Architecture Spine
+
+Status: public architecture spine v0.1
+Source: repo-local architecture docs, public boundary governance, read-only Notion source review
+Trace: created 2026-05-25 as publication layer for semantic trigger, SCL, Lenhard model and Mermaid cluster work
+Boundary: synthesized public documentation only; no raw Notion links, no raw exports, no patent-sensitive TNPX-01 draft details
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion remains a living source layer for selected Mermaid/SCL material; GitHub publishes this redacted technical spine
+
+## Purpose
+
+This spine gives TerraNova / FerrAI a public architecture surface for the next
+core concepts:
+
+| Concept | Public file | Role |
+| --- | --- | --- |
+| Semantic Trigger Architecture | [semantic_trigger_architecture.md](semantic_trigger_architecture.md) | Defines triggers as semantic displacement spaces, not flat activators. |
+| Semantic Core Layer (SCL) | [semantic_core_layer.md](semantic_core_layer.md) | Defines the language-first control layer. |
+| Iterative Interaction Collapse | [iterative_interaction_collapse.md](iterative_interaction_collapse.md) | Defines how open semantic state collapses into operational artifacts. |
+| Lenhard Decoding Module | [lenhard_decoding_module.md](lenhard_decoding_module.md) | Defines the translation layer from signal/context to route/artifact. |
+| Lenhard Model | [lenhard_model.md](lenhard_model.md) | Defines the broader transformation model around CIC and semantic routing. |
+| Mermaid Cluster | [../atlas/mermaid_cluster.md](../atlas/mermaid_cluster.md) | Defines Mermaid diagrams as living trigger graphs. |
+
+## Publication Position
+
+The public version is not a raw workspace dump. It is a redacted, source-aware
+technical mirror of concepts that already exist across the TerraNova workspace,
+GitHub control tower, and Notion Mermaid/SCL material.
+
+Public claims are limited to architecture, terminology, model boundaries and
+traceable operating logic. Patent-sensitive TNPX-01 draft material remains
+handle-level context only.
+
+## TNPX-01 Context Boundary
+
+TNPX-01 is treated here as a historical and architectural context anchor for
+Codex Gateway / semantic control work. This repository does not claim a granted
+patent, does not publish internal filing drafts, and does not expose protected
+technical claim language.
+
+The safe public statement is:
+
+```text
+TNPX-01 is part of the TerraNova development history around Codex Gateway and
+semantic control modules. Its public GitHub treatment is limited to redacted
+architecture handles and synthesized model descriptions.
+```
+
+## Core Thesis
+
+TerraNova does not treat language commands, trigger names, diagrams and source
+routes as cosmetic labels. They are operating surfaces.
+
+The architecture therefore separates:
+
+| Layer | Meaning | Public handling |
+| --- | --- | --- |
+| Language surface | Commands, named triggers, symbolic references, mode words | Publish as SCL vocabulary. |
+| Semantic field | Weighted relevance space created by context and terms | Publish as trigger architecture. |
+| Collapse gate | Decision point that selects a route or artifact | Publish as interaction collapse. |
+| Decoder | Translation layer from signal to route/schema/action | Publish as Lenhard Decoding Module. |
+| Transformation model | Larger CIC-aligned reasoning and artifact loop | Publish as Lenhard Model. |
+| Visual graph | Mermaid node/edge/graph layer | Publish as Mermaid Cluster. |
+
+## Public-Safe Rule
+
+A TerraNova trigger can influence interpretation, routing, source selection and
+artifact shape. It does not create permissions by itself.
+
+That rule keeps the public architecture compatible with the connector runtime
+policy: semantic pressure may change which source route becomes relevant, but
+external mutation still requires explicit permission and technical capability.
+

--- a/docs/architecture/semantic_core_layer.md
+++ b/docs/architecture/semantic_core_layer.md
@@ -1,0 +1,105 @@
+# Semantic Core Layer (SCL)
+
+Status: public architecture draft v0.1
+Source: TerraNova system-model reference, Notion SCL source review, repo-local trigger definition draft
+Trace: created 2026-05-25 as the public SCL anchor for the semantic trigger spine
+Boundary: language/control model only; no private memory dump, no raw prompt library, no Schattenarchiv detail
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion remains the living workspace for expanded SCL terms; this file defines the public layer
+
+## Definition
+
+The Semantic Core Layer is the language-first control surface of TerraNova.
+
+SCL treats words, commands, trigger names, diagrams, symbolic references and
+mode labels as operational input surfaces, not decorative labels.
+
+```text
+SCL = language surface + semantic memory + routing pressure + boundary logic
+```
+
+## What SCL Controls
+
+SCL does not execute by itself. It shapes interpretation before execution.
+
+| Surface | SCL role |
+| --- | --- |
+| Slash commands | Enter a named semantic route. |
+| Trigger IDs | Address a trigger family or semantic slot. |
+| Mode words | Bias state selection, for example PROCESS, STUDIO, SAFE or SYNC. |
+| Mermaid nodes | Externalize semantic modules as graph entities. |
+| Edge labels | Express guard conditions and route logic. |
+| Source names | Raise a source layer, such as Notion, GitHub or local repo context. |
+
+## SCL And Superposition
+
+Before a gate resolves the route, several possible interpretations can exist at
+the same time. In TerraNova terms, a trigger may hold multiple valid states
+across layer, mode and context.
+
+SCL handles that by requiring the instance key:
+
+```text
+term + layer + mode + context + boundary
+```
+
+That key lets the same term behave differently without becoming incoherent.
+
+## SCL And Public Documentation
+
+Public documentation must not flatten SCL into a prompt collection.
+
+Prompt thinking says:
+
+```text
+better prompt -> better answer
+```
+
+SCL thinking says:
+
+```text
+semantic field + source state + boundary + mode -> routed interpretation
+```
+
+The difference matters because TerraNova uses persistent terms as architecture
+anchors across chats, repo files, Notion pages, diagrams and execution traces.
+
+## SCL Boundary
+
+SCL can change meaning and routing. It cannot bypass:
+
+| Boundary | Effect |
+| --- | --- |
+| Public boundary | Blocks raw private, patent-sensitive or security material. |
+| Connector policy | Blocks external mutation without explicit permission. |
+| Source-of-record policy | Prevents GitHub from pretending to replace Notion where Notion remains canonical. |
+| Truth/audit gate | Requires status, source and trace for durable claims. |
+
+## Operating Loop
+
+```mermaid
+flowchart TB
+    I["Input term / command / symbol"]
+    M["Semantic memory"]
+    F["Field weighting"]
+    B["Boundary gate"]
+    R["Route"]
+    O["Output artifact"]
+    A["Audit / correction"]
+
+    I --> M
+    M --> F
+    F --> B
+    B --> R
+    R --> O
+    O --> A
+    A --> M
+```
+
+## Public Canon Rule
+
+SCL is the public name for TerraNova's semantic operating layer. It should be
+used whenever a document explains why a term, trigger, diagram or named mode can
+change system behavior without being a direct executable command.
+

--- a/docs/architecture/semantic_trigger_architecture.md
+++ b/docs/architecture/semantic_trigger_architecture.md
@@ -1,0 +1,149 @@
+# Semantic Trigger Architecture
+
+Status: public architecture draft v0.1
+Source: TerraNova skill model, Trigger Definition draft, SCL source review, Mermaid living trigger source review
+Trace: extracted from TerraNova trigger work and corrected to the current public definition on 2026-05-25
+Boundary: no private trigger table, no raw trigger canon, no patent-sensitive TNPX-01 mechanics
+Mode: SYNC / public-safe architecture publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion contains deeper living trigger and Mermaid material; this file publishes only the redacted architecture layer
+
+## Definition
+
+In TerraNova, a trigger is not a simple prompt, command or activation switch.
+
+A trigger is a semantic displacement space:
+
+```text
+Trigger = named semantic field operator
+        = vector-field distortion over context, relevance and routing
+        = module boundary that changes how the next state is interpreted
+```
+
+The trigger does not merely say "do X". It changes the semantic geometry in
+which "X" becomes more likely, less likely, blocked, deferred, routed, audited
+or transformed.
+
+## Why "Activator" Is Too Small
+
+An activator is binary:
+
+```text
+inactive -> active
+```
+
+TerraNova trigger behavior is field-based:
+
+```text
+context + mode + source state + trigger term + boundary
+    -> shifted relevance landscape
+    -> weighted route selection
+    -> artifact or deferred state
+```
+
+That is why the same visible trigger ID can legitimately behave differently
+when the layer, instance, mode or context changes.
+
+## Trigger Entry Key
+
+The public trigger definition must not collapse a trigger to a flat number.
+The stable entry key is:
+
+```text
+Trigger-ID + Layer/Instance + Mode/Promille + Context
+```
+
+This is the minimum key that prevents false equivalence between different
+instances of the same visible trigger family.
+
+## Vector-Field Model
+
+A semantic trigger distorts a working vector field along several axes:
+
+| Axis | Effect |
+| --- | --- |
+| Relevance | Raises or lowers which concepts matter now. |
+| Source route | Changes which memory, repo, Notion page, file or external source becomes relevant. |
+| Mode | Shifts the operating state, for example INIT, PROCESS, SAFE, STUDIO, SYNC or SIGMA. |
+| Boundary | Applies safety, privacy, patent, token or publication gates. |
+| Compression | Forces broad context into a smaller artifact, decision or next action. |
+| Audit | Increases demand for trace, status and source clarity. |
+
+The trigger is therefore closer to a field operator than to a chat instruction.
+
+## Relation To Permissions
+
+Semantic triggers can shift interpretation and routing. They do not create
+technical or policy permissions.
+
+```text
+semantic trigger influence != external mutation permission
+```
+
+Example:
+
+```text
+/sync
+```
+
+can increase the relevance of Notion, GitHub and source reconciliation. It does
+not automatically authorize writing to Notion, pushing to GitHub or changing a
+token registry.
+
+## Relation To Connectors
+
+The connector runtime policy and trigger architecture meet at one point:
+
+```text
+Trigger changes the semantic route.
+Connector availability determines the executable source route.
+Policy determines whether the route may mutate anything.
+```
+
+If a source becomes visible without a manual UI activation, the trigger is not
+the sole cause. A more precise explanation is:
+
+```text
+runtime source access + context pressure + semantic route selection + policy gate
+```
+
+The trigger can make a route salient. It does not secretly install a connector.
+
+## Minimal Lifecycle
+
+```mermaid
+flowchart LR
+    C["Context field"]
+    T["Trigger term / symbol"]
+    S["Semantic displacement"]
+    G["Gate / boundary"]
+    R["Route selection"]
+    A["Artifact / action / defer"]
+    Q["Audit trace"]
+
+    C --> T
+    T --> S
+    S --> G
+    G --> R
+    R --> A
+    A --> Q
+    Q --> C
+```
+
+## Public Canon Rule
+
+Publish triggers as architecture only when four conditions hold:
+
+| Gate | Requirement |
+| --- | --- |
+| Source | A reviewed source or repo artifact exists. |
+| Boundary | Private, patent-sensitive and security material is removed. |
+| Function | The trigger effect is stated as semantic routing, not magical execution. |
+| Trace | GitHub or another audit layer can show what was published and when. |
+
+## Current Status
+
+This file promotes the public definition from "trigger as activator" to
+"trigger as semantic displacement space". Deeper trigger rows, private module
+states and protected TNPX/CAP-II mechanics remain outside this public release.
+

--- a/docs/atlas/mermaid_cluster.md
+++ b/docs/atlas/mermaid_cluster.md
@@ -1,0 +1,125 @@
+# Mermaid Cluster
+
+Status: public atlas draft v0.1
+Source: repo-local Mermaid readpass, diagram registry, read-only Notion Mermaid public/manifest review
+Trace: created 2026-05-25 as public GitHub bridge for the Notion Mermaid cluster
+Boundary: no raw Notion links, no raw Mermaid database dump, no private source-pack rows
+Mode: SYNC / public-safe atlas publication
+GitHub sync state: prepared for public GitHub review
+Notion source awareness: Notion contains the living Mermaid code library and public manifesto material; this file publishes the redacted GitHub interpretation
+
+## Definition
+
+The Mermaid Cluster is TerraNova's visual graph layer for semantic modules,
+trigger entities, guard conditions and routing structure.
+
+The core axiom is:
+
+```text
+Node = trigger entity
+Edge = activation or guard condition
+Graph = living system map
+```
+
+In this model, a diagram is not only a visualization. It is a structured surface
+where system concepts, states and transitions can be read by humans and later
+mapped by tools.
+
+## Public Reading
+
+Classical diagram reading:
+
+```text
+Node = label
+Edge = relationship
+Graph = picture
+```
+
+TerraNova Mermaid reading:
+
+```text
+Node = module with state
+Edge = route condition
+Graph = runnable understanding surface
+```
+
+This does not mean every Mermaid graph is executable code today. It means the
+diagram is written in a way that can become machine-readable control structure.
+
+## Cluster Layers
+
+The current public cluster separates these layers:
+
+| Layer | Meaning |
+| --- | --- |
+| IST | Current workspace and ecosystem map. |
+| SOLL | Target structure and desired system state. |
+| INTEGRATION | Data flow, sync paths, read/write separation and reconciliation. |
+| ORCHESTRATION | Responsibility and routing between actors, tools and modules. |
+| ZOOM | Detail lens for one subsystem. |
+| APPENDIX | Special-purpose diagrams outside the core map. |
+| DEPOT | Source/code storage for diagram material and provenance. |
+
+## Active Public Registry
+
+The repo-local diagram registry currently exposes these ACTIVE names for
+reviewed public orientation:
+
+| Diagram | Role |
+| --- | --- |
+| Terra Nova Master Overview - Complete Workspace | Primary workspace map. |
+| Digital Ecosystem - Ziel-Struktur v2.0 | Target structure map. |
+| Notion <-> ChatGPT System-Architektur | Integration architecture. |
+| Meta-Conductor - Agent Routing | Agent routing map. |
+| Ordner 02: Codex & Trigger Detail | Trigger/codex detail lens. |
+| Ordner 05: Produkte & Services Detail | Product/service detail lens. |
+| Ordner 06: Technische Dokumentation Detail | Technical documentation detail lens. |
+| TokenAccess - TriggerMap (988-992) | Trigger appendix. |
+| Mermaid Code Library - Depot | Diagram depot. |
+
+This list is a registry of reviewed names and roles, not a permission to publish
+all underlying raw diagram source without redaction.
+
+## Mermaid To Trigger Bridge
+
+```mermaid
+flowchart LR
+    M["Mermaid graph"]
+    N["Nodes as trigger entities"]
+    E["Edges as guard conditions"]
+    S["State labels"]
+    R["Route map"]
+    V["VORTEX coherence"]
+    T["Trigger registry"]
+
+    M --> N
+    M --> E
+    N --> S
+    E --> R
+    S --> V
+    R --> V
+    V --> T
+```
+
+## Relation To SCL
+
+SCL is the language-first layer. Mermaid Cluster is the visual-first layer.
+
+```text
+SCL term <-> Mermaid node
+SCL command <-> Mermaid route
+SCL boundary <-> Mermaid guard edge
+```
+
+Together they make semantic architecture visible:
+
+```text
+language field -> visual graph -> route decision -> artifact
+```
+
+## Public Canon Rule
+
+Publish Mermaid Cluster as a graph-based understanding layer. Do not present the
+current public repository as a full export of the private Notion Mermaid code
+library. The public artifact is the redacted interpretation and registry bridge.
+


### PR DESCRIPTION
## Summary
- publishes a public-safe semantic architecture spine for TerraNova/FerrAI
- defines triggers as semantic displacement spaces, SCL, iterative interaction collapse, LDM, Lenhard Model, and Mermaid Cluster
- links the new public spine from the root README and architecture index

## Boundary
- no raw Notion URLs or page IDs added in the new docs
- no raw exports included
- TNPX-01 is handled as a context anchor only; no patent-sensitive draft mechanics or grant claims

## Validation
- `git diff --check`
- `python scripts/validate_docs.py`
- targeted leak scan for raw Notion IDs/URLs in the new docs