### PR TITLE
docs: add Gumroad Entry Pack bundle files

### DIFF
--- a/docs/public/entry_pack_bundle_v0_1/LICENSE_OR_USAGE_NOTE.md
+++ b/docs/public/entry_pack_bundle_v0_1/LICENSE_OR_USAGE_NOTE.md
@@ -1,0 +1,31 @@
+# License or Usage Note — Entry Pack v0.1
+
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Status: plain-language usage note  
+Boundary: public-safe digital documentation product
+
+## Plain-Language Use
+
+This bundle is provided as a paid digital documentation product.
+
+You may read it, store it for your own reference, and use it to understand the public TerraNova / FerrAI architecture.
+
+## Not Included
+
+This bundle does not include personal consulting, implementation support, private workspace access, payment-provider objects, private source exports, protected draft material, credential material, or commercial rights beyond normal personal reading and reference use.
+
+## Redistribution
+
+Do not resell, repackage or redistribute the bundle as a competing product.
+
+Small excerpts may be quoted for review, citation, commentary or discussion when attribution is kept clear.
+
+## No Legal Advice
+
+This note is a practical usage boundary, not legal advice and not a formal open-source license.
+
+For any broader commercial reuse, request permission from the rights holder.
+
+## Public Boundary
+
+The product does not include, grant, sell, reserve, imply or represent any token, NFT, DAO right, investment right, financial instrument or private system access.

--- a/docs/public/entry_pack_bundle_v0_1/README_START_HERE.md
+++ b/docs/public/entry_pack_bundle_v0_1/README_START_HERE.md
@@ -1,0 +1,65 @@
+# README — Start Here
+
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Bundle status: public-safe delivery bundle draft  
+Route: Gumroad first-sale test  
+Price anchor: USD 19  
+Boundary: digital documentation product only
+
+## Welcome
+
+Thank you for opening the TerraNova / FerrAI Architecture Entry Pack v0.1.
+
+This bundle is a compact entry point into the public TerraNova / FerrAI CIC
+architecture. It introduces the semantic architecture, governance boundary and
+artifact trail without exposing private workspace material.
+
+## Recommended Reading Order
+
+1. `entry_pack_architecture_v0_1.md`
+2. `entry_pack_architecture_boundary_v0_1.md`
+3. `semantic_architecture_public_release_v0_1.md`
+4. `public_semantic_architecture_spine.md`
+5. `artifact_map.md`
+6. `LICENSE_OR_USAGE_NOTE.md`
+
+## What This Bundle Is
+
+This is a digital documentation bundle.
+
+It is intended as an orientation layer for readers who want to understand the
+public TerraNova / FerrAI architecture, including semantic routing, evidence
+layers, governance boundaries and human-AI cooperation models.
+
+## What This Bundle Is Not
+
+This bundle is not:
+
+- a private workspace export,
+- legal, medical, financial or investment advice,
+- consulting or implementation support,
+- private Notion access,
+- DAO access,
+- a token sale,
+- an NFT product,
+- a security exploitation guide,
+- a promise of patent grant or commercial result.
+
+## Public Boundary
+
+The bundle contains only public-safe synthesized documentation.
+
+It does not include raw Notion exports, private trigger tables, private chats,
+wallet information, token mechanics, protected patent drafts or internal
+workspace data.
+
+The product does not include, grant, sell, reserve, imply or represent any
+token, NFT, DAO right, investment right, financial instrument or private system
+access.
+
+## Support Boundary
+
+No personalized consulting or implementation support is included.
+
+Questions, corrections or public-boundary concerns should be routed through the
+public repository or the seller's selected support channel.

--- a/docs/public/entry_pack_bundle_v0_1/artifact_map.md
+++ b/docs/public/entry_pack_bundle_v0_1/artifact_map.md
@@ -1,0 +1,51 @@
+# Artifact Map — Entry Pack v0.1
+
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Bundle status: public-safe delivery bundle draft  
+Boundary: public-safe synthesis only
+
+## Core Bundle Files
+
+| File | Role |
+| --- | --- |
+| `README_START_HERE.md` | Buyer-facing orientation and reading order. |
+| `../entry_pack_architecture_v0_1.md` | Main Architecture Entry Pack document. |
+| `../entry_pack_architecture_boundary_v0_1.md` | Boundary, non-claims and release gate. |
+| `../semantic_architecture_public_release_v0_1.md` | Public semantic architecture release candidate. |
+| `../gumroad_listing_copy_v0_1.md` | Manual Gumroad product-page copy. |
+| `LICENSE_OR_USAGE_NOTE.md` | Plain-language usage boundary. |
+| `bundle_manifest_v0_1.md` | Checklist for the deliverable bundle. |
+
+## Public Architecture References
+
+| Artifact | Role |
+| --- | --- |
+| `../../architecture/public_semantic_architecture_spine.md` | Public semantic architecture spine. |
+| `../../architecture/semantic_trigger_architecture.md` | Semantic trigger architecture. |
+| `../../architecture/semantic_core_layer.md` | Semantic Core Layer. |
+| `../../architecture/iterative_interaction_collapse.md` | Iterative Interaction Collapse. |
+| `../../architecture/recursive_iterative_interaction_collapse.md` | Recursive extension target. |
+| `../../architecture/lenhard_decoding_module.md` | Lenhard Decoding Module. |
+| `../../architecture/lenhard_model.md` | Lenhard Model. |
+| `../../atlas/mermaid_cluster.md` | Mermaid Cluster. |
+
+## Governance References
+
+| Artifact | Role |
+| --- | --- |
+| `../../governance/gumroad_entry_pack_activation_plan.md` | Gumroad route and publication gate. |
+| `../../governance/public_boundary.md` | Repository public boundary. |
+| `../../governance/source_of_record_policy.md` | Source-of-record policy. |
+| `../../governance/chatgpt_connector_runtime_policy.md` | Connector/runtime claim boundary. |
+
+## Excluded From Bundle
+
+The bundle must not include raw workspace exports, private trigger tables, private chats, wallet data, token-sale mechanics, protected patent drafts, payment-provider object IDs, private dashboard URLs, secrets or credentials.
+
+## Publication Gate
+
+The external publication command remains:
+
+```text
+GO Gumroad Entry Pack publish
+```

--- a/docs/public/entry_pack_bundle_v0_1/bundle_manifest_v0_1.md
+++ b/docs/public/entry_pack_bundle_v0_1/bundle_manifest_v0_1.md
@@ -1,0 +1,54 @@
+# Bundle Manifest — Entry Pack v0.1
+
+Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
+Status: delivery bundle draft  
+Route: Gumroad first-sale test  
+Boundary: public-safe documentation only
+
+## Intended Download Folder
+
+```text
+TerraNova_FerrAI_Architecture_Entry_Pack_v0.1/
+```
+
+## Required Files
+
+| File | Status | Role |
+| --- | --- | --- |
+| `README_START_HERE.md` | required | Buyer-facing start page. |
+| `entry_pack_architecture_v0_1.md` | required | Main entry document. |
+| `entry_pack_architecture_boundary_v0_1.md` | required | Boundary and non-claims. |
+| `semantic_architecture_public_release_v0_1.md` | required | Public architecture release candidate. |
+| `public_semantic_architecture_spine.md` | required | Public semantic spine. |
+| `artifact_map.md` | required | File and source map. |
+| `LICENSE_OR_USAGE_NOTE.md` | required | Plain-language usage boundary. |
+
+## Optional Files
+
+| File | Status | Role |
+| --- | --- | --- |
+| `semantic_architecture_public_release_v0_1.html` | optional | Rendered readable version if available. |
+| `semantic_architecture_public_release_v0_1.pdf` | optional | PDF version if available. |
+| `gumroad_listing_copy_v0_1.md` | optional/internal | Listing source copy, not required for buyer delivery. |
+
+## Pre-Upload Checklist
+
+- No raw workspace exports.
+- No private page links or internal IDs.
+- No private trigger tables.
+- No private chats.
+- No wallet data.
+- No token-sale mechanics.
+- No payment-provider object IDs.
+- No protected draft mechanics.
+- No secrets or credentials.
+
+## Publication Gate
+
+A Gumroad draft may be created manually after this bundle is reviewed.
+
+External publication requires:
+
+```text
+GO Gumroad Entry Pack publish
+```


### PR DESCRIPTION
## Summary

- Adds buyer-facing bundle files for the TerraNova / FerrAI Architecture Entry Pack v0.1.
- Adds a start-here file, artifact map, usage note and bundle manifest under `docs/public/entry_pack_bundle_v0_1/`.
- Keeps the bundle public-safe and aligned with the Gumroad-first route merged in PR #71.

## Boundary

- No Gumroad product is created by this PR.
- No payment link, checkout object, subscription, token sale, NFT sale, DAO right, private workspace access or consulting offer is created.
- No Stripe mutation.
- No Netlify deploy or production activation.
- No raw Notion URLs or page IDs.
- No private trigger tables, raw exports, Track C content, wallet data, secrets or protected TNPX draft mechanics.

## Bundle Files

- `docs/public/entry_pack_bundle_v0_1/README_START_HERE.md`
- `docs/public/entry_pack_bundle_v0_1/artifact_map.md`
- `docs/public/entry_pack_bundle_v0_1/LICENSE_OR_USAGE_NOTE.md`
- `docs/public/entry_pack_bundle_v0_1/bundle_manifest_v0_1.md`

## Validation

- GitHub connector write path used only for public-safe docs on branch `codex/gumroad-entry-pack-bundle-files-v0-1`.
- Manual review required before Gumroad upload.
- Final external publication remains gated by `GO Gumroad Entry Pack publish`.

## Next Steps

- Review exact download contents.
- Prepare ZIP/PDF/Markdown bundle locally or via a later build PR.
- Create Gumroad draft manually in the UI.
- Test purchase and refund before publication.