### PR TITLE
docs(governance): add Gumroad BIZ validation markers

### DIFF
--- a/docs/governance/gumroad_entry_pack_activation_plan.md
+++ b/docs/governance/gumroad_entry_pack_activation_plan.md
@@ -1,11 +1,15 @@
 # Gumroad Entry Pack Activation Plan v0.1
 
 Status: BIZ / commerce activation plan  
+Source: Gumroad route review and public-safe Entry Pack governance.  
 Product: TerraNova / FerrAI Architecture Entry Pack v0.1  
 Route: Gumroad first-sale test  
 Price anchor: USD 19  
 Boundary: digital documentation product only  
 Trace: prepared 2026-05-25 after Gumroad route review
+Mode: BIZ / commerce activation planning
+GitHub sync state: tracked in this repository; validate through `scripts/validate_docs.py`.
+Notion source awareness: required before product, publication or workspace-memory mutation.
 
 ## Purpose
 


### PR DESCRIPTION
## Scope

Scoped marker-only fix for the CI failure found during PR #78 review.

## Commit

- `d9397e6 docs(governance): add Gumroad BIZ validation markers`

## Changed files

Exactly 1 file:

- `docs/governance/gumroad_entry_pack_activation_plan.md`

## What changed

Added the missing BIZ documentation marker lines required by `scripts/validate_docs.py`:

- `Source:`
- `Mode:`
- `GitHub sync state:`
- `Notion source awareness:`

## Why

PR #78 failed GitHub Actions `Validate Docs` on the pull-request merge ref because `origin/main` contains `docs/governance/gumroad_entry_pack_activation_plan.md` with `Status: BIZ` but without the four required marker lines. This patch fixes that base-branch governance marker debt separately from the TNC-AUTO-001 branch.

## Validation

- `python scripts\validate_docs.py` OK
- `python -m unittest tests.test_validate_docs` OK, 2 tests
- `python -m json.tool schemas\artifact_status.schema.json` OK
- `python -m json.tool config\source_registry.json` OK

## Boundary

- marker-only governance patch
- no Gumroad product mutation
- no Notion write
- no Netlify, Stripe, Gumroad or Zenodo mutation
- no production mutation
- no raw or local-private material
- no private survival, Metarotik or Schattenarchiv expansion

## Relation

- separate from #77
- separate from LDB-002
- separate from PR #78 implementation scope
- intended to unblock the shared Validate Docs CI gate
- does not touch the original dirty worktree

## Human Gate

Draft only. Merge requires explicit later approval.