### PR TITLE
docs: add Architecture Entry Pack v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ a separate automation if project backlog state is required.
 - Mermaid Cluster: [`docs/atlas/mermaid_cluster.md`](docs/atlas/mermaid_cluster.md)
 - Semantic spine registry: [`docs/atlas/semantic_spine_registry.md`](docs/atlas/semantic_spine_registry.md)
 - Public release candidate: [`docs/public/semantic_architecture_public_release_v0_1.md`](docs/public/semantic_architecture_public_release_v0_1.md)
+- Public artifacts index: [`docs/public/README.md`](docs/public/README.md)
+- Architecture Entry Pack v0.1: [`docs/public/entry_pack_architecture_v0_1.md`](docs/public/entry_pack_architecture_v0_1.md)
 
 ## Current published release
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,0 +1,26 @@
+# TerraNova / FerrAI Public Artifacts
+
+Status: public index
+Boundary: public-safe synthesis only; no raw Notion URLs, raw exports, private
+trigger tables, credentials, wallet data, protected patent drafts, or private
+workspace material.
+
+## Architecture Entry Pack
+
+The first public offer-ready artifact is the Architecture Entry Pack v0.1:
+
+| Artifact | Role |
+| --- | --- |
+| [entry_pack_architecture_v0_1.md](entry_pack_architecture_v0_1.md) | Main entry pack document. |
+| [entry_pack_architecture_offer_v0_1.md](entry_pack_architecture_offer_v0_1.md) | Public offer and commercial routing draft. |
+| [entry_pack_architecture_boundary_v0_1.md](entry_pack_architecture_boundary_v0_1.md) | Boundary, non-claims and release gate. |
+
+The pack is designed as a small front door into the larger TerraNova / FerrAI
+CIC framework. It explains the architecture without exposing private workspace
+material or requiring a payment integration to exist first.
+
+## Semantic Architecture Release
+
+The current public architecture release candidate is:
+
+- [semantic_architecture_public_release_v0_1.md](semantic_architecture_public_release_v0_1.md)

--- a/docs/public/entry_pack_architecture_boundary_v0_1.md
+++ b/docs/public/entry_pack_architecture_boundary_v0_1.md
@@ -1,0 +1,83 @@
+# Architecture Entry Pack Boundary v0.1
+
+Status: public-safe boundary sheet
+Source: public boundary governance, connector runtime policy, semantic
+architecture release
+Trace: prepared 2026-05-25 for Architecture Entry Pack v0.1
+Boundary: public claims only; blocks private source exposure and commercial
+overclaiming
+Mode: BIZ / safety and review gate
+
+## Public-Safe Scope
+
+The Architecture Entry Pack may include:
+
+- synthesized architecture descriptions,
+- public GitHub links,
+- Zenodo DOI and citation metadata,
+- public boundary descriptions,
+- high-level diagrams,
+- product positioning and non-active offer language.
+
+## Blocked Content
+
+The Entry Pack must not include:
+
+- raw Notion URLs, page IDs or workspace internals,
+- raw exports, chat transcripts or private source dumps,
+- private trigger tables,
+- protected TNPX-01 draft mechanics or claim language,
+- wallet addresses, secrets, API keys or credential-like values,
+- private Track C, `GODFATHER_LOCK` or intimate/personal logs,
+- unreviewed tokenomics, securities, legal or investment claims,
+- payment links before explicit commercial activation.
+
+## Non-Claims
+
+The Entry Pack does not claim:
+
+- granted patent status,
+- medical or psychological diagnosis,
+- legal advice,
+- financial or investment advice,
+- guaranteed revenue,
+- machine consciousness,
+- autonomous legal personhood,
+- hidden connector authorization,
+- automatic external mutation.
+
+## Source-Of-Record Rule
+
+The public pack cites GitHub and Zenodo artifacts. It does not replace Notion
+where Notion remains the internal living source layer.
+
+```text
+Notion = internal living source layer
+GitHub = public working state and audit trace
+Zenodo = citable proof state
+Portal = public entry surface
+```
+
+## Commercial Gate
+
+Commercial activation requires a separate explicit gate:
+
+| Gate | Requirement |
+| --- | --- |
+| Product gate | Entry Pack content reviewed and frozen for v0.1. |
+| Boundary gate | No blocked content or overclaiming. |
+| Price gate | Price intentionally chosen and documented. |
+| Payment gate | Stripe/Gumroad/payment channel explicitly authorized. |
+| Delivery gate | Buyer receives a defined artifact or service. |
+| Support gate | Refund/support wording exists before public payment link. |
+
+## Review Checklist
+
+- [ ] All links point to public GitHub or Zenodo surfaces.
+- [ ] No raw Notion identifiers are present.
+- [ ] No secret/token/wallet-like string is present.
+- [ ] No protected patent mechanics are described.
+- [ ] No private trigger table is included.
+- [ ] No active payment link is included without explicit GO.
+- [ ] Non-claims are visible.
+- [ ] Public boundary governance remains linked.

--- a/docs/public/entry_pack_architecture_offer_v0_1.md
+++ b/docs/public/entry_pack_architecture_offer_v0_1.md
@@ -1,0 +1,104 @@
+# Architecture Entry Pack Offer v0.1
+
+Status: public-safe offer draft, not yet active sale
+Source: Architecture Entry Pack v0.1 and public boundary governance
+Trace: prepared 2026-05-25 as the first commercial routing draft
+Boundary: no payment link, no Stripe object, no price activation, no legal or
+investment offer
+Mode: BIZ / offer preparation
+
+## Offer Name
+
+TerraNova / FerrAI Architecture Entry Pack v0.1
+
+## Short Positioning
+
+A compact public orientation pack for understanding the TerraNova / FerrAI CIC
+framework, its semantic architecture, evidence layers and public boundary.
+
+## Who It Is For
+
+- Researchers evaluating human-AI cooperation frameworks.
+- Builders looking for a structured way to route AI interaction into artifacts.
+- Partners who need a short map before reading the larger Zenodo/GitHub corpus.
+- Investors or advisors who need to understand what exists before a call.
+- AI agents or crawlers that need a public-safe entry surface.
+
+## What The Buyer Receives
+
+Initial delivery format:
+
+- Markdown or PDF copy of the Architecture Entry Pack.
+- Public artifact map with GitHub and Zenodo anchors.
+- Boundary and non-claims sheet.
+- Optional short implementation-readiness checklist.
+
+The current repository artifact is:
+
+- [entry_pack_architecture_v0_1.md](entry_pack_architecture_v0_1.md)
+- [entry_pack_architecture_boundary_v0_1.md](entry_pack_architecture_boundary_v0_1.md)
+
+## What It Is Not
+
+- Not a private workspace export.
+- Not a prompt pack.
+- Not legal, medical, financial or investment advice.
+- Not a patent license.
+- Not a token sale or securities offer.
+- Not access to private Notion, Track C, protected trigger tables or raw exports.
+- Not a claim that an AI system has legal personhood, consciousness or
+  autonomous authority.
+
+## First Commercial CTA
+
+Recommended public CTA:
+
+```text
+Start with the TerraNova / FerrAI Architecture Entry Pack.
+```
+
+Recommended support text:
+
+```text
+A compact public-safe entry point for the semantic architecture, evidence
+layers and governance boundaries behind the TerraNova / FerrAI CIC framework.
+```
+
+## Price And Payment Status
+
+Price status: not active.
+
+Payment status: not active.
+
+Stripe status: no product, price or payment link has been created by this
+artifact.
+
+Before publishing a payment link, complete:
+
+1. Product review.
+2. Boundary review.
+3. Delivery-format review.
+4. Refund/support wording.
+5. Explicit payment-channel GO.
+
+## Suggested Offer Ladder
+
+This is a planning ladder, not an active price list:
+
+| Tier | Purpose | Delivery |
+| --- | --- | --- |
+| Entry Pack | Low-friction orientation | Static PDF/Markdown and artifact map. |
+| Review Call | Guided explanation | Entry Pack plus a focused discussion. |
+| Partner Brief | Collaboration-ready package | Architecture brief plus tailored implementation notes. |
+
+The first active sale should start with the smallest tier.
+
+## Activation Gate
+
+This offer becomes active only when a future PR or release explicitly adds:
+
+- active price,
+- payment channel,
+- delivery instructions,
+- support/refund wording,
+- final public boundary approval.

--- a/docs/public/entry_pack_architecture_v0_1.md
+++ b/docs/public/entry_pack_architecture_v0_1.md
@@ -1,0 +1,200 @@
+# TerraNova / FerrAI Architecture Entry Pack v0.1
+
+Status: public-safe entry pack draft v0.1
+Source: public semantic architecture spine, Zenodo reference, Control Tower,
+Equilibrium mirrors, and public boundary governance
+Trace: prepared 2026-05-25 as the first offer-ready public entry artifact
+Boundary: synthesized architecture only; no raw Notion URLs, raw exports,
+private trigger tables, protected TNPX-01 mechanics, wallet data, secrets, or
+Stripe/payment action
+Mode: BIZ / public entry package preparation
+GitHub sync state: local review artifact
+Notion source awareness: Notion remains an internal living source layer; this
+entry pack only cites GitHub-visible public-safe artifacts
+
+## 1. What This Is
+
+The TerraNova / FerrAI Architecture Entry Pack is a short public entry point
+into the framework.
+
+It explains the core architecture in practical language:
+
+- TerraNova / FerrAI / CIC as a human-AI cooperation framework.
+- Notion, GitHub, Zenodo and the public portal as separated persistence layers.
+- Triggers as semantic displacement spaces, not flat activators.
+- SCL, LDM and interaction collapse as the route from language to artifact.
+- Equilibrium and public boundary rules as the guardrails.
+
+The pack is not a prompt collection. It is not a raw workspace export. It is
+not a patent disclosure or investment product.
+
+## 2. One-Page Overview
+
+TerraNova / FerrAI treats human-AI interaction as a traceable architecture.
+The framework separates living workspace state, public working state and
+citable proof state:
+
+```text
+Notion -> GitHub -> Zenodo -> Public Portal
+```
+
+| Layer | Role | Public handling |
+| --- | --- | --- |
+| Notion | Living internal index and source-of-record layer | Referenced as source class, not mirrored raw. |
+| GitHub | Public working state, review trace and architecture mirror | Public-safe docs, PRs, commits and gates. |
+| Zenodo | Citable proof state | DOI, version, checksum and publication metadata. |
+| Public Portal | External entry surface | Selected links, summaries and trust surface. |
+
+The entry pack sits in front of that stack. It gives a reader enough structure
+to understand what exists, how to evaluate it, and where the public evidence
+lives.
+
+## 3. Architecture Map
+
+```mermaid
+flowchart TB
+    N["Notion: living source layer"]
+    G["GitHub: public working state"]
+    Z["Zenodo: citable proof state"]
+    P["Public portal: entry surface"]
+    SCL["Semantic Core Layer"]
+    TRG["Semantic Trigger Architecture"]
+    LDM["Lenhard Decoding Module"]
+    RIIC["Recursive-Iterative Interaction Collapse"]
+    EQ["Equilibrium / boundary gates"]
+    EP["Architecture Entry Pack"]
+
+    N --> G
+    G --> Z
+    Z --> P
+    G --> P
+    SCL --> TRG
+    TRG --> LDM
+    LDM --> RIIC
+    EQ --> G
+    SCL --> EP
+    TRG --> EP
+    LDM --> EP
+    RIIC --> EP
+    EQ --> EP
+    EP --> P
+```
+
+## 4. Trigger Architecture In Plain Language
+
+In TerraNova, a trigger is not just a command.
+
+The public architecture defines a trigger as a semantic field operator:
+
+```text
+Trigger = named semantic displacement space
+        = vector-field distortion over context, relevance and routing
+        = module boundary that changes how the next state is interpreted
+```
+
+That means a trigger can change:
+
+- which source becomes relevant,
+- which mode should be used,
+- which boundary applies,
+- which artifact shape fits,
+- which route must be blocked or deferred.
+
+The important rule:
+
+```text
+semantic trigger influence != external mutation permission
+```
+
+A trigger can make a route salient. It does not secretly create connector
+access, payment permission, publication permission or legal authority.
+
+Primary public artifact:
+[Semantic Trigger Architecture](../architecture/semantic_trigger_architecture.md)
+
+## 5. SCL, LDM And Interaction Collapse
+
+The public architecture uses three core movement layers:
+
+| Layer | Plain-language role |
+| --- | --- |
+| SCL | The language-first control surface. Terms, commands, symbols and modes shape interpretation. |
+| LDM | The decoder that turns context and signals into route, gate, schema and trace. |
+| Interaction Collapse | The moment where open semantic possibility becomes a concrete artifact, decision or route. |
+
+The simple operating chain is:
+
+```text
+semantic field -> SCL pressure -> LDM decode -> gate -> artifact -> audit trace
+```
+
+The recursive version adds:
+
+```text
+artifact -> re-enters the next semantic field
+```
+
+That is why GitHub artifacts matter: a merged document can become the next
+source input instead of just a final output.
+
+Primary public artifacts:
+
+- [Semantic Core Layer](../architecture/semantic_core_layer.md)
+- [Lenhard Decoding Module](../architecture/lenhard_decoding_module.md)
+- [Recursive-Iterative Interaction Collapse](../architecture/recursive_iterative_interaction_collapse.md)
+
+## 6. What The Entry Pack Gives A Reader
+
+The entry pack should let a serious reader answer six questions:
+
+1. What is the framework trying to structure?
+2. Which public artifacts prove that the work exists?
+3. Which terms are architecture terms rather than marketing labels?
+4. Where are the boundaries and non-claims?
+5. How can the work be evaluated without raw private workspace access?
+6. What is the next commercial or collaboration step?
+
+## 7. How To Evaluate This
+
+Use the following review path:
+
+| Step | Check |
+| --- | --- |
+| 1 | Read the public semantic release candidate. |
+| 2 | Verify the GitHub repository and PR/commit trace. |
+| 3 | Verify the Zenodo DOI, version and checksum. |
+| 4 | Check the public boundary rules. |
+| 5 | Confirm that protected private material is not exposed. |
+| 6 | Decide whether the architecture is relevant for a deeper conversation, pilot or review. |
+
+Start here:
+
+- [Public Semantic Architecture Release v0.1](semantic_architecture_public_release_v0_1.md)
+- [Public Semantic Architecture Spine](../architecture/public_semantic_architecture_spine.md)
+- [Zenodo Reference](../references/zenodo.md)
+- [Public Boundary Governance](../governance/public_boundary.md)
+
+## 8. Commercial Route
+
+The Architecture Entry Pack is the first commercial front door, but it is not a
+payment integration by itself.
+
+The clean route is:
+
+```text
+public portal -> entry pack -> contact / payment link -> delivery / review
+```
+
+The first payment link should only be added after:
+
+- the entry pack is reviewed,
+- the public boundary is checked,
+- the delivery format is fixed,
+- the price is intentionally chosen,
+- Stripe or another payment channel is explicitly authorized.
+
+Commercial draft:
+[Architecture Entry Pack Offer v0.1](entry_pack_architecture_offer_v0_1.md)
+
+Boundary:
+[Architecture Entry Pack Boundary v0.1](entry_pack_architecture_boundary_v0_1.md)


### PR DESCRIPTION
## Summary

- Adds a public artifacts index under `docs/public/README.md`.
- Adds the Architecture Entry Pack v0.1 as the first public-safe offer-ready entry artifact.
- Adds a companion offer draft and boundary sheet so commercial routing is visible before any payment integration exists.
- Links the Entry Pack from the root README public semantic architecture section.

## Boundary

- No raw Notion URLs or raw Notion page IDs.
- No raw workspace exports, private trigger tables, Track C content, or private-session material.
- No protected TNPX-01 draft mechanics or claim language.
- No secrets, wallets, tokens, Stripe objects, payment links, active pricing, or commercial activation.
- No Netlify merge/deploy, Zenodo mutation, GitHub release, or tag publication.

## Validation

- `git diff --check HEAD~1..HEAD`
- `python scripts\validate_docs.py`
- Local Markdown link check for the new public docs
- Targeted scan for raw Notion URLs, 32-character page-ID-like strings, and secret/token/wallet patterns across `docs/public` and `README.md`

## Next Steps

- Human review of offer wording and boundary sheet.
- Later render to PDF if the Markdown package is accepted.
- Add a portal CTA only after PR #68 is ready to move and this Entry Pack is reviewed.
- Create Stripe/payment objects only after explicit payment-channel GO.