### PR TITLE
docs(hygiene): soften sensitive-category disclosure in public_gate_status (DR-004)

### DIFF
--- a/data_exports/xxl_500k_snapshot/public_gate_status.md
+++ b/data_exports/xxl_500k_snapshot/public_gate_status.md
@@ -27,7 +27,7 @@ aggregate/index publication is open; raw publication and contextual extracts
 remain rejected.
 
 ## Action Taken (CEI-04A & CEI-04B)
-The 27 K3 hits (potential credential / wallet traces) and all PII/account traces (Emails, IBANs, Phone numbers) have been strictly isolated. 
+All sensitive categories (potential credential / wallet traces and personal / account / contact data) have been reviewed and strictly isolated outside the public repository.
 **No raw files will ever be published.** The data leak risk has been entirely neutralized by dropping the raw payload requirement.
 
 ## Allowed in public repository


### PR DESCRIPTION
## DR-004 — Public-Surface-Hygiene Patch

Softens the meta-over-disclosure line in `data_exports/xxl_500k_snapshot/public_gate_status.md`.

### Was
> The 27 K3 hits (potential credential / wallet traces) and all PII/account traces (Emails, IBANs, Phone numbers) have been strictly isolated.

### Wird
> All sensitive categories (potential credential / wallet traces and personal / account / contact data) have been reviewed and strictly isolated outside the public repository.

### Begründung
- Entfernt d'öffentlichi Nennig vo Zähl (27) + konkrete Kategorie-Enumeration (Emails, IBANs, Phone).
- **Kei Wert/Secret isch je exponiert gsi** — das reduziert nur d'Meta-Disclosure uf de public surface.
- Aggregates-only Gate / RAW_PUBLICATION: NO **unverändert**.

Human gate: Merge liit bi @silvan-lenhard.