### PR TITLE
docs: add Stripe Entry Pack activation plan

### DIFF
--- a/.github/workflows/tnv_notion_to_github.yml
+++ b/.github/workflows/tnv_notion_to_github.yml
@@ -83,3 +83,42 @@ jobs:
             git pull --rebase origin "$BRANCH"
             git push origin "HEAD:$BRANCH"
           fi
+deploy_to_github_pages:
+    name: 🚀 Deploy to GitHub Pages
+    needs: sync 
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: 📥 Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: 🔍 Validate Assets (Mode: validate / dry-run)
+        if: ${{ github.event.inputs.mode == 'validate' || github.event.inputs.mode == 'dry-run' }}
+        run: |
+          echo "Current Mode: ${{ github.event.inputs.mode }} -> Executing Dry-Run."
+          if [ -f "index.html" ]; then
+            echo "✅ VALIDATION PASS: index.html exists."
+          else
+            echo "❌ VALIDATION FAIL: index.html is missing!"
+            exit 1
+          fi
+
+      - name: 🛠️ Setup GitHub Pages
+        if: ${{ github.event.inputs.mode == 'full' }}
+        uses: actions/configure-pages@v5
+
+      - name: 📤 Upload Pages Artifact
+        if: ${{ github.event.inputs.mode == 'full' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.' 
+
+      - name: 🌍 Deploy to GitHub Pages
+        if: ${{ github.event.inputs.mode == 'full' }}
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,25 +4,35 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'README.md'
       - 'BIZ.md'
       - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
       - 'docs/codex/**'
       - 'docs/governance/**'
+      - 'docs/public/**'
+      - 'site/**'
       - 'schemas/artifact_status.schema.json'
       - 'config/source_registry.json'
       - 'scripts/validate_docs.py'
+      - 'scripts/validate_public_portal.py'
       - 'tests/test_validate_docs.py'
+      - 'tests/test_validate_public_portal.py'
       - '.github/workflows/validate-docs.yml'
   push:
     paths:
+      - 'README.md'
       - 'BIZ.md'
       - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
       - 'docs/codex/**'
       - 'docs/governance/**'
+      - 'docs/public/**'
+      - 'site/**'
       - 'schemas/artifact_status.schema.json'
       - 'config/source_registry.json'
       - 'scripts/validate_docs.py'
+      - 'scripts/validate_public_portal.py'
       - 'tests/test_validate_docs.py'
+      - 'tests/test_validate_public_portal.py'
       - '.github/workflows/validate-docs.yml'
 
 permissions:
@@ -45,6 +55,12 @@ jobs:
 
       - name: Run validator unit tests
         run: python -m unittest tests.test_validate_docs
+
+      - name: Validate public portal surfaces
+        run: python scripts/validate_public_portal.py
+
+      - name: Run public portal validator unit tests
+        run: python -m unittest tests.test_validate_public_portal
 
       - name: Validate registry and schema JSON
         run: |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ a separate automation if project backlog state is required.
 - Prism import manifest: [`docs/governance/prism_import_manifest.md`](docs/governance/prism_import_manifest.md)
 - Track C intake checklist: [`docs/governance/track_c_intake_checklist.md`](docs/governance/track_c_intake_checklist.md)
 - ChatGPT connector runtime policy: [`docs/governance/chatgpt_connector_runtime_policy.md`](docs/governance/chatgpt_connector_runtime_policy.md)
+- Stripe Entry Pack activation plan: [`docs/governance/stripe_entry_pack_activation_plan.md`](docs/governance/stripe_entry_pack_activation_plan.md)
 - Repository maturity note: [`docs/governance/repository_maturity.md`](docs/governance/repository_maturity.md)
 - Raw export review gate: [`raw/exports/REVIEW_GATE.md`](raw/exports/REVIEW_GATE.md)
 

--- a/docs/atlas/control-tower/README.md
+++ b/docs/atlas/control-tower/README.md
@@ -19,6 +19,7 @@ This folder defines the first implementation layer for **CAP 0.1.0 - Cognitive A
 | `cap-0.3-operational-control-iperka.md` | Operational IPERKA layer for queue execution, no-credit routines and bounded trigger steering. |
 | `cap-0.3.workstream-map.csv` | CAP 0.3 workstream map and completion signals. |
 | `cap-0.4-canon-admission-iperka.md` | Canon admission IPERKA layer for source-tiered canon governance. |
+| `cap-0.5-public-entry-product-ladder-iperka.md` | Public entry and product ladder IPERKA for Gumroad, Notion template, portal routing and Codex fallback. |
 | `canon-admission-rulebook.md` | CAP 0.4 rulebook for canon claims, source tiers, admission levels and downgrade rules. |
 | `canon-source-tier-map.csv` | Source-tier authority map for canon admission decisions. |
 | `canon-elevation-queue.csv` | Current queue of canon elevation actions and stop conditions. |
@@ -577,3 +578,13 @@ SOURCE-520 has completed the SessionStart primary source pass and was applied to
 SYNC-003 closes the GitHub trace after SOURCE-521. It keeps the closure scoped to Control Tower artifacts, `scripts/cap_control_checks.py` and the 2026-05-18 AUTO-001 result; unrelated dirty files remain untouched and no push is performed.
 
 SYNC-004 closes the repo-local GitHub trace after TEST-520 and SOURCE-520. It records that the current local branch `codex/governance-doc-validation` has a gone upstream and is 2 commits ahead / 45 commits behind `origin/main`, so no push, rebase or merge is performed in this pass. The closure remains scoped to Control Tower artifacts and `scripts/cap_control_checks.py`; unrelated dirty files remain untouched.
+
+## CAP 0.5 Continuation
+
+Next local public-entry layer:
+
+```text
+docs/atlas/control-tower/cap-0.5-public-entry-product-ladder-iperka.md
+```
+
+CAP 0.5 turns the verified public product layer into a source-safe operating surface. It records the three live Gumroad products, treats the Notion Marketplace state as pending until concrete directory evidence exists, keeps Codex as an optional local execution layer and routes future portal CTA work through verified product evidence instead of placeholder-only PR state.

--- a/docs/atlas/control-tower/cap-0.5-public-entry-product-ladder-iperka.md
+++ b/docs/atlas/control-tower/cap-0.5-public-entry-product-ladder-iperka.md
@@ -1,0 +1,294 @@
+# CAP 0.5 - Public Entry and Product Ladder IPERKA
+
+Status: BIZ/STUDIO bridge plan, repo-local, no external mutation
+Date: 2026-06-03
+Predecessor: `CAP 0.4 - Canon Admission IPERKA`
+Primary input: Gumroad product ladder, Notion Marketplace template, GitHub public-safe traces
+
+## Purpose
+
+CAP 0.5 turns the current public product layer into an explicit operating
+surface.
+
+The system no longer lacks bounded artifacts. Three Gumroad products are live,
+and the Notion template/public site is prepared while Marketplace directory
+visibility is still pending. The remaining problem is not artifact creation. The
+remaining problem is public routing, external comprehensibility, and source-safe
+correlation between Notion, GitHub, Gumroad, Zenodo and local verification.
+
+CAP 0.5 therefore defines how TerraNova presents its public entry layer without
+flattening the internal system, over-claiming validation, or making Codex a
+single point of failure.
+
+## Operating Thesis
+
+TerraNova is internally advanced enough to sustain a product ladder. It is not
+yet externally simple enough to be understood without a controlled entry path.
+
+The product layer must answer:
+
+- What can an outsider buy or duplicate now?
+- What source proves that the artifact exists?
+- What is public-safe and what remains internal?
+- Which system is source of record for each claim?
+- What GitHub trace, if any, mirrors the public claim?
+- What remains pending, deferred or human-gated?
+
+If an outsider cannot understand the ladder in one controlled pass, the issue is
+not lack of depth. It is routing debt.
+
+## Deterministic Boundaries
+
+Hard limits:
+
+- no Notion Marketplace status claim without a concrete source or visible listing
+- no Gumroad sales claim beyond verified public product pages
+- no Stripe direct-sale activation; Stripe remains mirror/records-only until a
+  separate explicit `GO Stripe ...` command exists
+- no Zenodo publication or metadata mutation inside CAP 0.5
+- no GitHub push, PR, merge or branch mutation inside this IPERKA
+- no public mirroring of private Notion raw data, trigger tables, secrets,
+  protected workspace mechanics or operator-sensitive material
+- no claim that Codex is required for TerraNova to operate
+- no claim that external validation exists before users, buyers, reviewers,
+  citations or marketplace approval prove it
+
+`/fff` may steer synthesis and prioritization. It cannot bypass product,
+payment, marketplace, GitHub or publication gates.
+
+## Product Layer Snapshot
+
+Verified public product surfaces as of 2026-06-03:
+
+| Surface | Status | Evidence |
+| --- | --- | --- |
+| Architecture Entry Pack v0.1 | Live Gumroad product, USD 19 | `https://silvanlenhard.gumroad.com/l/architecture-entry-pack-v0-1` returned `200 OK` |
+| CIC Blueprint Pack v0.1 | Live Gumroad product, USD 49 | `https://silvanlenhard.gumroad.com/l/cic-blueprint-pack-v0-1` returned `200 OK` |
+| CIC Implementation Workbook v0.1 | Live Gumroad product, USD 99 | `https://silvanlenhard.gumroad.com/l/cic-implementation-workbook-v0-1` returned `200 OK` |
+| AI Workflow & Artifact Pipeline v0.1 | Notion template/public-site layer prepared | Template fetched; `https://artifact-pipeline.notion.site` returned `200 OK` |
+| Notion Marketplace directory listing | Pending review/propagation | No concrete `notion.com/templates/...` listing verified yet |
+
+## Source-of-Record Map
+
+| Claim type | Source of record | Mirror / support |
+| --- | --- | --- |
+| Product live/reachable | Gumroad product URL | Notion BIZ logs, GitHub public bundle files |
+| Product ladder strategy | Notion BIZ pages | GitHub docs/public bundle traces |
+| Public-safe source artifacts | GitHub `docs/public/**` | Gumroad download payloads, Notion launch logs |
+| Template structure | Notion template page | Public Notion site, Marketplace submission pack |
+| Marketplace approval | Notion Marketplace / creator dashboard | Notion submission logs only until directory URL exists |
+| Payment records | Gumroad / Stripe mirror | Stripe 3er-Mirror page, no direct payment links |
+| Canon / AGU / RuleGraph | Notion source pages | GitHub mirror only after label-gate reconciliation |
+| Publication evidence | Zenodo | GitHub release notes and `docs/references/zenodo.md` |
+
+## I - Informieren
+
+Known state:
+
+| Signal | Value |
+| --- | --- |
+| Gumroad live products | 3 |
+| Gumroad direct product URLs verified | 3 |
+| Gumroad shop profile | Reachable, but HTML sections appear empty; direct URLs are stronger evidence |
+| Notion template public site | Reachable |
+| Notion Marketplace directory URL | Not yet verified |
+| Open GitHub PRs in current triage | `#77`, `#73`, `#70` |
+| PR `#77` | Draft portal-validator / registry review lane; `Validate Docs` is green |
+| PR `#70` | Draft, stale Stripe / payment-plan lane |
+| PR `#73` | Draft, placeholder-only portal CTA; blocked and not currently prioritized |
+| Portal-validator / registry lane state | No longer local-only; open as draft PR `#77` and still partially present in the current worktree |
+| External mutation count in this IPERKA | 0 |
+
+Active supporting sources:
+
+- `docs/public/entry_pack_bundle_v0_1/`
+- `docs/public/blueprint_pack_v0_1/`
+- `docs/public/implementation_workbook_v0_1/`
+- `docs/governance/stripe_entry_pack_activation_plan.md`
+- `docs/governance/source_of_record_policy.md`
+- `docs/governance/public_boundary.md`
+- Notion `BIZ-Launch Readiness - Codex-Pause-Fenster`
+- Notion `Stripe 3er-Mirror - Source of Truth`
+- Notion `Submit-Pack v0.1 - Konsolidiert (Gate 5)`
+- Gumroad live product URLs listed above
+
+Open pressure:
+
+- The public product ladder exists but is not yet presented as one coherent
+  outside-facing route.
+- The portal CTA PR is placeholder-only and does not reflect the verified
+  Gumroad ladder.
+- Notion Marketplace state is pending and must not be treated as failed or live
+  in the directory before evidence exists.
+- The Gumroad shop profile does not expose product sections in static HTML, so
+  direct product URLs remain the current hard proof.
+- Codex is useful for local verification but must not become a system dependency.
+- RuleGraph public mirror remains blocked until Canon Label Gate / R14-R19 label
+  reconciliation is resolved.
+
+## P - Planen
+
+CAP 0.5 has seven workstreams.
+
+| Workstream | Purpose | Output |
+| --- | --- | --- |
+| `CAP5-BOOT-001` | Create this product-entry IPERKA and freeze current product evidence. | This file and local memory update |
+| `PROD-ROUTE-001` | Define one public ladder route from Entry Pack to Workbook plus Notion template. | Product ladder map and short outside-facing narrative |
+| `PORTAL-CTA-001` | Replace placeholder portal logic with verified URL policy. | Local validator-backed patch; no merge/push without GO |
+| `MARKET-001` | Track Notion Marketplace review/propagation without false status claims. | Pending-state checklist and future evidence slot |
+| `GUMROAD-001` | Verify public metadata and boundary text for the three Gumroad products. | Read-only product audit summary |
+| `CODEX-FALLBACK-001` | Define how TerraNova operates when Codex limits apply. | Local script/API/MCP fallback runbook |
+| `CAP5-CLOSE-001` | Decide whether the public entry layer is ready for external review. | Close report and next gate |
+
+Batch order:
+
+1. `CAP5-BOOT-001`
+2. `PROD-ROUTE-001`
+3. `GUMROAD-001`
+4. `MARKET-001`
+5. `PORTAL-CTA-001`
+6. `CODEX-FALLBACK-001`
+7. `CAP5-CLOSE-001`
+
+This order keeps verified product reality ahead of portal or automation work.
+
+## E - Entscheiden
+
+Decision: CAP 0.5 starts repo-local and product-evidence-first.
+
+Reason:
+
+```text
+Three Gumroad products are live
+-> Notion template/public site is prepared
+-> Marketplace directory needs propagation/review time
+-> GitHub PR view is narrower than the real public product layer
+-> Codex is optional operator tooling, not the system core
+-> therefore public routing must be stabilized before more expansion
+```
+
+Selected stance:
+
+- treat Gumroad direct URLs as current hard external evidence
+- treat Notion Marketplace as pending until a directory URL or approval proof
+  exists
+- treat GitHub as public-safe trace and validator layer, not as the whole
+  product truth
+- treat Codex as useful but replaceable local execution layer
+- route outsiders through bounded artifacts before deep canon or RuleGraph
+
+## R - Realisieren
+
+### Batch CAP5-BOOT-001
+
+Actions:
+
+- create CAP 0.5 IPERKA locally
+- record the three verified Gumroad product URLs
+- record Notion Marketplace as pending review/propagation
+- keep external mutation count at 0
+
+### Batch PROD-ROUTE-001
+
+Actions:
+
+- define the product ladder:
+  - Entry Pack = public architecture entry
+  - Blueprint Pack = operating model / control logic layer
+  - Implementation Workbook = self-guided application layer
+  - Notion Template = external workflow container for non-TerraNova users
+- write a one-screen outside-facing explanation
+- separate "what is for buyers" from "what remains internal canon"
+
+### Batch GUMROAD-001
+
+Actions:
+
+- verify each product URL returns `200 OK`
+- record price, title, boundary / non-claims and intended buyer path
+- flag any metadata drift, listing-copy leftovers or public wording issues
+- do not perform purchases, refunds or product edits
+
+### Batch MARKET-001
+
+Actions:
+
+- keep `artifact-pipeline.notion.site` as public-site evidence
+- keep the template page as content evidence
+- reserve a slot for the future Marketplace directory URL
+- do not claim Marketplace publication until visible or explicitly confirmed
+
+### Batch PORTAL-CTA-001
+
+Actions:
+
+- keep the public portal validator patch as useful
+- block placeholder-only PR `#73`
+- decide future portal behavior from verified product ladder, not from stale PR
+  state
+- prepare a local patch only; no push or PR mutation without explicit GO
+
+### Batch CODEX-FALLBACK-001
+
+Actions:
+
+- define local scripts and API/MCP flows that keep TerraNova operable without
+  Codex
+- preserve Codex for repo diffs, tests and verification when limits allow
+- avoid routing source-of-truth decisions through Codex memory alone
+
+### Batch CAP5-CLOSE-001
+
+Exit check:
+
+```text
+Can an outsider understand the product ladder, access a verified public entry,
+and know what is included, excluded, pending and source-backed without Silvan
+being present?
+```
+
+## K - Kontrollieren
+
+Control metrics:
+
+| Metric | Target |
+| --- | --- |
+| Gumroad live product URLs with `200 OK` | 3 of 3 |
+| Products with visible price metadata | 3 of 3 |
+| Products with boundary / non-claims text | 3 of 3 |
+| Marketplace status over-claims | 0 |
+| Portal placeholder CTA accepted as complete | 0 |
+| External mutations without explicit GO | 0 |
+| Public product claims without source URL | 0 |
+| Codex dependency for core operation | 0 |
+| Private/internal mechanics exposed in public route | 0 |
+
+Every public-entry claim must answer:
+
+```text
+What is the artifact?
+Where can it be reached?
+What does it cost or what is its status?
+What does it include?
+What does it explicitly not include?
+Which system proves the claim?
+What remains pending?
+```
+
+## A - Auswerten
+
+CAP 0.5 is complete when:
+
+- the product ladder has one concise public route
+- the three Gumroad products have a read-only metadata audit
+- Notion Marketplace state is tracked as pending or verified with evidence
+- portal CTA policy no longer accepts placeholder-only content
+- Codex fallback operation is documented
+- no external mutation was performed without explicit GO
+
+Best next move after CAP 0.5 boot:
+
+```text
+PROD-ROUTE-001 - write the one-screen public ladder narrative and map it to the
+three Gumroad URLs plus the Notion template pending state.
+```

--- a/docs/governance/issue_status_registry.md
+++ b/docs/governance/issue_status_registry.md
@@ -1,8 +1,8 @@
 # Governance Issue Status Registry
 
 Status: BIZ / Governance
-Source: GitHub issue and PR state after PR #60 and PR #66 merge.
-Trace: Issues #15, #23, #25; PR #60, PR #66; Zenodo record `10.5281/zenodo.20073579`.
+Source: GitHub issue and PR state after PR #60 and PR #66 merge, refreshed on 2026-06-02.
+Trace: Issues #11, #15, #17, #23, #25; PR #60, PR #66; Zenodo record `10.5281/zenodo.20073579`.
 Boundary: Public-safe issue-status mirror only. It does not close issues by itself and does not mutate Notion or Zenodo.
 Mode: BIZ
 GitHub sync state: tracked in this repository; validate with `scripts/validate_docs.py`.
@@ -22,8 +22,9 @@ from outranking newer reviewed repository state.
 | #25 GitHub container hardening | Closed/completed | `docs/governance/public_boundary.md`; `docs/governance/repo_roles.md`; `raw/exports/REVIEW_GATE.md`; `raw/exports/incoming/README.md`; PR #66, merge commit `49e4024` | Keep as historical closure anchor |
 | #15 Citation/stub reality check | Open | `CITATION.cff`; `docs/references/zenodo.md`; `docs/architecture/core_grid_spec.md`; `docs/science/dissertation/appendix/A02_formula_collection.tex`; `docs/architecture/cic_convergence_9_layers.md` | Keep open until A.2 formulas and CIC convergence receive controlled real exports |
 | #13 Source-tier and Prism naming | Open | `docs/governance/source_tier_and_naming_policy.md`; `docs/ai/cic_atlas_usage.md`; `docs/ai/prism_atlas_usage.md` | Keep open until public naming review and external product-name decision are complete |
-| #17 Prism scale governance | Open | `docs/governance/prism_import_manifest.md`; `raw/exports/prism/source-pack/README.md`; `docs/atlas/README.md`; boundary docs from PR #66 | Keep open until a real import batch is classified against the manifest |
-| #10/#11 Track C intake/review | Open | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; `raw/exports/incoming/README.md`; Track C references in issue bodies | Keep open until a real Track C batch is classified against the checklist |
+| #17 Prism scale governance | Closed/completed | `docs/governance/prism_import_manifest.md`; `raw/exports/prism/source-pack/README.md`; `docs/atlas/README.md`; boundary docs from PR #66; GitHub issue closed as completed on 2026-05-25 | None for the issue; future import batches must still pass the manifest |
+| #10 Track C intake | Open | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; `raw/exports/incoming/README.md`; Track C references in issue body | Keep open until a real Track C batch is classified against the checklist |
+| #11 Prism workspace review | Closed/completed | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; issue closure on 2026-05-25 | Keep as historical review marker; no blind merge or deletion implied |
 
 ## Issue #15 Reality Check
 
@@ -56,18 +57,21 @@ container-hardening surfaces:
 The remaining credential-rotation proof remains an account-level operational
 check, not repository text evidence.
 
-## Issue #17 Import Gate
+## Issue #17 Closure Check
 
-The Prism scale checkpoint now has a public import manifest:
+Issue #17 is closed as completed. The Prism scale checkpoint now has a public
+import manifest:
 
 - `docs/governance/prism_import_manifest.md`
 
-This is not a bulk-import approval. It is the gate a future import batch must
-pass before entering public docs.
+Closure is not a bulk-import approval. The manifest remains the gate a future
+import batch must pass before entering public docs.
 
 ## Issues #10/#11 Track C Gate
 
-Track C now has a public intake checklist:
+Issue #10 remains open as the Track C intake marker. Issue #11 is closed as a
+historical Prism workspace review marker. Track C now has a public intake
+checklist:
 
 - `docs/governance/track_c_intake_checklist.md`
 

--- a/docs/governance/stripe_entry_pack_activation_plan.md
+++ b/docs/governance/stripe_entry_pack_activation_plan.md
@@ -120,4 +120,3 @@ The payment route does not create:
 - guaranteed business outcome,
 - private workspace access,
 - access to raw Notion or protected trigger material.
-

--- a/docs/governance/stripe_entry_pack_activation_plan.md
+++ b/docs/governance/stripe_entry_pack_activation_plan.md
@@ -1,0 +1,123 @@
+# Stripe Entry Pack Activation Plan
+
+Status: payment-channel activation plan, not active sale
+Source: Architecture Entry Pack v0.1, public boundary governance, Stripe read-only
+inventory check
+Trace: prepared 2026-05-25 after Netlify portal and Architecture Entry Pack
+merge
+Boundary: no Stripe mutation, no payment link, no active price, no live sale
+Mode: BIZ / payment gate preparation
+
+## Decision
+
+The first Stripe route should use the **Architecture Entry Pack v0.1**, not the
+older prompt-based Entry Pack lane.
+
+The prompt-based product lane is treated as legacy/hold because the current
+commercial front door is architecture understanding, not master prompts.
+
+## Product Target
+
+Recommended Stripe product label:
+
+```text
+TerraNova / FerrAI Architecture Entry Pack v0.1
+```
+
+Recommended product description:
+
+```text
+A compact public-safe orientation pack for the TerraNova / FerrAI CIC
+framework, its semantic architecture, evidence layers, and governance
+boundaries.
+```
+
+Product type:
+
+```text
+one_time_digital_product
+```
+
+## Price Gate
+
+No price is active yet.
+
+Before creating a Stripe price, decide:
+
+| Field | Required decision |
+| --- | --- |
+| Currency | CHF unless a later commercial review chooses otherwise. |
+| Amount | Must be deliberately chosen and recorded before Stripe creation. |
+| Tax behavior | Must be reviewed before public payment link. |
+| Delivery | Must point to a stable public artifact or controlled delivery flow. |
+| Refund/support | Must be written before public payment link. |
+
+## Payment Link Gate
+
+A Stripe Payment Link may be created only after these gates pass:
+
+1. Product copy reviewed.
+2. Boundary sheet reviewed.
+3. Price recorded.
+4. Delivery path recorded.
+5. Refund/support wording recorded.
+6. Explicit command: `GO Stripe Entry Pack create payment link`.
+
+Until then, the portal and public docs may say:
+
+```text
+Payment route: pending.
+```
+
+## Delivery Model
+
+Initial delivery should stay simple:
+
+| Artifact | Delivery route |
+| --- | --- |
+| Entry Pack Markdown | Public GitHub artifact. |
+| Entry Pack PDF | Optional later render artifact. |
+| Boundary Sheet | Public GitHub artifact. |
+| Offer Draft | Public GitHub artifact until active sale copy exists. |
+
+The first active sale should not depend on private Notion access, raw exports,
+manual token handling, or protected workspace material.
+
+## Blocked Actions
+
+Do not create or publish:
+
+- a payment link before the explicit payment GO,
+- a price before amount/currency are final,
+- a product that reuses the prompt-based legacy positioning,
+- a subscription for the first Entry Pack,
+- any Stripe customer object for testing without a real need,
+- any webhook, Checkout integration, Function, or backend before the static
+  Payment Link route has been evaluated.
+
+## Minimal Activation Sequence
+
+When ready:
+
+```text
+1. Create Stripe product: TerraNova / FerrAI Architecture Entry Pack v0.1
+2. Create one-time CHF price.
+3. Create Payment Link for that price.
+4. Add payment link to a separate commercial activation PR.
+5. Re-run public boundary and link checks.
+6. Merge only after explicit GO.
+```
+
+## Non-Claims
+
+The payment route does not create:
+
+- investment product,
+- token sale,
+- patent license,
+- legal advice,
+- medical or psychological advice,
+- guaranteed business outcome,
+- private workspace access,
+- access to raw Notion or protected trigger material.
+

--- a/docs/public/entry_pack_architecture_offer_v0_1.md
+++ b/docs/public/entry_pack_architecture_offer_v0_1.md
@@ -73,6 +73,9 @@ Payment status: not active.
 Stripe status: no product, price or payment link has been created by this
 artifact.
 
+Stripe planning:
+[Stripe Entry Pack Activation Plan](../governance/stripe_entry_pack_activation_plan.md)
+
 Before publishing a payment link, complete:
 
 1. Product review.

--- a/scripts/validate_public_portal.py
+++ b/scripts/validate_public_portal.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Validate public portal surfaces used by public-facing entry-pack PRs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_INDEX = Path("site/index.html")
+ENTRY_PACK_LINK = Path("site/entry-pack-link.txt")
+REQUIRED_PUBLIC_DOCS = [
+    Path("docs/public/entry_pack_architecture_v0_1.md"),
+    Path("docs/public/entry_pack_architecture_offer_v0_1.md"),
+    Path("docs/public/entry_pack_architecture_boundary_v0_1.md"),
+]
+REQUIRED_SITE_STRINGS = [
+    "Start with the Entry Pack",
+    "Architecture Entry Pack v0.1",
+    "Open offer draft",
+    "Open boundary sheet",
+]
+REQUIRED_SITE_LINKS = [
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_v0_1.md",
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_offer_v0_1.md",
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_boundary_v0_1.md",
+]
+PLACEHOLDER_RE = re.compile(r"placeholder", re.IGNORECASE)
+HTTPS_URL_RE = re.compile(r"^https://\S+$")
+
+
+def fail(message: str) -> None:
+    print(f"[validate-public-portal] ERROR: {message}", file=sys.stderr)
+
+
+def validate_repo(root: Path) -> list[str]:
+    errors: list[str] = []
+
+    for rel_path in REQUIRED_PUBLIC_DOCS:
+        if not (root / rel_path).is_file():
+            errors.append(f"missing required public document: {rel_path.as_posix()}")
+
+    site_index = root / SITE_INDEX
+    if not site_index.is_file():
+        errors.append(f"missing portal index: {SITE_INDEX.as_posix()}")
+        return errors
+
+    text = site_index.read_text(encoding="utf-8")
+    for value in REQUIRED_SITE_STRINGS:
+        if value not in text:
+            errors.append(f"site/index.html missing required text: {value}")
+    for value in REQUIRED_SITE_LINKS:
+        if value not in text:
+            errors.append(f"site/index.html missing required link: {value}")
+
+    entry_pack_link = root / ENTRY_PACK_LINK
+    if entry_pack_link.exists():
+        link_text = entry_pack_link.read_text(encoding="utf-8").strip()
+        if not link_text:
+            errors.append(f"{ENTRY_PACK_LINK.as_posix()} is empty")
+        elif PLACEHOLDER_RE.search(link_text):
+            errors.append(f"{ENTRY_PACK_LINK.as_posix()} still contains placeholder text")
+        elif not HTTPS_URL_RE.fullmatch(link_text):
+            errors.append(
+                f"{ENTRY_PACK_LINK.as_posix()} must contain exactly one https URL when present"
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_repo(REPO_ROOT)
+    if errors:
+        for error in errors:
+            fail(error)
+        return 1
+    print("[validate-public-portal] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_public_portal.py
+++ b/tests/test_validate_public_portal.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_public_portal.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("validate_public_portal", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidatePublicPortalTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+
+    def write_repo(self, root: Path) -> None:
+        for rel_path in self.mod.REQUIRED_PUBLIC_DOCS:
+            path = root / rel_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"# {path.stem}\n", encoding="utf-8")
+
+        site_index = root / self.mod.SITE_INDEX
+        site_index.parent.mkdir(parents=True, exist_ok=True)
+        site_index.write_text(
+            "\n".join(
+                [
+                    "<html>",
+                    "<body>",
+                    *self.mod.REQUIRED_SITE_STRINGS,
+                    *self.mod.REQUIRED_SITE_LINKS,
+                    "</body>",
+                    "</html>",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    def test_validate_repo_accepts_required_public_surfaces(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+
+            self.assertEqual(self.mod.validate_repo(repo_root), [])
+
+    def test_validate_repo_rejects_placeholder_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            placeholder = repo_root / self.mod.ENTRY_PACK_LINK
+            placeholder.parent.mkdir(parents=True, exist_ok=True)
+            placeholder.write_text(
+                "Entry Pack live route placeholder for portal CTA.",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt still contains placeholder text"],
+            )
+
+    def test_validate_repo_rejects_empty_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            entry_pack_link = repo_root / self.mod.ENTRY_PACK_LINK
+            entry_pack_link.parent.mkdir(parents=True, exist_ok=True)
+            entry_pack_link.write_text("  \n", encoding="utf-8")
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt is empty"],
+            )
+
+    def test_validate_repo_rejects_non_https_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            entry_pack_link = repo_root / self.mod.ENTRY_PACK_LINK
+            entry_pack_link.parent.mkdir(parents=True, exist_ok=True)
+            entry_pack_link.write_text("http://example.test/entry-pack", encoding="utf-8")
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt must contain exactly one https URL when present"],
+            )
+
+    def test_validate_repo_rejects_missing_public_document(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            missing_doc = repo_root / self.mod.REQUIRED_PUBLIC_DOCS[0]
+            missing_doc.unlink()
+
+            self.assertIn(
+                "missing required public document: docs/public/entry_pack_architecture_v0_1.md",
+                self.mod.validate_repo(repo_root),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a public-safe Stripe activation plan for the Architecture Entry Pack v0.1 route.

- Adds `docs/governance/stripe_entry_pack_activation_plan.md` as the payment-channel gate.
- Links the plan from the root README governance section.
- Links the plan from the Architecture Entry Pack offer draft.
- Records the decision that the older prompt-based lane stays legacy/hold while the first current route is Architecture Entry Pack v0.1.

## Boundary

- No Stripe mutation in this PR.
- No payment link, product, price, customer, webhook, Checkout integration, Function, or backend activation.
- No Stripe object IDs published.
- No raw Notion URLs or page IDs.
- No secrets, tokens, wallets, raw exports, private trigger tables, Track C content, or protected TNPX mechanics.

## Validation

- `git diff --check HEAD~2..HEAD`
- `python scripts/validate_docs.py`
- Targeted scan for Notion URLs/page IDs, Stripe object IDs, token/secret/wallet patterns.

## Next Gate

Stripe payment activation requires a later explicit command: `GO Stripe Entry Pack create payment link`.