### PR TITLE
DR-001: Public front-door overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ stays traceable instead of disappearing into chat logs.
 ## Public-safe boundaries
 
 - Draft PRs are used **intentionally** as review gates — not signs of an unfinished mess.
-- Files under `raw/exports/` and `data_exports/` are sanitized placeholders / fill-versions, not live data dumps.
+- Files under `raw/exports/` are sanitized placeholders / fill-versions, not live data dumps. Other export-related directories require separate review before being described publicly.
 - Internal terms (Prism, Trigger Registry, Equilibrium) are legacy/internal vocabulary; see the governance docs before reading them as products.
 
 ## Current status

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The atlas does not change the production sync workflow. It is a separate, machin
 2. Share Notion database with integration (in Notion UI)
 3. Workflow runs automatically every 10 minutes
 
-The workflow resolves `GITHUB_REPO` automatically from `$ github.repository `.
+The workflow resolves `GITHUB_REPO` automatically from the GitHub Actions `github.repository` context expression.
 Optional override for cross-repo sync: set `TARGET_GITHUB_REPO` (secret or variable) to `owner/repo`.
 
 **Trigger manually:**

--- a/README.md
+++ b/README.md
@@ -1,19 +1,67 @@
-# TerraNova Notion -> GitHub Controller (Minimal)
+# TerraNova / FerrAI CIC
 
-## What it does
+A human–AI **research-operations framework** for moving work from private notes,
+signals and conversations into reviewed, versioned, public-safe artifacts.
+
+> **This repository is not the whole system.**
+> It is the *public-safe, versioned evidence and release surface* of
+> TerraNova / FerrAI CIC — not the live working core.
+
+## What it is
+
+An auditable framework for human–AI cooperation (Cognitive Intelligent
+Cooperation, "CIC"): every step moves from a living source-of-record into
+reviewed, citable, public-safe output.
+
+## What problem it solves
+
+Most AI-assisted work leaves no clean trail. TerraNova separates **where work
+lives**, **where it is reviewed**, and **where it is citable** — so progress
+stays traceable instead of disappearing into chat logs.
+
+## Architecture
+
+| Layer | Role |
+|-------|------|
+| **Notion** | Living source-of-record (working core) |
+| **GitHub** (this repo) | Public-safe working & audit mirror / release surface |
+| **Zenodo** | Citable long-form archive — DOI 10.5281/zenodo.20073579 |
+
+## Public-safe boundaries
+
+- Draft PRs are used **intentionally** as review gates — not signs of an unfinished mess.
+- Files under `raw/exports/` and `data_exports/` are sanitized placeholders / fill-versions, not live data dumps.
+- Internal terms (Prism, Trigger Registry, Equilibrium) are legacy/internal vocabulary; see the governance docs before reading them as products.
+
+## Current status
+
+**Advanced prototype / active research workbench — not a finished SaaS product.**
+Strong governance and technical substrate; public onboarding is being hardened.
+
+## Where to start
+
+1. Read this README (you are here).
+2. [`docs/public/README.md`](docs/public/README.md) — public artifacts index & lexicon.
+3. Zenodo record — citable reference, *not* the entry point.
+
+---
+
+## Notion → GitHub Controller (minimal sync)
+
+### What it does
 - Polls a Notion database (`AI_Incidents_and_Changes`)
 - For rows where `Export_to_GitHub` is ✅ and `GitHub_Issue_URL` is empty:
   - Creates a GitHub Issue
   - Writes the Issue URL + timestamp back to Notion
 
-## Repo layers
+### Repo layers
 - `Notion -> GitHub sync`: the existing production path for `AI_Incidents_and_Changes`.
 - `Atlas layer`: a canonical workspace-atlas seed in [`atlas/README.md`](atlas/README.md) and [`atlas/atlas.manifest.v1.json`](atlas/atlas.manifest.v1.json).
 - `Prism atlas layer`: reviewed local docs generated from Prism/Notion exports in [`docs/atlas/README.md`](docs/atlas/README.md), with trigger gaps tracked in [`docs/triggers/gap_ledger.md`](docs/triggers/gap_ledger.md).
 
 The atlas does not change the production sync workflow. It is a separate, machine-readable workspace inventory seeded from a user-provided TerraNova workspace export so future exporters or visualizers have a stable contract to build on.
 
-## Setup (GitHub Actions – RECOMMENDED)
+### Setup (GitHub Actions – RECOMMENDED)
 
 **See [SETUP_RUNBOOK.md](SETUP_RUNBOOK.md) for complete step-by-step guide.**
 
@@ -25,7 +73,7 @@ The atlas does not change the production sync workflow. It is a separate, machin
 2. Share Notion database with integration (in Notion UI)
 3. Workflow runs automatically every 10 minutes
 
-The workflow resolves `GITHUB_REPO` automatically from `${{ github.repository }}`.
+The workflow resolves `GITHUB_REPO` automatically from `$ github.repository `.
 Optional override for cross-repo sync: set `TARGET_GITHUB_REPO` (secret or variable) to `owner/repo`.
 
 **Trigger manually:**
@@ -33,12 +81,12 @@ Optional override for cross-repo sync: set `TARGET_GITHUB_REPO` (secret or varia
 gh workflow run tnv_notion_to_github.yml --repo owner/repo
 ```
 
-## Safety defaults
+### Safety defaults
 - The script only exports rows you explicitly mark (`Export_to_GitHub`).
 - No automatic mutation of compliance risk fields.
 - Tokens are never stored in Notion or in the repo – only GitHub encrypted secrets.
 
-## Local run (not recommended – use workflow instead)
+### Local run (not recommended – use workflow instead)
 ```bash
 export NOTION_TOKEN="..."
 export NOTION_DATABASE_ID_CHANGES="..."
@@ -50,15 +98,15 @@ export GITHUB_REPO="owner/repo"
 python scripts/notion_to_github.py
 ```
 
-## GitHub Projects v2
+### GitHub Projects v2
 The controller does not mutate GitHub Projects v2. It creates Issues and writes
 the Issue URL back to Notion. Add exported Issues to a project manually or with
 a separate automation if project backlog state is required.
 
-## Business brief
+### Business brief
 - See `BIZ.md` for a concise `/biz` business-facing overview, KPI suggestions, and operating cadence.
 
-## Governance and public boundary
+### Governance and public boundary
 - Public repository boundary: [`docs/governance/public_boundary.md`](docs/governance/public_boundary.md)
 - Repository role vocabulary: [`docs/governance/repo_roles.md`](docs/governance/repo_roles.md)
 - Source-of-record policy: [`docs/governance/source_of_record_policy.md`](docs/governance/source_of_record_policy.md)
@@ -70,7 +118,7 @@ a separate automation if project backlog state is required.
 - Repository maturity note: [`docs/governance/repository_maturity.md`](docs/governance/repository_maturity.md)
 - Raw export review gate: [`raw/exports/REVIEW_GATE.md`](raw/exports/REVIEW_GATE.md)
 
-## Public semantic architecture
+### Public semantic architecture
 - Architecture index: [`docs/architecture/README.md`](docs/architecture/README.md)
 - Public semantic spine: [`docs/architecture/public_semantic_architecture_spine.md`](docs/architecture/public_semantic_architecture_spine.md)
 - Semantic Trigger Architecture: [`docs/architecture/semantic_trigger_architecture.md`](docs/architecture/semantic_trigger_architecture.md)
@@ -85,7 +133,7 @@ a separate automation if project backlog state is required.
 - Public artifacts index: [`docs/public/README.md`](docs/public/README.md)
 - Architecture Entry Pack v0.1: [`docs/public/entry_pack_architecture_v0_1.md`](docs/public/entry_pack_architecture_v0_1.md)
 
-## Current published release
+### Current published release
 
 The current citable Zenodo release is RC01-v12:
 
@@ -93,14 +141,14 @@ The current citable Zenodo release is RC01-v12:
 - Record: https://zenodo.org/records/20073579
 - GitHub mirror artifact: `releases/zenodo/rc01-v12-2026-05-07/`
 
-## Atlas validation
+### Atlas validation
 Validate the atlas manifest from the repo root:
 
 ```bash
 python scripts/validate_atlas.py atlas/atlas.manifest.v1.json
 ```
 
-## Prism atlas renderer
+### Prism atlas renderer
 Render the current Prism source pack into reviewed local docs:
 
 ```bash


### PR DESCRIPTION
## DR-001 — Public Front Door Hardening

**Rail:** GPT/Deep Research public-surface audit → FerrAI live-connector verification
**Scope:** `README.md` only. No code, release, tag, or Zenodo change.
**Gate:** Draft PR — review gate, not yet ready for merge.

### Why
The Deep Research analytical review found the core issue is **not lack of depth** but the **public entry sequence**: an outside reader landing from Zenodo → GitHub sees a dense surface and a narrow "Notion → GitHub Controller" title, with no quick orientation to the wider TerraNova / FerrAI CIC framework.

### What this PR does
Prepends a short, external-facing front-door section at the top of the README:
- One-line what-it-is + the explicit clarifier *"This repository is not the whole system."*
- What problem it solves
- Architecture rails table (Notion = source-of-record · GitHub = public-safe mirror · Zenodo = citable archive)
- Public-safe boundaries (draft PRs as intentional gates; `raw/exports/` & `data_exports/` are sanitized placeholders; internal vocab flagged)
- Current status (advanced prototype / active research workbench, not a SaaS product)
- Where to start

**No content removed.** The existing Notion → GitHub controller documentation is preserved verbatim below the front-door, relabelled as a section.

### FerrAI verification notes
- Built on live-connector reads of `main`, not just the public web surface.
- **No claims about adjacent forks** in the front-door: the Deep Research's `miniapps` / `gumroad` / `notion-mcp-server` fork claims are **not confirmed** by a fork-inclusive org listing, so they are deliberately omitted.
- A GitHub Actions expression in the controller setup section was flattened by an encoding step in the first commit and repaired in the follow-up commit (`0176654`).

### Not in scope (parked for later DR items)
- DR-002 Naming map / Prism external freeze
- DR-003 Stable vs hardening maturity matrix
- DR-004 Public folder/surface hygiene (`raw/exports`, `data_exports/xxl_500k_snapshot`)
- DR-005 Trigger Registry relational view plan
- DR-006 Zenodo title / page-count clarification
- DR-007 Adjacent forks disclaimer (pending fork-inclusive listing)