### PR TITLE
feat(vercel): add Python API scaffold

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,15 @@
+from http.server import BaseHTTPRequestHandler
+import json
+
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        body = {
+            "service": "terra-nova-s-framework",
+            "status": "ok",
+            "boundary": "public-safe; no secrets, no raw Notion",
+        }
+        self.wfile.write(json.dumps(body).encode("utf-8"))

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
+}


### PR DESCRIPTION
Scope anchor: Vercel Python /api v0.1

## Scope
- Add minimal stdlib-only Python serverless API scaffold under `api/index.py`.
- Add `vercel.json` rewrite to route requests to `/api/index`.
- No dependency changes.

## Validation
- `python -m py_compile api/index.py` OK
- `python -m json.tool vercel.json` OK
- `git diff --check` OK
- Leak scan on `api/` and `vercel.json` OK: no raw Notion URLs, no 32-hex page IDs, no token/wallet-like strings.

## Boundary
- Public-safe only.
- No secrets.
- No raw Notion.
- No production deploy claim.
- No environment variables added.
- No Netlify change.
- No domain change.

## Vercel
- Intended as a Preview-only PR surface.
- Do not promote to Production in this PR.
- Production deploy remains gated by explicit `GO Vercel prod /api v0.1`.