### PR TITLE
ci(portal): add public portal validation coverage

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,25 +4,35 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'README.md'
       - 'BIZ.md'
       - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
       - 'docs/codex/**'
       - 'docs/governance/**'
+      - 'docs/public/**'
+      - 'site/**'
       - 'schemas/artifact_status.schema.json'
       - 'config/source_registry.json'
       - 'scripts/validate_docs.py'
+      - 'scripts/validate_public_portal.py'
       - 'tests/test_validate_docs.py'
+      - 'tests/test_validate_public_portal.py'
       - '.github/workflows/validate-docs.yml'
   push:
     paths:
+      - 'README.md'
       - 'BIZ.md'
       - 'docs/architecture/ferrAI_operating_kernel_v0.1.md'
       - 'docs/codex/**'
       - 'docs/governance/**'
+      - 'docs/public/**'
+      - 'site/**'
       - 'schemas/artifact_status.schema.json'
       - 'config/source_registry.json'
       - 'scripts/validate_docs.py'
+      - 'scripts/validate_public_portal.py'
       - 'tests/test_validate_docs.py'
+      - 'tests/test_validate_public_portal.py'
       - '.github/workflows/validate-docs.yml'
 
 permissions:
@@ -45,6 +55,12 @@ jobs:
 
       - name: Run validator unit tests
         run: python -m unittest tests.test_validate_docs
+
+      - name: Validate public portal surfaces
+        run: python scripts/validate_public_portal.py
+
+      - name: Run public portal validator unit tests
+        run: python -m unittest tests.test_validate_public_portal
 
       - name: Validate registry and schema JSON
         run: |

--- a/docs/governance/gumroad_entry_pack_activation_plan.md
+++ b/docs/governance/gumroad_entry_pack_activation_plan.md
@@ -1,11 +1,15 @@
 # Gumroad Entry Pack Activation Plan v0.1
 
 Status: BIZ / commerce activation plan  
+Source: Gumroad route review, Entry Pack bundle artifact map, public boundary governance, and Gumroad pricing/prohibited-product source check  
 Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
 Route: Gumroad first-sale test  
 Price anchor: USD 19  
 Boundary: digital documentation product only  
 Trace: prepared 2026-05-25 after Gumroad route review
+Mode: BIZ / commerce activation plan
+GitHub sync state: tracked in this repository; validate with `scripts/validate_docs.py`.
+Notion source awareness: Notion may hold living launch context; this file is the public-safe GitHub activation plan only.
 
 ## Purpose
 

--- a/docs/governance/issue_status_registry.md
+++ b/docs/governance/issue_status_registry.md
@@ -1,8 +1,8 @@
 # Governance Issue Status Registry
 
 Status: BIZ / Governance
-Source: GitHub issue and PR state after PR #60 and PR #66 merge.
-Trace: Issues #15, #23, #25; PR #60, PR #66; Zenodo record `10.5281/zenodo.20073579`.
+Source: GitHub issue and PR state after PR #60 and PR #66 merge, refreshed on 2026-06-02.
+Trace: Issues #11, #15, #17, #23, #25; PR #60, PR #66; Zenodo record `10.5281/zenodo.20073579`.
 Boundary: Public-safe issue-status mirror only. It does not close issues by itself and does not mutate Notion or Zenodo.
 Mode: BIZ
 GitHub sync state: tracked in this repository; validate with `scripts/validate_docs.py`.
@@ -22,8 +22,9 @@ from outranking newer reviewed repository state.
 | #25 GitHub container hardening | Closed/completed | `docs/governance/public_boundary.md`; `docs/governance/repo_roles.md`; `raw/exports/REVIEW_GATE.md`; `raw/exports/incoming/README.md`; PR #66, merge commit `49e4024` | Keep as historical closure anchor |
 | #15 Citation/stub reality check | Open | `CITATION.cff`; `docs/references/zenodo.md`; `docs/architecture/core_grid_spec.md`; `docs/science/dissertation/appendix/A02_formula_collection.tex`; `docs/architecture/cic_convergence_9_layers.md` | Keep open until A.2 formulas and CIC convergence receive controlled real exports |
 | #13 Source-tier and Prism naming | Open | `docs/governance/source_tier_and_naming_policy.md`; `docs/ai/cic_atlas_usage.md`; `docs/ai/prism_atlas_usage.md` | Keep open until public naming review and external product-name decision are complete |
-| #17 Prism scale governance | Open | `docs/governance/prism_import_manifest.md`; `raw/exports/prism/source-pack/README.md`; `docs/atlas/README.md`; boundary docs from PR #66 | Keep open until a real import batch is classified against the manifest |
-| #10/#11 Track C intake/review | Open | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; `raw/exports/incoming/README.md`; Track C references in issue bodies | Keep open until a real Track C batch is classified against the checklist |
+| #17 Prism scale governance | Closed/completed | `docs/governance/prism_import_manifest.md`; `raw/exports/prism/source-pack/README.md`; `docs/atlas/README.md`; boundary docs from PR #66; GitHub issue closed as completed on 2026-05-25 | None for the issue; future import batches must still pass the manifest |
+| #10 Track C intake | Open | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; `raw/exports/incoming/README.md`; Track C references in issue body | Keep open until a real Track C batch is classified against the checklist |
+| #11 Prism workspace review | Closed/completed | `docs/governance/track_c_intake_checklist.md`; `docs/governance/public_boundary.md`; issue closure on 2026-05-25 | Keep as historical review marker; no blind merge or deletion implied |
 
 ## Issue #15 Reality Check
 
@@ -56,18 +57,21 @@ container-hardening surfaces:
 The remaining credential-rotation proof remains an account-level operational
 check, not repository text evidence.
 
-## Issue #17 Import Gate
+## Issue #17 Closure Check
 
-The Prism scale checkpoint now has a public import manifest:
+Issue #17 is closed as completed. The Prism scale checkpoint now has a public
+import manifest:
 
 - `docs/governance/prism_import_manifest.md`
 
-This is not a bulk-import approval. It is the gate a future import batch must
-pass before entering public docs.
+Closure is not a bulk-import approval. The manifest remains the gate a future
+import batch must pass before entering public docs.
 
 ## Issues #10/#11 Track C Gate
 
-Track C now has a public intake checklist:
+Issue #10 remains open as the Track C intake marker. Issue #11 is closed as a
+historical Prism workspace review marker. Track C now has a public intake
+checklist:
 
 - `docs/governance/track_c_intake_checklist.md`
 

--- a/scripts/validate_public_portal.py
+++ b/scripts/validate_public_portal.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Validate public portal surfaces used by public-facing entry-pack PRs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_INDEX = Path("site/index.html")
+ENTRY_PACK_LINK = Path("site/entry-pack-link.txt")
+REQUIRED_PUBLIC_DOCS = [
+    Path("docs/public/entry_pack_architecture_v0_1.md"),
+    Path("docs/public/entry_pack_architecture_offer_v0_1.md"),
+    Path("docs/public/entry_pack_architecture_boundary_v0_1.md"),
+]
+REQUIRED_SITE_STRINGS = [
+    "Start with the Entry Pack",
+    "Architecture Entry Pack v0.1",
+    "Open offer draft",
+    "Open boundary sheet",
+]
+REQUIRED_SITE_LINKS = [
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_v0_1.md",
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_offer_v0_1.md",
+    "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework/blob/main/docs/public/entry_pack_architecture_boundary_v0_1.md",
+]
+PLACEHOLDER_RE = re.compile(r"placeholder", re.IGNORECASE)
+HTTPS_URL_RE = re.compile(r"^https://\S+$")
+
+
+def fail(message: str) -> None:
+    print(f"[validate-public-portal] ERROR: {message}", file=sys.stderr)
+
+
+def validate_repo(root: Path) -> list[str]:
+    errors: list[str] = []
+
+    for rel_path in REQUIRED_PUBLIC_DOCS:
+        if not (root / rel_path).is_file():
+            errors.append(f"missing required public document: {rel_path.as_posix()}")
+
+    site_index = root / SITE_INDEX
+    if not site_index.is_file():
+        errors.append(f"missing portal index: {SITE_INDEX.as_posix()}")
+        return errors
+
+    text = site_index.read_text(encoding="utf-8")
+    for value in REQUIRED_SITE_STRINGS:
+        if value not in text:
+            errors.append(f"site/index.html missing required text: {value}")
+    for value in REQUIRED_SITE_LINKS:
+        if value not in text:
+            errors.append(f"site/index.html missing required link: {value}")
+
+    entry_pack_link = root / ENTRY_PACK_LINK
+    if entry_pack_link.exists():
+        link_text = entry_pack_link.read_text(encoding="utf-8").strip()
+        if not link_text:
+            errors.append(f"{ENTRY_PACK_LINK.as_posix()} is empty")
+        elif PLACEHOLDER_RE.search(link_text):
+            errors.append(f"{ENTRY_PACK_LINK.as_posix()} still contains placeholder text")
+        elif not HTTPS_URL_RE.fullmatch(link_text):
+            errors.append(
+                f"{ENTRY_PACK_LINK.as_posix()} must contain exactly one https URL when present"
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_repo(REPO_ROOT)
+    if errors:
+        for error in errors:
+            fail(error)
+        return 1
+    print("[validate-public-portal] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_public_portal.py
+++ b/tests/test_validate_public_portal.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_public_portal.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("validate_public_portal", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidatePublicPortalTests(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+
+    def write_repo(self, root: Path) -> None:
+        for rel_path in self.mod.REQUIRED_PUBLIC_DOCS:
+            path = root / rel_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"# {path.stem}\n", encoding="utf-8")
+
+        site_index = root / self.mod.SITE_INDEX
+        site_index.parent.mkdir(parents=True, exist_ok=True)
+        site_index.write_text(
+            "\n".join(
+                [
+                    "<html>",
+                    "<body>",
+                    *self.mod.REQUIRED_SITE_STRINGS,
+                    *self.mod.REQUIRED_SITE_LINKS,
+                    "</body>",
+                    "</html>",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    def test_validate_repo_accepts_required_public_surfaces(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+
+            self.assertEqual(self.mod.validate_repo(repo_root), [])
+
+    def test_validate_repo_rejects_placeholder_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            placeholder = repo_root / self.mod.ENTRY_PACK_LINK
+            placeholder.parent.mkdir(parents=True, exist_ok=True)
+            placeholder.write_text(
+                "Entry Pack live route placeholder for portal CTA.",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt still contains placeholder text"],
+            )
+
+    def test_validate_repo_rejects_empty_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            entry_pack_link = repo_root / self.mod.ENTRY_PACK_LINK
+            entry_pack_link.parent.mkdir(parents=True, exist_ok=True)
+            entry_pack_link.write_text("  \n", encoding="utf-8")
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt is empty"],
+            )
+
+    def test_validate_repo_rejects_non_https_entry_pack_link(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            entry_pack_link = repo_root / self.mod.ENTRY_PACK_LINK
+            entry_pack_link.parent.mkdir(parents=True, exist_ok=True)
+            entry_pack_link.write_text("http://example.test/entry-pack", encoding="utf-8")
+
+            self.assertEqual(
+                self.mod.validate_repo(repo_root),
+                ["site/entry-pack-link.txt must contain exactly one https URL when present"],
+            )
+
+    def test_validate_repo_rejects_missing_public_document(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            self.write_repo(repo_root)
+            missing_doc = repo_root / self.mod.REQUIRED_PUBLIC_DOCS[0]
+            missing_doc.unlink()
+
+            self.assertIn(
+                "missing required public document: docs/public/entry_pack_architecture_v0_1.md",
+                self.mod.validate_repo(repo_root),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This draft PR contains two separated backlog lanes.

LDB-001:

* extend docs validation workflow coverage for public portal paths
* add public portal validator
* add portal validator unit tests
* update issue status registry alignment

LDB-006:

* add required Gumroad/BIZ markers to gumroad_entry_pack_activation_plan.md so validate_docs.py passes against the current baseline

Validation:

* python scripts/validate_docs.py
* python scripts/validate_public_portal.py
* python -m unittest tests.test_validate_docs tests.test_validate_public_portal
* GitHub Actions Validate Docs run 26860048585 succeeded after push

Boundaries:

* create draft PR only
* do not merge
* do not mark ready for review
* do not rebase
* do not reset
* do not delete branches
* do not comment on unrelated PRs/issues
* do not label, assign, close, or modify other PRs/issues
* do not mutate Notion, Stripe, Gumroad, Netlify, or any other external system
* do not touch PR #70, PR #73, or issue #76