### PR TITLE
docs: add Gumroad Entry Pack activation plan

### DIFF
--- a/docs/governance/gumroad_entry_pack_activation_plan.md
+++ b/docs/governance/gumroad_entry_pack_activation_plan.md
@@ -1,0 +1,211 @@
+# Gumroad Entry Pack Activation Plan v0.1
+
+Status: BIZ / commerce activation plan  
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Route: Gumroad first-sale test  
+Price anchor: USD 19  
+Boundary: digital documentation product only  
+Trace: prepared 2026-05-25 after Gumroad route review
+
+## Purpose
+
+This document defines the first public commercial wrapper for TerraNova / FerrAI.
+
+The goal is to test whether a public-safe architecture documentation product can
+be sold as a clear digital artifact without exposing private workspace material,
+token mechanics, investment claims, consulting services or protected research
+layers.
+
+## Why Gumroad First
+
+Gumroad is the first route because it is optimized for direct digital products,
+e-books, courses and downloadable documentation products. It also avoids a custom
+checkout implementation during the first market proof.
+
+Current source check, 2026-05-25:
+
+- Gumroad pricing page lists `10% + $0.50` per transaction for direct/profile
+  sales and `30%` for new customers who buy through Discover.
+- Gumroad pricing page states that Gumroad acts as Merchant of Record for sales
+  tax handling.
+- Gumroad prohibited-products page blocks several relevant risk categories,
+  including consulting firms, virtual currency/cryptocurrency/NFT products,
+  hacking/cracking materials, investment/business-opportunity services and
+  other prohibited services.
+
+Source URLs:
+
+- https://gumroad.com/pricing
+- https://gumroad.com/prohibited
+
+Because those pages can change, the pricing and prohibited-product wording must
+be rechecked before publication.
+
+## Product Definition
+
+The product is:
+
+```text
+TerraNova / FerrAI Architecture Entry Pack v0.1
+```
+
+It is a digital documentation product containing public-safe architecture,
+governance and semantic model material.
+
+It is not a token, not an NFT, not an investment product, not consulting, not a
+private-access pass and not a security exploitation manual.
+
+## Initial Price Anchor
+
+Initial manual Gumroad test price:
+
+```text
+USD 19
+```
+
+Rationale:
+
+- Low enough for a first market proof.
+- High enough to signal structured intellectual work.
+- Simple enough for direct Gumroad checkout.
+- Does not imply investment value, token access or private system access.
+
+This repository does not create an active Gumroad product, checkout link or live
+price. The product page is created manually in the Gumroad UI after final review.
+
+## Included Product Material
+
+The first product may include:
+
+- Architecture Entry Pack Markdown or PDF.
+- Public semantic architecture release file.
+- HTML version if available.
+- Public artifact map.
+- Boundary and non-claim statement.
+- Short orientation note.
+
+## Excluded Material
+
+Do not include:
+
+- raw Notion exports,
+- raw Notion URLs or page IDs,
+- private trigger tables,
+- Schattenarchiv / SIGMA material,
+- wallet addresses,
+- token sale mechanics,
+- DAO access rights,
+- investment language,
+- consulting promises,
+- protected TNPX draft mechanics,
+- illegal hacking, cracking or exploit instructions,
+- private chats or personal data.
+
+## Compliance Position
+
+Frame the product as:
+
+```text
+digital documentation / architecture reference
+```
+
+Do not frame it as:
+
+```text
+investment
+token sale
+crypto product
+NFT product
+consulting
+business opportunity
+financial advice
+legal advice
+security exploitation guide
+private workspace access
+```
+
+## Public Non-Claims
+
+The product does not include, grant, sell, reserve, imply or represent any token,
+NFT, DAO right, investment right, financial instrument or private system access.
+
+The product does not claim:
+
+- guaranteed financial return,
+- patent grant,
+- legal compliance certification,
+- medical, psychological or therapeutic effect,
+- access to private systems,
+- access to tokens, wallets or DAO voting,
+- implementation support,
+- personalized consulting.
+
+## Suggested Product Name
+
+```text
+TerraNova / FerrAI Architecture Entry Pack v0.1
+```
+
+## Suggested Subtitle
+
+```text
+A public-safe entry bundle for semantic architecture, CIC governance and human-AI cooperation models.
+```
+
+## First Sales Hypothesis
+
+A small public audience may be willing to pay USD 19 for a compact, curated,
+public-safe introduction to the TerraNova / FerrAI architecture if the offer is
+clear, bounded and professionally packaged.
+
+## Success Criteria
+
+The first test is successful if:
+
+- Gumroad listing is approved and live.
+- Product can be purchased.
+- Delivery files are correct.
+- No prohibited claims are present.
+- No private data is included.
+- First external buyer or meaningful checkout interest appears.
+- User feedback identifies the next packaging improvement.
+
+## Failure Criteria
+
+Pause or revise if:
+
+- Gumroad flags the product.
+- Product wording implies crypto, investment or consulting.
+- Private material is accidentally included.
+- Buyers misunderstand it as token, DAO or private workspace access.
+- The product is too abstract to understand.
+
+## Manual Gumroad UI Steps
+
+1. Create a new digital product in Gumroad.
+2. Use the title and copy from `docs/public/gumroad_listing_copy_v0_1.md`.
+3. Set price to USD 19 for the first test.
+4. Upload only reviewed public-safe files.
+5. Keep Discover optional and review wording before enabling broader exposure.
+6. Publish only after final boundary check.
+
+## Next Actions
+
+1. Review this activation plan.
+2. Review `docs/public/gumroad_listing_copy_v0_1.md`.
+3. Prepare product bundle files.
+4. Run public-boundary scan.
+5. Create Gumroad product page manually in UI.
+6. Upload files.
+7. Publish after final boundary check.
+
+## Explicit Publication Gate
+
+The exact external publication command is:
+
+```text
+GO Gumroad Entry Pack publish
+```
+
+Until that command is given, this repository contains planning and listing copy
+only. It does not create a live Gumroad product or payment route.

--- a/docs/public/gumroad_listing_copy_v0_1.md
+++ b/docs/public/gumroad_listing_copy_v0_1.md
@@ -1,0 +1,140 @@
+# Gumroad Listing Copy v0.1
+
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Price: USD 19  
+Status: listing draft, not yet active sale  
+Boundary: public-safe digital documentation product  
+Trace: prepared 2026-05-25 for manual Gumroad UI setup
+
+## Product Title
+
+TerraNova / FerrAI Architecture Entry Pack v0.1
+
+## Short Subtitle
+
+A public-safe entry bundle for semantic architecture, CIC governance and human-AI cooperation models.
+
+## Short Description
+
+TerraNova / FerrAI Architecture Entry Pack v0.1 is a compact digital
+documentation bundle introducing the public architecture of TerraNova / FerrAI:
+semantic triggers, the Semantic Core Layer, iterative interaction collapse, the
+Lenhard Decoding Module, the Lenhard Model, Mermaid Cluster and CIC governance.
+
+This is an architecture reference product. It is not a token, NFT, investment,
+consulting service, private workspace access or security exploitation guide.
+
+## Long Description
+
+This entry pack gives you a structured first view into the TerraNova / FerrAI
+architecture.
+
+It introduces a public-safe model for human-AI cooperation based on semantic
+routing, traceable artifacts, governance boundaries and source-aware
+documentation.
+
+Inside the pack, you receive a curated set of public documentation files
+explaining:
+
+- Semantic Trigger Architecture
+- Semantic Core Layer
+- Iterative Interaction Collapse
+- Recursive-Iterative Interaction Collapse
+- Lenhard Decoding Module
+- Lenhard Model
+- Mermaid Cluster
+- CIC governance framing
+- Public boundary and source-of-record logic
+
+The material is designed as a reference and orientation layer for people
+interested in AI cooperation systems, semantic architecture, knowledge
+governance, documentation systems and human-AI workflow design.
+
+## What You Get
+
+- Public semantic architecture release file.
+- Architecture Entry Pack document.
+- Boundary and non-claims sheet.
+- Public artifact map.
+- Markdown source version where available.
+- PDF or HTML version where available.
+
+## What This Is
+
+This is:
+
+- a digital documentation product,
+- an architecture reference,
+- a public-safe introduction,
+- a structured model overview,
+- a starting point for understanding TerraNova / FerrAI.
+
+## What This Is Not
+
+This is not:
+
+- a token sale,
+- an NFT,
+- an investment product,
+- financial advice,
+- legal advice,
+- medical advice,
+- consulting,
+- private workspace access,
+- DAO access,
+- a hacking or cracking manual,
+- a promise of implementation support.
+
+## Who It Is For
+
+This pack may be useful for:
+
+- AI researchers and builders,
+- documentation architects,
+- governance designers,
+- founders exploring human-AI workflows,
+- people interested in semantic systems,
+- readers following TerraNova / FerrAI public releases.
+
+## Boundary Note
+
+This product contains only public-safe synthesized documentation.
+
+It does not include raw Notion exports, private trigger tables, private chats,
+wallet information, token mechanics, protected patent drafts or internal
+workspace data.
+
+The product does not include, grant, sell, reserve, imply or represent any
+token, NFT, DAO right, investment right, financial instrument or private system
+access.
+
+## Suggested Price
+
+USD 19
+
+## Suggested Gumroad Category
+
+Digital product / e-book / documentation
+
+## Suggested Cover Text
+
+```text
+TerraNova / FerrAI
+Architecture Entry Pack v0.1
+
+Semantic architecture
+CIC governance
+Human-AI cooperation
+```
+
+## Refund / Support Note
+
+This is a digital documentation product. Please read the product description
+carefully before purchasing.
+
+No personalized consulting or implementation support is included.
+
+## Manual Product Page Note
+
+This file is listing copy only. The actual Gumroad product page must be created
+manually in the Gumroad UI after final boundary review.


### PR DESCRIPTION
## Summary

- Adds `docs/governance/gumroad_entry_pack_activation_plan.md` for the first Gumroad route of the Architecture Entry Pack v0.1.
- Adds `docs/public/gumroad_listing_copy_v0_1.md` as manual Gumroad UI listing copy.
- Sets USD 19 as the first test price anchor.
- Keeps Gumroad publication behind a later explicit `GO Gumroad Entry Pack publish` gate.

## Boundary

- No live Gumroad product is created by this PR.
- No payment link, checkout object, subscription, token sale, NFT sale, DAO right, private workspace access or consulting offer is created.
- No raw Notion URLs or page IDs.
- No private trigger tables, raw exports, Track C content, wallet data, secrets or protected TNPX draft mechanics.
- No legal, medical or financial advice.

## Validation

- GitHub connector write path used only for docs on branch `codex/gumroad-entry-pack-activation-v0-1`.
- Targeted repo search before patch found no existing Gumroad artifacts.
- Manual review required for Gumroad pricing/prohibited-product wording before external publication.

## Next Gate

External Gumroad page creation and publication requires: `GO Gumroad Entry Pack publish`.