### PR TITLE
site: add Gumroad Entry Pack CTA placeholder

### DIFF
--- a/site/entry-pack-link.txt
+++ b/site/entry-pack-link.txt
@@ -1,0 +1,2 @@
+Entry Pack live route placeholder for portal CTA.
+Replace with the verified direct product link in the final review.


### PR DESCRIPTION
## Summary

- Starts the Netlify/Gumroad CTA lane without triggering a Netlify deploy.
- Adds a placeholder note under `site/` for the live Entry Pack route.
- The direct Gumroad URL update to `site/index.html` was attempted but blocked by the safety filter in this run.

## Boundary

- No Netlify deploy.
- No Stripe payment link.
- No new payment route.
- No secrets, wallets, raw Notion URLs, private exports or protected material.

## Current state

Gumroad is already the primary live route. This PR is only the portal-link preparation lane.

## Next steps

- Human or later AI-safe patch should replace the placeholder with the verified Gumroad product URL in `site/index.html`.
- Keep Netlify builds paused until credits reset or manual resume is explicitly chosen.