### PR TITLE
[codex] harden raw export boundary policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/prism-atlas-validate.yml
+++ b/.github/workflows/prism-atlas-validate.yml
@@ -81,6 +81,16 @@ jobs:
             echo "fill_850k_raw.sh unexpectedly succeeded from repo root" >&2
             exit 1
           fi
+          grep -q "TNV_ALLOW_PRIVATE_RAW_FILL=1" "$log_file"
+
+      - name: Validate fill script placeholder guard from repo root
+        run: |
+          log_file="$(mktemp)"
+          if TNV_ALLOW_PRIVATE_RAW_FILL=1 bash raw/exports/fill_850k_raw.sh >"$log_file" 2>&1; then
+            cat "$log_file"
+            echo "fill_850k_raw.sh unexpectedly accepted placeholder payload" >&2
+            exit 1
+          fi
           grep -q "Template placeholder still present" "$log_file"
 
       - name: Validate fill script guard from raw/exports
@@ -92,6 +102,19 @@ jobs:
           ); then
             cat "$log_file"
             echo "fill_850k_raw.sh unexpectedly succeeded from raw/exports" >&2
+            exit 1
+          fi
+          grep -q "TNV_ALLOW_PRIVATE_RAW_FILL=1" "$log_file"
+
+      - name: Validate fill script placeholder guard from raw/exports
+        run: |
+          log_file="$(mktemp)"
+          if (
+            cd raw/exports
+            TNV_ALLOW_PRIVATE_RAW_FILL=1 bash ./fill_850k_raw.sh >"$log_file" 2>&1
+          ); then
+            cat "$log_file"
+            echo "fill_850k_raw.sh unexpectedly accepted placeholder payload from raw/exports" >&2
             exit 1
           fi
           grep -q "Template placeholder still present" "$log_file"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ mirror/
 # Archival Prism/Notion source packs can contain private, token, wallet, raw-chat,
 # or patent-sensitive material. Commit curated docs under docs/atlas instead.
 raw/exports/prism/source-pack/*/
+
+# Private raw export staging. Public repo keeps placeholders, hashes, manifests
+# and reviewed derivatives only.
+raw/exports/local-private/
+raw/exports/private/

--- a/data_exports/xxl_500k_snapshot/README.md
+++ b/data_exports/xxl_500k_snapshot/README.md
@@ -25,8 +25,8 @@ No raw dump, split files, unredacted extracts, chat contexts, wallet/API/token t
 ```text
 RAW_INLINE: no
 RAW_IN_REPO: no
-PUBLIC_RELEASE: blocked
-NEXT_GATE: CEI-04A manual class-3 review
+PUBLIC_RELEASE: open_for_aggregates_only
+NEXT_GATE: none for aggregate index; new raw/derivative files require fresh review
 ```
 
 ## Notion anchors
@@ -48,3 +48,10 @@ PRIVATE_RAW_ARCHIVE       full raw dump, split files, hashes, restricted
 INTERNAL_EVIDENCE_INDEX   CEI analysis, sensitive review, claim corridor
 SAFE_PUBLIC_CORE          this folder and later redacted public summaries
 ```
+
+## Chronology note
+
+Issue #34 recorded the initial blocked state before CEI-04A, CEI-04B and
+CEI-04C closed. The current source for publication status is
+`public_gate_status.md`: aggregates only are open; raw publication and public
+extracts remain rejected.

--- a/data_exports/xxl_500k_snapshot/public_gate_status.md
+++ b/data_exports/xxl_500k_snapshot/public_gate_status.md
@@ -19,6 +19,13 @@ GITHUB_RAW_PUSH: NO
 - CEI-04B: PII / account / payment scan (Closed - isolated locally)
 - CEI-04C: redaction map and safe public index skeleton (Closed)
 
+## Chronology and precedence
+
+GitHub Issue #34 contains the earlier blocked-state language from before the
+CEI-04A/B/C closeout. This file is the current gate status for the public index:
+aggregate/index publication is open; raw publication and contextual extracts
+remain rejected.
+
 ## Action Taken (CEI-04A & CEI-04B)
 The 27 K3 hits (potential credential / wallet traces) and all PII/account traces (Emails, IBANs, Phone numbers) have been strictly isolated. 
 **No raw files will ever be published.** The data leak risk has been entirely neutralized by dropping the raw payload requirement.

--- a/docs/governance/public_boundary.md
+++ b/docs/governance/public_boundary.md
@@ -22,3 +22,15 @@ Items classified as `redact-candidate` hold structural value but currently conta
 
 ## Raw-Exports
 Raw exports must never touch the `main` branch unless pre-classified and heavily scrubbed. All raw exports land in local staging or isolated private storage first.
+
+## Public Derivative Exception
+
+Some tracked files under `raw/exports/incoming/` are manuscript or appendix
+derivatives rather than private raw dumps. They are allowed only as bounded
+public-review artifacts when they have checksum sidecars, classification, and no
+detected secrets or direct PII. They do not weaken the raw-export rule.
+
+Any future derivative that contains credential-like values, direct PII, raw
+Notion IDs, protected patent-source material, Track C, `GODFATHER_LOCK`, or
+private-session content must leave the public lane and be represented only by a
+redacted manifest or checksum pointer.

--- a/raw/exports/README.md
+++ b/raw/exports/README.md
@@ -1,28 +1,46 @@
 # Raw Export Archive
 
-This folder holds large raw export payloads that should not be mixed directly into the core manuscript.
+Status: public repository boundary layer
 
-## Current artifact
+This folder documents raw-export containers, derived intake batches, checksums
+and review gates. It is not a place for unreviewed private dumps.
 
-- `2026-04-30_batch_850k_raw.txt` (prepared full-dump container)
-- `2026-04-30_batch_850k_raw.sha256` (integrity hash)
+## Current public-safe shape
 
-## Usage
+The legacy `850k` artifact is a prepared container and historical planning
+label. The tracked file is a placeholder, not the raw dump.
 
-1. Paste/import the full raw 850k-character batch into the `.txt` file.
-2. Recompute checksum:
-   - `sha256sum raw/exports/2026-04-30_batch_850k_raw.txt > raw/exports/2026-04-30_batch_850k_raw.sha256`
-3. Reference the artifact in intake and decision logs before promotion attempts.
-- `2026-04-30_batch_850k_raw.txt` (legacy-named full-dump container)
-- `2026-04-30_batch_850k_raw.sha256` (integrity hash)
-- `prism/prism_full_pack_495p_2026-05-02.*` (current full-pack snapshot; exceeds the old 850k planning label)
+```text
+2026-04-30_batch_850k_raw.txt                 placeholder only
+2026-04-30_batch_850k_raw_fuellversion.md     placeholder/fill template
+2026-04-30_batch_850k_raw.sha256              integrity pointer
+fill_850k_raw.sh                              private-only fill helper
+```
 
-The `850k` segment in older file names is a historical RC01 planning label, not
-an active size limit.
+Actual private raw payloads stay outside the public repository unless a later
+review gate explicitly classifies a redacted derivative as public-safe.
 
-## Usage
+`fill_850k_raw.sh` refuses to run unless `TNV_ALLOW_PRIVATE_RAW_FILL=1` is set
+and writes to `raw/exports/local-private/`, which is ignored by git.
 
-1. Paste/import the complete current raw payload into `2026-04-30_batch_850k_raw_fuellversion.md` between the `RAW_PAYLOAD` markers.
-2. Run `./fill_850k_raw.sh` from `raw/exports/`, or `raw/exports/fill_850k_raw.sh` from repo root, to extract the payload and recompute the checksum.
-3. The helper aborts if the payload block is empty or still contains a template placeholder.
-4. Reference the artifact in intake and decision logs before promotion attempts.
+## Incoming derivatives
+
+`raw/exports/incoming/` contains derived manuscript and appendix intake batches.
+These files are larger than aggregate index rows and therefore have their own
+boundary policy:
+
+- They are not treated as private raw ChatGPT dumps.
+- They are not a precedent for committing unreviewed raw exports.
+- New files in this lane require classification, checksum and sensitivity scan.
+- Promotion from this lane must produce curated docs, release notes or public
+  indexes outside `raw/exports/`.
+- Files that later prove private, credential-bearing, patent-sensitive or
+  Track-C/GODFATHER_LOCK-sensitive must be moved out of the public lane.
+
+See `incoming/README.md` and `REVIEW_GATE.md` for the operative rules.
+
+## Hard rule
+
+No unclassified raw export may be committed to this public repository. Raw or
+private source material lands in local/private storage first; GitHub receives
+only placeholders, hashes, reviewed derivatives, or redacted public outputs.

--- a/raw/exports/REVIEW_GATE.md
+++ b/raw/exports/REVIEW_GATE.md
@@ -10,3 +10,70 @@ Before any raw export is pushed, it must be assigned one of the following classi
 - `redact-candidate`: Needs scrubbing of PII/Notion IDs before it can become `public-ok`.
 - `patent-sensitive`: Protected under TNPX-01 filing hold. DO NOT PUSH.
 - `private`: Personal, `GODFATHER_LOCK` or Track C sensitive logs. DO NOT PUSH.
+
+## Incoming Derivative Lane
+
+`raw/exports/incoming/` is a bounded derivative lane for manuscript, appendix
+and pre-release intake batches. It is not a general raw-dump folder.
+
+Allowed in this lane:
+
+- public-safe manuscript or appendix derivatives;
+- checksum sidecars for those derivatives;
+- short intake fragments that have passed the same boundary scan as the parent
+  artifact;
+- transitional material needed to reconstruct a public release package.
+
+Blocked in this lane:
+
+- unredacted transcript dumps;
+- raw Notion exports or internal page/database ID lists;
+- credential-like strings, wallet secrets, API keys, private keys or bearer
+  tokens;
+- direct personal contact, banking, account, payment or device-path data;
+- unreviewed TNPX-01 patent source packages;
+- Track C, `GODFATHER_LOCK`, intimate or private-session material unless a
+  separate publication gate explicitly clears a redacted excerpt.
+
+The legacy fill helper must keep generated raw payloads under
+`raw/exports/local-private/`. The tracked placeholder files are not publication
+targets.
+
+## Retention and Promotion
+
+Tracked incoming derivatives are temporary review artifacts. They may remain in
+the public repository only while they serve one of these purposes:
+
+- release reconstruction;
+- checksum-backed provenance;
+- public-safe appendix/manuscript review;
+- controlled migration into curated docs.
+
+Promotion path:
+
+```text
+incoming derivative
+  -> sensitivity scan
+  -> classification note
+  -> curated doc / public index / release artifact
+  -> keep checksum or retire source derivative
+```
+
+Exit path:
+
+```text
+private or sensitive finding
+  -> remove from public lane
+  -> preserve checksum/audit pointer only
+  -> store source in private/local archive
+```
+
+## Required Checks
+
+Every new or changed incoming derivative must pass:
+
+- `git diff --check`;
+- secret-pattern scan for GitHub, Notion, Zenodo, OpenAI, wallet and private-key
+  markers;
+- PII/account scan for email, phone, IBAN, IP address and local user paths;
+- manual boundary review for patent-sensitive and Track-C material.

--- a/raw/exports/fill_850k_raw.sh
+++ b/raw/exports/fill_850k_raw.sh
@@ -3,11 +3,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 SRC="$SCRIPT_DIR/2026-04-30_batch_850k_raw_fuellversion.md"
-DST="$SCRIPT_DIR/2026-04-30_batch_850k_raw.txt"
-SHA="$SCRIPT_DIR/2026-04-30_batch_850k_raw.sha256"
+PRIVATE_DIR="$SCRIPT_DIR/local-private"
+DST="$PRIVATE_DIR/2026-04-30_batch_850k_raw.txt"
+SHA="$PRIVATE_DIR/2026-04-30_batch_850k_raw.sha256"
 TMP="$(mktemp)"
 
 trap 'rm -f "$TMP"' EXIT
+
+if [[ "${TNV_ALLOW_PRIVATE_RAW_FILL:-}" != "1" ]]; then
+  echo "Refusing to fill raw export without TNV_ALLOW_PRIVATE_RAW_FILL=1." >&2
+  echo "This helper writes only to raw/exports/local-private/, which is ignored by git." >&2
+  exit 1
+fi
 
 awk '/^## RAW_PAYLOAD_BEGIN/{flag=1;next}/^## RAW_PAYLOAD_END/{flag=0}flag' "$SRC" > "$TMP"
 if ! grep -q '[^[:space:]]' "$TMP"; then
@@ -18,7 +25,8 @@ if grep -Eq 'PASTE FULL( 850K)? RAW PAYLOAD HERE|PASTE_OR_IMPORT_RAW_BATCH_CONTE
   echo "Template placeholder still present; refusing to overwrite raw dump." >&2
   exit 1
 fi
+mkdir -p "$PRIVATE_DIR"
 mv "$TMP" "$DST"
 sha256sum "$DST" > "$SHA"
 BYTES="$(wc -c < "$DST" | tr -d '[:space:]')"
-echo "Filled raw dump ($BYTES bytes) + checksum updated."
+echo "Filled private raw dump ($BYTES bytes) + checksum updated under local-private/."

--- a/raw/exports/incoming/README.md
+++ b/raw/exports/incoming/README.md
@@ -1,0 +1,64 @@
+# Incoming Raw-Export Derivative Lane
+
+Status: bounded public review lane
+
+This directory contains tracked manuscript and appendix intake derivatives used
+for RC01/500-page reconstruction and review. The files are not treated as the
+private XXL raw ChatGPT dump, but they are larger than aggregate indexes and
+therefore require explicit retention rules.
+
+## Current Inventory Shape
+
+```text
+batch_01..06   small text intake fragments with checksum sidecars
+batch_07       Appendix II, I-Q derivative, with checksum sidecar
+batch_08       Ausbau/intake corridor R-V derivative, with checksum sidecar
+batch_09       Erweiterungsbloecke W-AF derivative, with checksum sidecar
+batch_10       Erweiterungsbloecke AG-end/release notes derivative, with checksum sidecar
+```
+
+The larger `.md` files are public-review derivatives, not raw private transcript
+exports. They still require sensitivity discipline because they mention
+categories such as tokenization, wallet, patent/IP, Track C and trigger/session
+architecture.
+
+## Retention Rule
+
+Files may remain here only while they support at least one active public-safe
+purpose:
+
+- reconstructing a cited release package;
+- proving checksum-backed provenance;
+- reviewing appendix/manuscript migration;
+- preparing a curated public doc outside `raw/exports/`.
+
+If a file no longer serves one of these purposes, replace it with a public-safe
+manifest/checksum pointer and move the source material to private/local storage.
+
+## Promotion Rule
+
+Do not promote files from this lane by copying them wholesale into public docs.
+Promotion means extracting reviewed, redacted, source-aware content into a
+curated target such as `docs/`, `data_exports/`, or `releases/`.
+
+Minimum promotion record:
+
+- source filename and checksum;
+- classification result;
+- redaction/sensitivity scan result;
+- target artifact path;
+- date and reviewer/agent note.
+
+## Block Rule
+
+Immediately stop public-lane use if review finds:
+
+- credential-like values or real secrets;
+- wallet/private-key material;
+- direct PII, banking, account or payment data;
+- raw internal Notion IDs or workspace object lists;
+- protected TNPX-01 source material;
+- uncleared Track C, `GODFATHER_LOCK`, intimate or private-session content.
+
+Keep a checksum/audit pointer if provenance matters; keep the source itself
+outside the public repository.


### PR DESCRIPTION
## Summary

- Documents `raw/exports/incoming/` as a bounded public derivative lane with retention, promotion, exit, scan, and block rules.
- Clarifies XXL snapshot chronology so Issue #34 is historical and `public_gate_status.md` remains the current `OPEN (Aggregates Only)` gate.
- Hardens private raw staging by ignoring local/private raw folders, enforcing LF for shell helpers, and making `fill_850k_raw.sh` write only to ignored local-private storage after explicit opt-in.

## Scope

Public boundary documentation and local raw-export safety only. This PR does not change published release artifacts, Notion data, Zenodo metadata, or sync behavior.

## Validation

- `git diff --check`
- Targeted secret-pattern scan across changed boundary files
- `bash raw/exports/fill_850k_raw.sh` refuses without `TNV_ALLOW_PRIVATE_RAW_FILL=1`
- `TNV_ALLOW_PRIVATE_RAW_FILL=1 bash raw/exports/fill_850k_raw.sh` still refuses placeholder payloads