### PR TITLE
docs: add CIC Implementation Workbook v0.1

### DIFF
--- a/docs/public/implementation_workbook_v0_1/BUYER_ACTION_CHECKLIST.md
+++ b/docs/public/implementation_workbook_v0_1/BUYER_ACTION_CHECKLIST.md
@@ -1,0 +1,51 @@
+# Buyer Action Checklist — Implementation Workbook v0.1
+
+Status: buyer-facing action checklist  
+Boundary: self-guided checklist only
+
+## Use This Checklist After Reading
+
+| Action | Done |
+| --- | --- |
+| I wrote a one-sentence scope note. |  |
+| I mapped my private, working, proof, public and sales layers. |  |
+| I chose one artifact to create first. |  |
+| I defined what must not be exposed. |  |
+| I wrote a non-claims statement. |  |
+| I chose a publication or sale route. |  |
+| I checked that the buyer or reader can understand the offer without private context. |  |
+| I set a review or observation window. |  |
+
+## Minimum Viable CIC-Style Lane
+
+A small first lane can be as simple as:
+
+```text
+one problem -> one scope note -> one artifact -> one boundary check -> one public or buyer surface
+```
+
+## Stop Conditions
+
+Stop and review before publishing if:
+
+- the artifact depends on private context to make sense,
+- the product page implies support that is not included,
+- the price is unclear,
+- delivery files do not match the listing,
+- claims sound like investment, legal, financial or medical advice,
+- raw exports or secrets are included.
+
+## Suggested Next Step
+
+After completing this workbook, create a small internal package:
+
+```text
+MY_CIC_LANE_v0_1/
+├── SCOPE_NOTE.md
+├── SOURCE_MAP.md
+├── ARTIFACT_PIPELINE.md
+├── BOUNDARY_CHECK.md
+└── PUBLICATION_AND_SALE_ROUTE.md
+```
+
+This internal package can become a future public artifact only after review.

--- a/docs/public/implementation_workbook_v0_1/README_START_HERE.md
+++ b/docs/public/implementation_workbook_v0_1/README_START_HERE.md
@@ -1,0 +1,42 @@
+# README — Start Here
+
+Product: TerraNova / FerrAI CIC Implementation Workbook v0.1  
+Status: public-safe buyer-facing workbook draft  
+Route: third Gumroad product layer  
+Suggested launch price: USD 99  
+Boundary: digital documentation and workbook product only
+
+## Welcome
+
+This Implementation Workbook is the third product layer after the Architecture Entry Pack and the CIC Blueprint Pack.
+
+The Entry Pack answers: What is TerraNova / FerrAI CIC?
+
+The Blueprint Pack answers: How does the operating architecture work?
+
+The Implementation Workbook answers: How can I apply the pattern to my own work in a bounded, source-aware way?
+
+## Recommended Reading Order
+
+1. `WORKBOOK_OVERVIEW.md`
+2. `STEP_01_SIGNAL_TO_SCOPE.md`
+3. `STEP_02_SOURCE_MAP.md`
+4. `STEP_03_ARTIFACT_PIPELINE.md`
+5. `STEP_04_BOUNDARY_CHECK.md`
+6. `STEP_05_PUBLICATION_AND_SALE_ROUTE.md`
+7. `WORKSHEETS.md`
+8. `BUYER_ACTION_CHECKLIST.md`
+
+## What This Product Is
+
+This is a structured implementation workbook. It turns the public CIC operating pattern into practical worksheets, checklists and review steps.
+
+It is based on pattern recycling from existing public-safe playbooks, checklists, step plans and governance artifacts. It is not a raw export of internal workspaces.
+
+## What This Product Is Not
+
+This product is not consulting, implementation support, private workspace access, legal advice, financial advice, medical advice, a token sale, an NFT product, DAO access, software access or a guarantee of business results.
+
+## Public Boundary
+
+This workbook contains public-safe synthesis only. It does not include raw Notion exports, private trigger tables, private chats, wallet information, protected patent mechanics, secrets, credentials or private customer data.

--- a/docs/public/implementation_workbook_v0_1/STEP_01_SIGNAL_TO_SCOPE.md
+++ b/docs/public/implementation_workbook_v0_1/STEP_01_SIGNAL_TO_SCOPE.md
@@ -1,0 +1,54 @@
+# Step 01 — Signal To Scope
+
+Status: public-safe workbook step  
+Boundary: no private intake data included
+
+## Goal
+
+Turn a vague signal into a bounded scope.
+
+A signal can be an idea, pain point, repeated decision, messy workflow, research question or product opportunity.
+
+## Exercise
+
+Write one sentence for each prompt:
+
+| Prompt | Your answer |
+| --- | --- |
+| What problem keeps returning? |  |
+| Who needs the result? |  |
+| What output would help them? |  |
+| What should stay out of scope? |  |
+| What would make this useful within 7 days? |  |
+
+## Scope Formula
+
+Use this sentence:
+
+```text
+This workflow helps [person/group] turn [signal/problem] into [artifact/output] without exposing [boundary].
+```
+
+## Example
+
+```text
+This workflow helps a small founder turn scattered AI-chat decisions into a public-safe product brief without exposing private workspace data.
+```
+
+## Gate
+
+Before continuing, check:
+
+- the scope is small enough to finish,
+- the output is concrete,
+- the boundary is named,
+- the buyer or reader is clear,
+- no private material is required to understand the result.
+
+## Output
+
+Create a file or note named:
+
+```text
+SCOPE_NOTE.md
+```

--- a/docs/public/implementation_workbook_v0_1/STEP_02_SOURCE_MAP.md
+++ b/docs/public/implementation_workbook_v0_1/STEP_02_SOURCE_MAP.md
@@ -1,0 +1,49 @@
+# Step 02 — Source Map
+
+Status: public-safe workbook step  
+Boundary: source-role exercise only
+
+## Goal
+
+Separate where information lives before deciding what can be published or sold.
+
+A source map prevents private notes, working drafts, public proof and buyer-facing material from being mixed together.
+
+## Exercise
+
+Fill the table for your own project:
+
+| Source layer | Example surface | What belongs here? | Public? |
+| --- | --- | --- | --- |
+| Living private layer | Notion, local notes, private docs | Raw thinking, logs, internal decisions | No / limited |
+| Working artifact layer | GitHub, shared folder, reviewed docs | Drafts, diffs, source mirrors, review trace | Sometimes |
+| Proof layer | DOI, archive, release record | Versioned proof, citations, checksums | Yes |
+| Public surface | Website, listing, public README | Selected explanation and links | Yes |
+| Sales route | Gumroad, Stripe, invoice | Product page, price, delivery | Yes / buyer-only |
+
+## Source Rule
+
+Each claim should have a home.
+
+```text
+private source != public claim
+working draft != citable proof
+product page != full system access
+```
+
+## Gate
+
+Before continuing, check:
+
+- which layer is the source of record,
+- which layer is only a public mirror,
+- which layer a buyer can see,
+- which layer must never be exposed raw.
+
+## Output
+
+Create a file or note named:
+
+```text
+SOURCE_MAP.md
+```

--- a/docs/public/implementation_workbook_v0_1/STEP_03_ARTIFACT_PIPELINE.md
+++ b/docs/public/implementation_workbook_v0_1/STEP_03_ARTIFACT_PIPELINE.md
@@ -1,0 +1,58 @@
+# Step 03 — Artifact Pipeline
+
+Status: public-safe workbook step  
+Boundary: workflow design exercise only
+
+## Goal
+
+Design a simple route from signal to durable artifact.
+
+An artifact is a concrete output that can be reviewed, versioned, shared or packaged. Examples include a brief, policy, checklist, README, release note, buyer guide or product bundle.
+
+## Pipeline Formula
+
+```text
+signal -> decision -> draft -> review -> artifact -> proof -> surface
+```
+
+## Exercise
+
+Choose one small workflow and fill this map:
+
+| Stage | Your project |
+| --- | --- |
+| Signal |  |
+| Decision needed |  |
+| Draft artifact |  |
+| Reviewer or check |  |
+| Final artifact |  |
+| Proof trace |  |
+| Public or buyer surface |  |
+
+## Artifact Types
+
+| Type | Good for |
+| --- | --- |
+| Brief | Explaining a concept quickly. |
+| Checklist | Making repeatable decisions. |
+| Manifest | Listing files, versions and boundaries. |
+| Policy | Defining rules and non-claims. |
+| Map | Showing how parts relate. |
+| Workbook | Helping a reader apply a pattern. |
+
+## Gate
+
+Before continuing, check:
+
+- one artifact has a named owner,
+- the artifact can be completed in a short cycle,
+- the proof trace is clear,
+- the public surface is not confused with private workspace access.
+
+## Output
+
+Create a file or note named:
+
+```text
+ARTIFACT_PIPELINE.md
+```

--- a/docs/public/implementation_workbook_v0_1/STEP_04_BOUNDARY_CHECK.md
+++ b/docs/public/implementation_workbook_v0_1/STEP_04_BOUNDARY_CHECK.md
@@ -1,0 +1,55 @@
+# Step 04 — Boundary Check
+
+Status: public-safe workbook step  
+Boundary: buyer-facing safety and expectation check
+
+## Goal
+
+Define what must not be exposed, promised or implied.
+
+A boundary check protects the reader, the creator and the buyer from confusing public documentation with private access, investment access, legal advice or implementation support.
+
+## Exercise
+
+Fill the table before publishing or selling anything:
+
+| Boundary class | What is excluded? | How will you say it clearly? |
+| --- | --- | --- |
+| Private material |  |  |
+| Raw exports |  |  |
+| Credentials / secrets |  |  |
+| Customer data |  |  |
+| Financial or legal claims |  |  |
+| Token / NFT / DAO claims |  |  |
+| Consulting or support promises |  |  |
+| Software access claims |  |  |
+
+## Non-Claim Template
+
+Use this sentence where appropriate:
+
+```text
+This product is a digital documentation product. It does not include consulting, private workspace access, software access, token rights, NFT rights, DAO rights, investment rights, legal advice, financial advice, medical advice or a promise of commercial result.
+```
+
+## Public-Safe Test
+
+Ask:
+
+- Could a buyer misunderstand this as access to a private system?
+- Could a buyer misunderstand this as investment opportunity?
+- Could a buyer expect personalized implementation support?
+- Does the product include anything that was never reviewed for public use?
+- Does the product expose raw notes instead of synthesized artifacts?
+
+## Gate
+
+Do not publish until every unclear claim is either removed, softened or explicitly bounded.
+
+## Output
+
+Create a file or note named:
+
+```text
+BOUNDARY_CHECK.md
+```

--- a/docs/public/implementation_workbook_v0_1/STEP_05_PUBLICATION_AND_SALE_ROUTE.md
+++ b/docs/public/implementation_workbook_v0_1/STEP_05_PUBLICATION_AND_SALE_ROUTE.md
@@ -1,0 +1,62 @@
+# Step 05 — Publication And Sale Route
+
+Status: public-safe workbook step  
+Boundary: route planning only, no payment activation
+
+## Goal
+
+Plan how a reviewed artifact becomes visible, downloadable or sellable.
+
+Publication is not the same as sale. A proof record is not the same as a product page. A product page is not the same as private system access.
+
+## Route Map
+
+```text
+artifact -> review -> proof trace -> public surface -> sales route -> feedback
+```
+
+## Exercise
+
+Fill this map for one product or artifact:
+
+| Route element | Your plan |
+| --- | --- |
+| Artifact name |  |
+| Public-safe review done? |  |
+| Proof trace |  |
+| Public surface |  |
+| Sales route |  |
+| Price |  |
+| Delivery files |  |
+| Refund / support boundary |  |
+| Feedback window |  |
+
+## Route Options
+
+| Route | Role |
+| --- | --- |
+| GitHub | Public working state and documentation trace. |
+| Zenodo | Citable proof state and archive reference. |
+| Website / portal | Navigation and trust surface. |
+| Gumroad | Digital product wrapper and delivery route. |
+| Stripe | Optional payment infrastructure for later or parallel checkout. |
+| Email / invoice | Manual commercial route for higher-touch work. |
+
+## Gate
+
+Before publishing or selling, confirm:
+
+- the price is visible,
+- the buyer knows what is included,
+- the buyer knows what is not included,
+- delivery files match the listing,
+- no private material is attached,
+- the public proof path is not overstated.
+
+## Output
+
+Create a file or note named:
+
+```text
+PUBLICATION_AND_SALE_ROUTE.md
+```

--- a/docs/public/implementation_workbook_v0_1/WORKBOOK_OVERVIEW.md
+++ b/docs/public/implementation_workbook_v0_1/WORKBOOK_OVERVIEW.md
@@ -1,0 +1,48 @@
+# Workbook Overview — Implementation Workbook v0.1
+
+Status: public-safe workbook draft  
+Boundary: pattern implementation aid only
+
+## Purpose
+
+The Implementation Workbook helps a reader build a small, bounded CIC-style workflow for their own project.
+
+It does not ask the reader to copy TerraNova / FerrAI internals. Instead, it translates the public operating pattern into exercises:
+
+```text
+signal -> scope -> source map -> artifact pipeline -> boundary check -> publication or sale route
+```
+
+## Who This Is For
+
+This workbook is for readers who want to move from passive understanding to applied structure:
+
+- founders,
+- AI builders,
+- documentation architects,
+- researchers,
+- operators,
+- creators packaging knowledge work,
+- people who already read the Entry Pack or Blueprint Pack.
+
+## What You Will Produce
+
+By the end, the reader should have:
+
+| Output | Description |
+| --- | --- |
+| Scope note | A short statement of what the workflow is meant to structure. |
+| Source map | A map of private, working, citable and public surfaces. |
+| Artifact pipeline | A route from idea to document to proof to buyer surface. |
+| Boundary checklist | A list of what must not be exposed or claimed. |
+| Publication route | A simple plan for release, product page or review gate. |
+
+## Operating Rule
+
+Small, verified outputs beat large, unbounded dumps.
+
+The workbook is designed to create one small operational lane first, then let the reader expand only after the boundary is stable.
+
+## Buyer Gain
+
+A buyer gets a practical bridge from architecture to action: not just what CIC means, but how to sketch a responsible source-aware workflow in their own context.

--- a/docs/public/implementation_workbook_v0_1/WORKSHEETS.md
+++ b/docs/public/implementation_workbook_v0_1/WORKSHEETS.md
@@ -1,0 +1,84 @@
+# Worksheets — Implementation Workbook v0.1
+
+Status: public-safe workbook worksheets  
+Boundary: templates only
+
+## Worksheet 1 — Scope Note
+
+```text
+This workflow helps [person/group] turn [signal/problem] into [artifact/output] without exposing [boundary].
+```
+
+My scope note:
+
+```text
+
+```
+
+## Worksheet 2 — Source Map
+
+| Layer | My source | Public status | Notes |
+| --- | --- | --- | --- |
+| Living private layer |  |  |  |
+| Working artifact layer |  |  |  |
+| Proof layer |  |  |  |
+| Public surface |  |  |  |
+| Sales route |  |  |  |
+
+## Worksheet 3 — Artifact Pipeline
+
+| Stage | My answer |
+| --- | --- |
+| Signal |  |
+| Decision |  |
+| Draft |  |
+| Review |  |
+| Final artifact |  |
+| Proof trace |  |
+| Public surface |  |
+
+## Worksheet 4 — Boundary Statement
+
+This product or artifact is:
+
+```text
+
+```
+
+This product or artifact is not:
+
+```text
+
+```
+
+Excluded material:
+
+```text
+
+```
+
+## Worksheet 5 — Sale Route
+
+| Question | My answer |
+| --- | --- |
+| What is being sold? |  |
+| Price |  |
+| Files included |  |
+| Files excluded |  |
+| Delivery route |  |
+| Public proof path |  |
+| Refund/support boundary |  |
+| Observation window |  |
+
+## Final Check
+
+Before publishing, answer yes or no:
+
+| Check | Yes / No |
+| --- | --- |
+| Buyer can understand the offer without private context. |  |
+| Price and delivery are clear. |  |
+| Non-claims are visible. |  |
+| Files match the listing. |  |
+| No raw private data is included. |  |
+| A review or observation window is defined. |  |

--- a/docs/public/implementation_workbook_v0_1/workbook_listing_copy_v0_1.md
+++ b/docs/public/implementation_workbook_v0_1/workbook_listing_copy_v0_1.md
@@ -1,0 +1,53 @@
+# Implementation Workbook Listing Copy v0.1
+
+Product: TerraNova / FerrAI CIC Implementation Workbook v0.1  
+Suggested launch price: USD 99  
+Status: listing draft, not yet active sale  
+Boundary: public-safe digital documentation and workbook product
+
+## Product Title
+
+TerraNova / FerrAI CIC Implementation Workbook v0.1
+
+## Short Subtitle
+
+A self-guided workbook for applying the public CIC pattern to your own source-aware human-AI workflow.
+
+## Short Description
+
+The TerraNova / FerrAI CIC Implementation Workbook v0.1 is the third product layer after the Architecture Entry Pack and CIC Blueprint Pack. It helps readers translate the public CIC operating pattern into a small, practical workflow: scope, source map, artifact pipeline, boundary check, publication route and buyer-facing review.
+
+This is a self-guided documentation and workbook product. It is not consulting, private workspace access, software access, token access, an NFT, investment product, legal advice, financial advice, medical advice or implementation support.
+
+## What You Get
+
+- Start-here guide
+- Workbook overview
+- Step 01: Signal to Scope
+- Step 02: Source Map
+- Step 03: Artifact Pipeline
+- Step 04: Boundary Check
+- Step 05: Publication and Sale Route
+- Worksheets
+- Buyer Action Checklist
+
+## Who It Is For
+
+This workbook may be useful for:
+
+- founders building AI-assisted operations,
+- AI builders and workflow designers,
+- documentation architects,
+- creators packaging knowledge work,
+- researchers studying human-AI collaboration,
+- readers who want to apply the Entry Pack and Blueprint Pack patterns to their own workflow.
+
+## Suggested Price
+
+USD 99 for the first launch test.
+
+## Non-Claims
+
+The product does not include, grant, sell, reserve, imply or represent any token, NFT, DAO right, investment right, financial instrument, private system access, software access or personalized implementation support.
+
+No legal, financial, medical or tax advice is included.


### PR DESCRIPTION
## Summary

Adds the TerraNova / FerrAI CIC Implementation Workbook v0.1 as the third public-safe Gumroad product layer.

This is a pattern-recycling build: it turns existing public-safe playbook, checklist, step-plan and governance patterns into a buyer-facing workbook body.

Suggested launch price: USD 99.

## Boundary

No Gumroad product is created by this PR.
No Stripe action, payment link or checkout activation.
No Netlify deploy.
No private workspace data, raw exports, private trigger tables, wallet data, protected drafts, secrets or credentials.
No consulting promise, implementation support, legal advice, financial advice, medical advice or investment claim.

## Files

- README_START_HERE.md
- WORKBOOK_OVERVIEW.md
- STEP_01_SIGNAL_TO_SCOPE.md
- STEP_02_SOURCE_MAP.md
- STEP_03_ARTIFACT_PIPELINE.md
- STEP_04_BOUNDARY_CHECK.md
- STEP_05_PUBLICATION_AND_SALE_ROUTE.md
- WORKSHEETS.md
- BUYER_ACTION_CHECKLIST.md
- workbook_listing_copy_v0_1.md

## Next Gate

External Gumroad product creation requires: GO Workbook Pack Gumroad Draft.