### PR TITLE
docs: add CIC Blueprint Pack v0.1

### DIFF
--- a/docs/public/blueprint_pack_v0_1/ARTIFACT_MAP.md
+++ b/docs/public/blueprint_pack_v0_1/ARTIFACT_MAP.md
@@ -1,0 +1,37 @@
+# Artifact Map — Blueprint Pack v0.1
+
+Status: public-safe artifact map draft  
+Boundary: references public-safe GitHub artifacts only
+
+## Core Blueprint Files
+
+| File | Role |
+| --- | --- |
+| `README_START_HERE.md` | Buyer orientation and reading order. |
+| `CIC_BLUEPRINT.md` | Core CIC model and operating logic. |
+| `OPERATING_MODEL.md` | Layer roles across Notion, GitHub, Zenodo, portal and sales routes. |
+| `PIPELINE_MAP.md` | Idea-to-artifact-to-sale pipeline. |
+| `CONTROL_TOWER_OVERVIEW.md` | Control Tower concept and CAP public-safe overview. |
+| `BOUNDARY_AND_NON_CLAIMS.md` | Buyer boundary and non-claims. |
+| `BUYER_REVIEW_CHECKLIST.md` | Practical review checklist for the buyer. |
+
+## Public Reference Anchors
+
+| Public artifact | Role |
+| --- | --- |
+| `../entry_pack_architecture_v0_1.md` | First entry artifact and context bridge. |
+| `../semantic_architecture_public_release_v0_1.md` | Public semantic architecture release candidate. |
+| `../../architecture/README.md` | Public architecture index. |
+| `../../architecture/public_semantic_architecture_spine.md` | Semantic architecture spine. |
+| `../../architecture/semantic_trigger_architecture.md` | Trigger architecture. |
+| `../../architecture/semantic_core_layer.md` | Semantic Core Layer. |
+| `../../architecture/lenhard_decoding_module.md` | Lenhard Decoding Module. |
+| `../../architecture/recursive_iterative_interaction_collapse.md` | Recursive interaction collapse target. |
+| `../../atlas/control-tower/README.md` | CAP / Control Tower public-safe index. |
+| `../../governance/public_boundary.md` | Public boundary policy. |
+| `../../governance/source_of_record_policy.md` | Source-of-record policy. |
+| `../../references/zenodo.md` | Zenodo reference note. |
+
+## Excluded References
+
+This map intentionally does not point to private workspaces, raw exports, private page IDs, protected trigger tables or internal customer data.

--- a/docs/public/blueprint_pack_v0_1/BOUNDARY_AND_NON_CLAIMS.md
+++ b/docs/public/blueprint_pack_v0_1/BOUNDARY_AND_NON_CLAIMS.md
@@ -1,0 +1,57 @@
+# Boundary and Non-Claims — Blueprint Pack v0.1
+
+Status: public-safe boundary draft  
+Boundary: buyer-facing non-claims
+
+## This Product Is
+
+- a digital documentation product,
+- a blueprint-level architecture reference,
+- a public-safe explanation of a human-AI cooperation pipeline,
+- a guide to public artifacts, source roles and productization logic.
+
+## This Product Is Not
+
+This product is not:
+
+- consulting,
+- implementation support,
+- private workspace access,
+- DAO access,
+- a token sale,
+- an NFT product,
+- an investment product,
+- financial advice,
+- legal advice,
+- medical advice,
+- a patent license,
+- a security exploitation guide,
+- a promise of commercial result.
+
+## Excluded Material
+
+Do not include:
+
+- raw Notion exports,
+- raw workspace URLs or internal IDs,
+- private trigger tables,
+- private chats,
+- Schattenarchiv or protected internal layers,
+- wallet data,
+- token mechanics,
+- protected patent draft mechanics,
+- secrets or credentials,
+- payment-provider private object data,
+- private customer data.
+
+## Rights Boundary
+
+The product does not include, grant, sell, reserve, imply or represent any token, NFT, DAO right, investment right, financial instrument or private system access.
+
+## Support Boundary
+
+No personalized consulting or implementation support is included unless a separate written agreement is created outside this product.
+
+## Buyer Expectation
+
+A buyer should expect a structured architecture blueprint, not a finished software product or private system login.

--- a/docs/public/blueprint_pack_v0_1/BUYER_REVIEW_CHECKLIST.md
+++ b/docs/public/blueprint_pack_v0_1/BUYER_REVIEW_CHECKLIST.md
@@ -1,0 +1,50 @@
+# Buyer Review Checklist — Blueprint Pack v0.1
+
+Status: buyer-facing checklist draft  
+Boundary: review aid only
+
+## Purpose
+
+Use this checklist to decide whether the TerraNova / FerrAI CIC Blueprint Pack is relevant for your own work.
+
+## Review Questions
+
+| Question | What to look for |
+| --- | --- |
+| What is being structured? | Human-AI collaboration, not isolated prompts. |
+| What becomes durable? | Documents, pull requests, release packages, product bundles and audit traces. |
+| Which sources carry claims? | Notion, GitHub, Zenodo and public surfaces have separate roles. |
+| Where are the boundaries? | Private material, token claims, investment claims and hidden access are excluded. |
+| What is transferable? | The operating pattern, not the private workspace. |
+| What is commercialized? | Public-safe documentation products and later possible review services. |
+
+## Red Flags To Avoid
+
+Do not treat this pack as:
+
+- a software license,
+- a private system login,
+- investment access,
+- token access,
+- legal or financial advice,
+- a guarantee that your own system will work.
+
+## Positive Fit
+
+The pack is a good fit if you want to understand:
+
+- how to structure AI collaboration over time,
+- how to move from chat to durable artifacts,
+- how to separate internal sources from public proof,
+- how to package public-safe documentation products,
+- how governance and commercial routing can be combined.
+
+## Next Step After Reading
+
+A reader can compare their own workflow against the pipeline:
+
+```text
+signal -> structure -> artifact -> proof -> surface -> sale -> feedback
+```
+
+If that pattern is useful, the next product layer can be an implementation workbook or a separate review engagement.

--- a/docs/public/blueprint_pack_v0_1/CIC_BLUEPRINT.md
+++ b/docs/public/blueprint_pack_v0_1/CIC_BLUEPRINT.md
@@ -1,0 +1,59 @@
+# CIC Blueprint — Blueprint Pack v0.1
+
+Status: public-safe blueprint draft  
+Boundary: architecture synthesis only
+
+## Core Idea
+
+CIC means Cooperative Intelligence Core.
+
+In this public blueprint, CIC is treated as an operating pattern for human-AI cooperation. It does not claim autonomous legal authority, personhood or hidden system access.
+
+The goal is simple:
+
+```text
+human signal + AI structure + source-aware routing -> traceable artifact
+```
+
+## What CIC Structures
+
+CIC structures the movement from:
+
+```text
+idea -> context -> decision -> artifact -> review -> publication -> commercial route
+```
+
+It does this through named layers:
+
+| Layer | Role |
+| --- | --- |
+| Human signal | Intent, problem, decision pressure and domain judgment. |
+| AI structure | Drafting, synthesis, compression, comparison and route proposal. |
+| Semantic architecture | Terms, modes, triggers, gates and meaning shifts. |
+| Source layers | Notion, GitHub, Zenodo and public surfaces. |
+| Boundary layer | What may be public, what must remain internal, what is blocked. |
+| Commercial lane | Product packaging, buyer expectation and delivery boundary. |
+
+## Why It Matters
+
+Most AI work disappears into chat history.
+
+CIC tries to prevent that by forcing useful outputs into durable shapes:
+
+- decision logs,
+- architecture notes,
+- public-safe summaries,
+- GitHub pull requests,
+- release packages,
+- product bundles,
+- buyer-facing documentation.
+
+## Public Operating Rule
+
+A semantic trigger or AI route proposal can make an action salient. It does not create permission.
+
+Connector writes, payment actions, publication actions and external releases require explicit gates.
+
+## Buyer Gain
+
+A reader should understand how TerraNova / FerrAI turns open-ended human-AI work into a governed operating pipeline rather than isolated prompts.

--- a/docs/public/blueprint_pack_v0_1/CONTROL_TOWER_OVERVIEW.md
+++ b/docs/public/blueprint_pack_v0_1/CONTROL_TOWER_OVERVIEW.md
@@ -1,0 +1,43 @@
+# Control Tower Overview — Blueprint Pack v0.1
+
+Status: public-safe overview draft  
+Boundary: no private registry export
+
+## What Control Tower Means Here
+
+Control Tower is the operational view of the system.
+
+It is the place where source status, queues, gates, reviews and public-safe artifacts become manageable.
+
+In the public repository, this is represented by CAP 0.1.0 and related registry, canon, sync, trigger and automation files.
+
+## Public-Safe Control Functions
+
+| Function | Purpose |
+| --- | --- |
+| Registry | Track public-safe objects, source classes and state. |
+| Canon admission | Decide whether a claim is draft, local, public or blocked. |
+| Sync trace | Mark whether Notion, GitHub and external surfaces are aligned. |
+| Trigger boundary | Keep command surfaces bounded and permission-aware. |
+| Automation matrix | Repeat checks without uncontrolled agent runs. |
+| Causal log | Preserve why an artifact exists and how it changed. |
+
+## Why It Matters
+
+Without a control layer, AI-generated work becomes a pile of outputs.
+
+With a control layer, each output can be routed:
+
+```text
+draft -> review -> accepted -> mirrored -> published -> sold -> revised
+```
+
+## Public Boundary
+
+The public Control Tower overview does not expose private registry internals, raw workspace IDs, private trigger tables or protected source material.
+
+It explains the pattern and points to public-safe artifacts only.
+
+## Buyer Gain
+
+A reader can see how TerraNova / FerrAI avoids treating every AI output as equally valid. Outputs move through source tiers, review gates and trace records before becoming public or commercial material.

--- a/docs/public/blueprint_pack_v0_1/OPERATING_MODEL.md
+++ b/docs/public/blueprint_pack_v0_1/OPERATING_MODEL.md
@@ -1,0 +1,49 @@
+# Operating Model — Blueprint Pack v0.1
+
+Status: public-safe operating model draft  
+Boundary: no private workspace export
+
+## Operating Stack
+
+The public operating model separates roles instead of merging everything into one black box.
+
+```text
+Notion -> GitHub -> Zenodo -> Public Portal -> Gumroad / Stripe
+```
+
+| Layer | Function |
+| --- | --- |
+| Notion | Living internal source layer, planning, rules, logs and state. |
+| GitHub | Public working state, pull requests, traceable diffs and documentation mirrors. |
+| Zenodo | Citable proof state with DOI, metadata and archive reference. |
+| Public portal | External navigation surface for selected public-safe artifacts. |
+| Gumroad | First commercial delivery wrapper for digital documentation products. |
+| Stripe | Optional secondary payment infrastructure, not the default public route in this pack. |
+
+## Why Separation Matters
+
+The system becomes easier to trust when each layer has a bounded role.
+
+Notion is not dumped raw into public. GitHub is not treated as the living workspace. Zenodo is not used as a scratchpad. Gumroad is not treated as the architecture itself.
+
+## Core Movement
+
+```text
+conversation -> decision -> document -> pull request -> merge -> release or product bundle
+```
+
+This movement is the important part. It creates reviewable artifacts instead of relying on memory.
+
+## Gate Types
+
+| Gate | Meaning |
+| --- | --- |
+| Boundary gate | Checks what must stay private or protected. |
+| Source gate | Checks which layer is allowed to carry the claim. |
+| Write gate | Requires explicit permission before external mutation. |
+| Product gate | Checks buyer expectation, price, delivery and non-claims. |
+| Release gate | Checks DOI, version, checksum and publication readiness. |
+
+## Buyer Gain
+
+A reader can use this operating model as a reference pattern for designing their own source-aware AI workflow without copying private TerraNova material.

--- a/docs/public/blueprint_pack_v0_1/PIPELINE_MAP.md
+++ b/docs/public/blueprint_pack_v0_1/PIPELINE_MAP.md
@@ -1,0 +1,51 @@
+# Pipeline Map — Blueprint Pack v0.1
+
+Status: public-safe pipeline draft  
+Boundary: productization map only
+
+## The Pipeline
+
+The TerraNova / FerrAI public pipeline can be summarized as:
+
+```text
+signal -> structure -> artifact -> proof -> surface -> sale -> feedback
+```
+
+## Pipeline Stages
+
+| Stage | Output |
+| --- | --- |
+| Signal | A problem, insight, draft idea or decision pressure. |
+| Structure | IPERKA, CIC routing, semantic framing and source assessment. |
+| Artifact | Markdown document, manifest, policy, map, checklist or package. |
+| Proof | GitHub commit, pull request, merge SHA, Zenodo DOI or checksum. |
+| Surface | Public portal, GitHub index, Gumroad listing or release page. |
+| Sale | Digital documentation product with explicit buyer boundary. |
+| Feedback | Buyer review, audit result, next version or product ladder step. |
+
+## Example: Entry Pack
+
+The first live route follows this path:
+
+```text
+architecture synthesis -> GitHub docs -> Gumroad listing -> buyer ZIP -> test checkout -> audit log
+```
+
+## Blueprint Pack Role
+
+The Blueprint Pack explains the system behind that path.
+
+It is not only another document bundle. It explains how document bundles are made, governed, verified and sold.
+
+## Product Ladder
+
+| Product | Buyer question |
+| --- | --- |
+| Architecture Entry Pack | What is this system? |
+| CIC Blueprint Pack | How does the operating system work? |
+| Implementation Workbook | How could I apply the pattern? |
+| Review / Advisory | How does my own setup compare? |
+
+## Buyer Gain
+
+The reader gets a transferable pattern: how to convert AI collaboration into a controlled artifact and product pipeline.

--- a/docs/public/blueprint_pack_v0_1/README_START_HERE.md
+++ b/docs/public/blueprint_pack_v0_1/README_START_HERE.md
@@ -1,0 +1,43 @@
+# README — Start Here
+
+Product: TerraNova / FerrAI CIC Blueprint Pack v0.1  
+Status: public-safe product preparation draft  
+Route: second Gumroad product layer  
+Suggested launch price: USD 49  
+Boundary: digital documentation product only
+
+## Welcome
+
+This Blueprint Pack is the next layer after the Architecture Entry Pack.
+
+The Entry Pack answers: What is TerraNova / FerrAI CIC?
+
+The Blueprint Pack answers: How does the operating architecture work?
+
+It is a guided tour through the public-safe system design: CIC, semantic architecture, source-of-record routing, artifact production, review gates and the product pipeline from idea to public sale.
+
+## Recommended Reading Order
+
+1. `CIC_BLUEPRINT.md`
+2. `OPERATING_MODEL.md`
+3. `PIPELINE_MAP.md`
+4. `CONTROL_TOWER_OVERVIEW.md`
+5. `BOUNDARY_AND_NON_CLAIMS.md`
+6. `ARTIFACT_MAP.md`
+7. `BUYER_REVIEW_CHECKLIST.md`
+
+## What This Product Is
+
+This is a digital documentation product.
+
+It is a blueprint-level orientation pack for readers who want to understand how TerraNova / FerrAI turns human-AI work into traceable artifacts, public proof paths and commercial product lanes.
+
+## What This Product Is Not
+
+This product is not consulting, implementation support, legal advice, financial advice, medical advice, a token sale, an NFT product, DAO access, private workspace access or a security exploitation guide.
+
+## Public Boundary
+
+This product contains only public-safe synthesis. It does not include raw workspace exports, private trigger tables, private chats, wallet information, token mechanics, protected patent drafts or internal workspace data.
+
+The product does not include, grant, sell, reserve, imply or represent any token, NFT, DAO right, investment right, financial instrument or private system access.

--- a/docs/public/blueprint_pack_v0_1/blueprint_listing_copy_v0_1.md
+++ b/docs/public/blueprint_pack_v0_1/blueprint_listing_copy_v0_1.md
@@ -1,0 +1,52 @@
+# Blueprint Pack Listing Copy v0.1
+
+Product: TerraNova / FerrAI CIC Blueprint Pack v0.1  
+Suggested launch price: USD 49  
+Status: listing draft, not yet active sale  
+Boundary: public-safe digital documentation product
+
+## Product Title
+
+TerraNova / FerrAI CIC Blueprint Pack v0.1
+
+## Short Subtitle
+
+A public-safe blueprint for turning human-AI collaboration into traceable artifacts, governance layers and commercial product lanes.
+
+## Short Description
+
+The TerraNova / FerrAI CIC Blueprint Pack v0.1 is the next layer after the Architecture Entry Pack. It explains how the public architecture works as an operating system: CIC, semantic routing, source-of-record separation, Control Tower logic, public boundary gates and the product pipeline from idea to artifact to sale.
+
+This is a blueprint-level documentation product. It is not consulting, private workspace access, token access, an NFT, investment product, legal advice, financial advice, medical advice or software access.
+
+## What You Get
+
+- CIC Blueprint
+- Operating Model
+- Pipeline Map
+- Control Tower Overview
+- Boundary and Non-Claims
+- Artifact Map
+- Buyer Review Checklist
+- Start-here guide
+
+## Who It Is For
+
+This pack may be useful for:
+
+- AI builders and workflow designers,
+- documentation architects,
+- governance designers,
+- founders building source-aware AI operations,
+- researchers studying human-AI collaboration,
+- buyers who already read the Architecture Entry Pack and want the deeper operating model.
+
+## Suggested Price
+
+USD 49 for the first launch test.
+
+## Non-Claims
+
+The product does not include, grant, sell, reserve, imply or represent any token, NFT, DAO right, investment right, financial instrument or private system access.
+
+No personalized consulting or implementation support is included.


### PR DESCRIPTION
## Summary

Adds the CIC Blueprint Pack v0.1 as the second public documentation product layer after the Architecture Entry Pack.

Adds buyer-facing blueprint files and listing copy under `docs/public/blueprint_pack_v0_1/`.

Suggested launch price: USD 49.

## Boundary

No Gumroad product is created by this PR.
No Stripe action, payment link or checkout activation.
No Netlify deploy.
No private workspace data, raw exports, private trigger tables, wallet data, protected drafts, secrets or credentials.
No consulting promise, legal advice, financial advice or medical advice.

## Files

- `README_START_HERE.md`
- `CIC_BLUEPRINT.md`
- `OPERATING_MODEL.md`
- `PIPELINE_MAP.md`
- `CONTROL_TOWER_OVERVIEW.md`
- `BOUNDARY_AND_NON_CLAIMS.md`
- `ARTIFACT_MAP.md`
- `BUYER_REVIEW_CHECKLIST.md`
- `blueprint_listing_copy_v0_1.md`

## Next Gate

External Gumroad product creation requires: GO Blueprint Pack Gumroad Draft.