### PR TITLE
TNC-AUTO-001: reject hard-linked report targets before writing

### DIFF
--- a/scripts/tnc_auto_001.py
+++ b/scripts/tnc_auto_001.py
@@ -215,6 +215,17 @@ def validate_report_targets(output_dir: Path) -> None:
     symlink_targets = [name for name in REPORT_OUTPUT_FILES if (output_dir / name).is_symlink()]
     if symlink_targets:
         raise ValueError("report targets must not be symlinks before writing: " + ", ".join(symlink_targets))
+    hardlink_targets = [
+        name
+        for name in REPORT_OUTPUT_FILES
+        if (output_dir / name).is_file()
+        and not (output_dir / name).is_symlink()
+        and (output_dir / name).stat().st_nlink > 1
+    ]
+    if hardlink_targets:
+        raise ValueError(
+            "report targets must not be hard-linked before writing: " + ", ".join(hardlink_targets)
+        )
 
 
 def build_source_record(root: Path, path: Path) -> SourceRecord:

--- a/tests/test_tnc_auto_001.py
+++ b/tests/test_tnc_auto_001.py
@@ -4,6 +4,7 @@ import ast
 import csv
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -288,6 +289,32 @@ class TncAuto001Tests(unittest.TestCase):
                 self.skipTest(f"symlink creation unavailable: {exc}")
 
             with self.assertRaisesRegex(ValueError, "report targets must not be symlinks before writing"):
+                self.mod.run_controller(
+                    root,
+                    Path("raw/exports/local-private"),
+                    Path("raw/exports/local-private/tnc-auto-001-dry-run"),
+                    None,
+                )
+
+            self.assertEqual(tracked_target.read_text(encoding="utf-8"), "keep me")
+
+    def test_run_controller_refuses_hardlinked_report_target_before_writing(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            init_gitignore(root)
+            source_dir = root / "raw" / "exports" / "local-private"
+            source_dir.mkdir(parents=True)
+            (source_dir / "tncic-neutral.md").write_text("A neutral note, no blocker terms.", encoding="utf-8")
+            output_dir = source_dir / "tnc-auto-001-dry-run"
+            output_dir.mkdir(parents=True)
+            tracked_target = root / "tracked-report.md"
+            tracked_target.write_text("keep me", encoding="utf-8")
+            try:
+                os.link(tracked_target, output_dir / "claim_ledger.csv")
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"hardlink creation unavailable: {exc}")
+
+            with self.assertRaisesRegex(ValueError, "report targets must not be hard-linked before writing"):
                 self.mod.run_controller(
                     root,
                     Path("raw/exports/local-private"),


### PR DESCRIPTION
## Follow-up A — Hardlink-Guard (TNC-AUTO-001)

Resolves the deferred review thread from PR #78: `validate_report_targets()` previously rejected only **symlinked** report targets. A pre-existing **hard-linked** report target could still let a controller write clobber a tracked file outside the local-private sandbox.

### Change
- `scripts/tnc_auto_001.py` — extend `validate_report_targets()` to also refuse hard-linked report targets (`Path.stat().st_nlink > 1`) **before any write**, ordered immediately after the existing symlink check. Raises `ValueError("report targets must not be hard-linked before writing: …")`.
- `tests/test_tnc_auto_001.py` — add `test_run_controller_refuses_hardlinked_report_target_before_writing`, analogous to the symlink regression test, using `os.link(...)` and asserting the tracked target is left untouched.

### Scope guard
- Exactly 2 files touched. No workflow/CI, dependency, secret, migration, payment, publication or public-surface changes.
- Pure additive hardening; normal dry-runs (fresh report files, `st_nlink == 1`) are unaffected.

Merge only after CI is green.