### PR TITLE
docs: finalize Edentität concept status after PR #89

### DIFF
--- a/docs/public/concepts/edentitaet/CROSSWALK.md
+++ b/docs/public/concepts/edentitaet/CROSSWALK.md
@@ -1,6 +1,6 @@
 # Edentität — cross-system trace v0.1
 
-Status: public-safe crosswalk draft  
+Status: public-safe crosswalk v0.1  
 Purpose: connect the living concept source, public mirror, evidence trail and long-form archive without exposing private workspace material
 
 ## Source map
@@ -80,12 +80,17 @@ Suggested pinpoint citation:
 
 > Lenhard, Silvan (2026), *FerrAI / Terra’Nova’CIC — Werkmonographie und Evidenzapparat*, v16, Appendix BY, pp. 645–647, DOI: 10.5281/zenodo.20732376.
 
-## Promotion gate
+## Promotion status
 
-This draft may be promoted from `reference` to `canonical` in the public repo
-when:
+This concept pack was promoted to the public `main` branch on 2026-07-11 via PR #89.
+Within the GitHub public mirror, it is the reviewed terminology anchor for
+Edentität v0.1. Notion remains the living source-of-record.
 
-- the wording is reviewed by the human owner;
-- the external provenance wording is confirmed;
-- repository validation passes;
-- the branch is merged through the normal review gate.
+Promotion evidence:
+
+- wording reviewed by the human owner;
+- external provenance wording confirmed;
+- Zenodo v16 DOI and page anchors verified;
+- Vercel and Netlify deployment previews passed;
+- merged through the normal review gate;
+- merge commit: `b42d1739c92e4fb0f172cb0dae09d2daadf5b868`.

--- a/docs/public/concepts/edentitaet/README.md
+++ b/docs/public/concepts/edentitaet/README.md
@@ -1,11 +1,12 @@
 # Edentität — public concept anchor v0.1
 
-Status: public-safe concept draft v0.1  
+Status: public-safe concept anchor v0.1  
 Source: Notion canon review (`EDENTITÄT-CANON-001`, `Edentität ≠ KSE ≠ Identität`)  
 Trace: TerraNova internal concept line dated 2026-03-21; canon anchor dated 2026-06-08; Zenodo v16 long-form anchor dated 2026-06-17  
 Boundary: conceptual and architectural description only; no consciousness, personhood, legal-status, patent or first-coinage claim  
 Mode: SYNC / public-safe terminology mirror  
-GitHub sync state: prepared for review on `docs/edentitaet-concept-pack-v0-1`  
+GitHub sync state: merged to `main` via PR #89 on 2026-07-11  
+Merge commit: `b42d1739c92e4fb0f172cb0dae09d2daadf5b868`  
 Source-of-record awareness: Notion remains the living definition source; this file is the reviewed public mirror
 
 ## Definition


### PR DESCRIPTION
## Summary

Post-merge status correction for the Edentität concept pack.

## Changes

- changes the concept README from draft wording to the active public-safe anchor status
- records PR #89 and merge commit `b42d1739c92e4fb0f172cb0dae09d2daadf5b868`
- replaces the now-obsolete promotion gate with the completed promotion status
- preserves Notion as the living source-of-record and GitHub as the reviewed public mirror

## Scope

Status metadata only. No change to the Edentität definition, provenance, non-claims, Zenodo DOI, or page anchors.

## Review checklist

- [x] Branch starts from the PR #89 merge commit
- [x] Only `README.md` and `CROSSWALK.md` changed
- [x] Draft language removed
- [x] Merge trace recorded
- [x] Source-of-record boundary preserved

No merge requested yet.