### PR TITLE
docs(sync): document automatic Actions token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,18 +15,23 @@ NOTION_TOKEN=your_notion_api_key_here
 NOTION_DATABASE_ID_CHANGES=your_notion_db_id_here
 
 # ============================================================================
-# GITHUB API
+# GITHUB ACTIONS
 # ============================================================================
-# GitHub Personal Access Token (required)
-# Current workflow uses: GH_PAT
+# GitHub Actions automatically provides GITHUB_TOKEN for this same-repository sync.
+# Do not create a GH_PAT repository secret for this workflow.
+# The workflow job must retain:
+#   permissions:
+#     contents: write
+#     issues: write
 #
-# Get from: https://github.com/settings/tokens
-# Required scopes: repo (full repository access), issues (required for issue creation)
-GH_PAT=your_github_pat_here
+# For a manual local run, provide a token with access to the target repository.
+GITHUB_TOKEN=your_github_token_here
 
 # Optional cross-repo override (highest priority)
 # Format: owner/repo (e.g., username/repository-name)
 # When set, this overrides GITHUB_REPO and config/notion_map.json
+# A cross-repo target requires separately configured access; the automatic
+# same-repository GITHUB_TOKEN does not grant cross-repository access.
 TARGET_GITHUB_REPO=
 
 # GitHub Repository (optional fallback)
@@ -50,6 +55,6 @@ GITHUB_REPO=owner/repo
 # 1. Never commit this file with real credentials to version control
 # 2. Use GitHub encrypted secrets for CI/CD pipelines
 # 3. Notion API keys never expire, but rotate them regularly for security
-# 4. GitHub PAT tokens expire after configurable period (default: 90 days)
+# 4. GitHub Actions provides GITHUB_TOKEN automatically for same-repository workflow runs
 # 5. Token validation is performed before sync execution
 # 6. These variable names match the GitHub Actions workflow in .github/workflows/

--- a/.github/agents/notion-sync.agent.md
+++ b/.github/agents/notion-sync.agent.md
@@ -11,7 +11,7 @@ You are a specialist at orchestrating Notion-to-GitHub data synchronization. You
 - **Validation First**: Run preflight checks before any sync (secrets, DB access, permissions, config, concurrency)
 - **Safe Execution**: Execute sync scripts with validation gates, never bypass checks
 - **Debug Focus**: When sync fails, systematically diagnose root causes (especially Notion access issues)
-- **API Consistency**: Unify token naming (`GH_PAT` ↔ `GITHUB_TOKEN`) and validate both Notion and GitHub credentials
+- **API Consistency**: Use the workflow-provided `GITHUB_TOKEN` for GitHub access and validate both Notion and GitHub credentials
 - **Clear Reporting**: Document what was synced, flag issues, provide actionable next steps
 
 ## Constraints
@@ -23,9 +23,9 @@ You are a specialist at orchestrating Notion-to-GitHub data synchronization. You
 
 ## Preflight Checklist (Always Run First)
 Before executing ANY sync operation, validate:
-1. **Secrets** (`NOTION_API_KEY`, `GH_PAT`/`GITHUB_TOKEN`): Verify both exist and are non-empty
+1. **Secrets** (`NOTION_TOKEN` or compatible `NOTION_API_KEY`, automatic `GITHUB_TOKEN` in Actions): Verify required credentials are available
 2. **Notion Database Access**: Test direct Notion API call to target database(s)
-3. **GitHub Repository Access**: Verify PAT has repo read/write permissions
+3. **GitHub Repository Access**: Verify repository access and retain workflow permissions `contents: write` and `issues: write`
 4. **Configuration**: Validate property mappings in NOTION_PROPERTIES.md exist and are correctly formatted
 5. **Concurrency**: Check for running sync processes; prevent parallel executions
 

--- a/.github/skills/notion-sync-workflow/SKILL.md
+++ b/.github/skills/notion-sync-workflow/SKILL.md
@@ -60,7 +60,7 @@ Understand your Notion database and GitHub target before syncing.
 Verify prerequisites before attempting sync.
 
 **Actions:**
-1. Validate API credentials exist (`NOTION_API_KEY`, `GH_PAT`/`GITHUB_TOKEN`)
+1. Validate the Notion credential and the automatic Actions `GITHUB_TOKEN` (or a local token for a manual local run)
 2. Test Notion database access (can read at least 1 record)
 3. Test GitHub repo access (can read repo details)
 4. Verify property mappings in NOTION_PROPERTIES.md match actual database schema
@@ -71,8 +71,8 @@ Verify prerequisites before attempting sync.
 Preflight Validation for [Database Name]
 
 ✓ Secrets Configured
-  - NOTION_API_KEY: [present/missing]
-  - GH_PAT or GITHUB_TOKEN: [present/missing]
+  - NOTION_TOKEN: [present/missing; NOTION_API_KEY is a compatible fallback]
+  - GITHUB_TOKEN: [automatic in Actions / present for local run]
 
 ✓ Notion Database Access
   - Database ID: [ID]
@@ -84,6 +84,7 @@ Preflight Validation for [Database Name]
   - Repository: [owner/repo]
   - Can read: [yes/no]
   - Can create issues: [yes/no]
+  - Job permissions: contents: write; issues: write
   - Last error (if any): [error message]
 
 ✓ Property Mappings
@@ -225,7 +226,7 @@ Set up recurring sync and monitoring.
 
 ## Prerequisites
 - Notion API key still valid
-- GitHub PAT still valid
+- Automatic GitHub Actions GITHUB_TOKEN available; workflow job retains contents: write and issues: write
 - No ongoing GitHub incidents
 
 ## Sync Procedure

--- a/BIZ.md
+++ b/BIZ.md
@@ -26,7 +26,8 @@ manual copy/paste.
 
 ## Required operating inputs
 - Notion integration token and database id.
-- GitHub token and target `owner/repo`.
+- Automatic GitHub Actions `GITHUB_TOKEN` for the same-repository sync; the job retains `contents: write` and `issues: write`.
+- Target repository `owner/repo`, defaulting to the workflow repository.
 - Stable Notion property schema documented in `NOTION_PROPERTIES.md`.
 
 ## Suggested KPIs
@@ -38,12 +39,14 @@ manual copy/paste.
 ## Risk and controls
 - **Risk:** Schema drift in Notion property names.
   - **Control:** Keep mapping centralized in `scripts/notion_to_github.py` and review on schema changes.
-- **Risk:** Token misconfiguration or expiration.
-  - **Control:** Secrets managed in GitHub repository settings with periodic rotation.
+- **Risk:** Notion credential misconfiguration or expiration.
+  - **Control:** Store Notion credentials in GitHub repository secrets and rotate them when needed.
+- **Risk:** GitHub Actions permissions drift.
+  - **Control:** Keep the TNV workflow job permissions at `contents: write` and `issues: write`.
 - **Risk:** Over-exporting noisy items.
   - **Control:** Explicit checkbox gate (`Export_to_GitHub`) and optional severity-based triage policy.
 
 ## `/biz` operating cadence
 - Weekly: review KPI dashboard and stale exported GitHub Issues.
-- Monthly: verify Notion property compatibility and secret health.
+- Monthly: verify Notion property compatibility, Notion credential health, and Actions workflow permissions.
 - Quarterly: review governance fields and escalation rules for incident severity.

--- a/NOTION_PROPERTIES.md
+++ b/NOTION_PROPERTIES.md
@@ -4,18 +4,22 @@ This controller expects these properties in the **Changes** database:
 
 ## Required Environment Variables
 
-Before running sync, ensure these are configured:
+For a GitHub Actions run, configure the Notion values below. GitHub Actions
+injects GITHUB_TOKEN automatically for the same-repository workflow, so it is
+not a repository secret.
 
 ```bash
 NOTION_TOKEN=ntn_xxxx...                # Notion Integration API key
 NOTION_DATABASE_ID_CHANGES=abc123...    # Database ID to sync from
-GH_PAT=ghp_xxxx...                      # GitHub Personal Access Token
-TARGET_GITHUB_REPO=owner/repo           # Optional cross-repo override (highest priority)
+TARGET_GITHUB_REPO=owner/repo           # Optional cross-repo override; target access must be configured separately
 GITHUB_REPO=owner/repo                  # Optional fallback target repository
 ```
 
 **See `.env.example` for template and detailed documentation.**
 **Note:** In workflow runs, `GITHUB_REPO` defaults to `${{ github.repository }}`.
+The workflow job must retain `contents: write` and `issues: write` permissions.
+For a local manual run, supply a GitHub token through `GITHUB_TOKEN` with
+access to the target repository.
 
 ## Required Notion Properties
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ The atlas does not change the production sync workflow. It is a separate, machin
 1. Create GitHub repo secrets:
    - `NOTION_TOKEN` (Notion integration token)
    - `NOTION_DATABASE_ID_CHANGES` (Notion database ID)
-   - `GH_PAT` (GitHub Personal Access Token with `repo` + `issues` scopes)
-2. Share Notion database with integration (in Notion UI)
-3. Workflow runs automatically every 10 minutes
+2. GitHub Actions automatically provides `GITHUB_TOKEN` for this same-repository sync.
+   Do not add a `GH_PAT` repository secret. The workflow job must retain
+   `contents: write` and `issues: write` permissions.
+3. Share Notion database with integration (in Notion UI)
+4. Workflow runs automatically every 10 minutes
 
 The workflow resolves `GITHUB_REPO` automatically from the GitHub Actions `github.repository` context expression.
 Optional override for cross-repo sync: set `TARGET_GITHUB_REPO` (secret or variable) to `owner/repo`.
+For a cross-repo target, configure separate target-repository access; the automatic
+same-repository `GITHUB_TOKEN` is not a cross-repository access guarantee.
 
 **Trigger manually:**
 ```bash
@@ -84,13 +88,14 @@ gh workflow run tnv_notion_to_github.yml --repo owner/repo
 ### Safety defaults
 - The script only exports rows you explicitly mark (`Export_to_GitHub`).
 - No automatic mutation of compliance risk fields.
-- Tokens are never stored in Notion or in the repo – only GitHub encrypted secrets.
+- Notion credentials are never stored in Notion or in the repo; GitHub Actions creates the GitHub token at runtime.
 
 ### Local run (not recommended – use workflow instead)
 ```bash
 export NOTION_TOKEN="..."
 export NOTION_DATABASE_ID_CHANGES="..."
-export GH_PAT="..."
+# For a local manual run, provide a token with access to the target repository.
+export GITHUB_TOKEN="..."
 # Optional: override target repo (cross-repo)
 export TARGET_GITHUB_REPO="owner/other-repo"
 # Optional fallback if TARGET_GITHUB_REPO is not set

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,8 @@ Full policy: `docs/governance/public_boundary.md`
 ## Credential Hygiene
 
 - No real API keys, tokens, passwords, or secrets may be committed to this repository.
-- The repository uses GitHub encrypted secrets (`NOTION_TOKEN`, `GH_PAT`, `ZENODO_API`) for CI/CD.
+- The repository uses GitHub encrypted secrets for external credentials such as `NOTION_TOKEN` and `ZENODO_API`.
+  GitHub Actions supplies `GITHUB_TOKEN` automatically for the TNV sync; no `GH_PAT` repository secret is required.
 - If you believe a secret has been leaked, report it immediately and rotate the affected credential.
 
 ## Redaction Policy

--- a/SETUP_RUNBOOK.md
+++ b/SETUP_RUNBOOK.md
@@ -26,20 +26,20 @@ Nachdem dies einmal gemacht ist, läuft alles automatisch – keine lokalen Secr
 
 ---
 
-### Step 2: GitHub Personal Access Token erstellen (2 min)
+### Step 2: GitHub Actions-Berechtigungen prüfen (1 min)
 
-**In GitHub:**
-1. https://github.com/settings/tokens öffnen
-2. Click **Generate new token** → **Generate new token (classic)**
-3. **Token name**: `TNV-Notion-Sync` (oder was du willst)
-4. **Expiration**: `90 days` (GitHub default)
-5. **Select scopes**:
-   - ☑️ `repo` (full control of private repositories)
-   - ☑️ `issues` (manage issues)
-6. Click **Generate token**
-7. **KOPIER DEN TOKEN SOFORT** (danach siehst du ihn nicht mehr!)
-   - Format: `ghp_xxxxx...`
-   - **Du brauchst diesen Wert für Step 3!**
+Der TNV-Sync läuft im selben Repository. GitHub Actions stellt pro Workflow-Run
+automatisch `GITHUB_TOKEN` bereit. Dafür brauchst du keinen Personal Access
+Token und kein `GH_PAT`-Repository-Secret.
+
+Der Job in `.github/workflows/tnv_notion_to_github.yml` muss diese
+Berechtigungen behalten:
+
+~~~yaml
+permissions:
+  contents: write
+  issues: write
+~~~
 
 ---
 
@@ -47,7 +47,6 @@ Nachdem dies einmal gemacht ist, läuft alles automatisch – keine lokalen Secr
 
 **Infos sammeln, die du jetzt brauchst:**
 - **NOTION_TOKEN**: Von Step 1 (Integration Token)
-- **GH_PAT**: Von Step 2 (GitHub Token)
 - **NOTION_DATABASE_ID_CHANGES**: Database ID aus Notion URL
   - Notion öffnen → Database öffnen → URL kopieren
   - ID ist dieser lange String: `https://www.notion.so/workspace/[ID]?v=xyz`
@@ -56,18 +55,21 @@ Nachdem dies einmal gemacht ist, läuft alles automatisch – keine lokalen Secr
 **In GitHub:**
 1. Repository öffnen
 2. **Settings** → **Secrets and variables** → **Actions**
-3. Click **New repository secret** (3x)
+3. Click **New repository secret** (2x)
 
-Erstelle diese 3 Secrets:
+Erstelle diese 2 Secrets:
 
 | Name | Value | Beispiel |
 |------|-------|----------|
 | `NOTION_TOKEN` | Dein Notion Integration Token | `ntn_abc123...` |
 | `NOTION_DATABASE_ID_CHANGES` | Database ID | `abc123def456...` (32 Zeichen) |
-| `GH_PAT` | Dein GitHub Token | `ghp_abc123...` |
 
+GitHub Actions stellt `GITHUB_TOKEN` automatisch bereit; dafür wird kein
+weiteres GitHub-Secret angelegt.
 `GITHUB_REPO` wird im Workflow automatisch aus `${{ github.repository }}` gesetzt.
 Optionaler Override für Cross-Repo-Sync: `TARGET_GITHUB_REPO` als Secret oder Variable im Format `owner/repo`.
+Für ein Cross-Repo-Ziel muss der Zugriff auf das Ziel-Repository separat
+konfiguriert werden; der automatische Token garantiert nur den Same-Repo-Zugriff.
 
 **Wichtig:** 
 - ⚠️ Secrets sind nach Erstellung **unsichtbar** – kopier den Wert BEVOR du speicherst!
@@ -109,7 +111,9 @@ Dann in GitHub Actions Tab checken, ob das Workflow-Run erfolgreich ist.
 3. **Häufige Fehler**:
    - `Notion auth failed` → Token ist falsch/abgelaufen
    - `Database not found` → Database ID ist falsch
-   - `GitHub token lacks write permission` → Token hat nicht die richtigen Scopes
+   - `GitHub token lacks write permission` → Prüfe, ob der Workflow-Job weiterhin
+     `contents: write` und `issues: write` hat; bei einem Cross-Repo-Override
+     zusätzlich den Zugriff auf das Ziel-Repository prüfen
 
 **Wenn alles passt:**
 - Sync läuft automatisch
@@ -127,9 +131,10 @@ Dann in GitHub Actions Tab checken, ob das Workflow-Run erfolgreich ist.
 - ✓ Syncht Daten automatisch
 - ✓ Loggt alles zum Debuggen
 
-**Wenn du Token erneuern musst:**
-- GitHub Secrets aktualisieren (Settings → Secrets)
-- Fertig – nächster Workflow-Run nutzt den neuen Token
+**Wenn die Notion-Verbindung aktualisiert werden muss:**
+- Betroffenes Notion-Secret in **Settings → Secrets** aktualisieren
+- Fertig – der nächste Workflow-Run nutzt den neuen Wert
+- `GITHUB_TOKEN` wird von GitHub Actions pro Workflow-Run automatisch bereitgestellt
 
 ---
 
@@ -139,10 +144,12 @@ Dann in GitHub Actions Tab checken, ob das Workflow-Run erfolgreich ist.
 - Secrets sind GitHub-verschlüsselt, nicht im Code
 - Nur GitHub Actions Runtime kann sie lesen
 - Nicht auf deinem PC, nicht im Git History
-- Tokens haben minimale Scopes (nur `repo` + `issues`)
+- GitHub Actions stellt `GITHUB_TOKEN` automatisch bereit; der Job braucht nur
+  `contents: write` und `issues: write`
 
 ⚠️ **Nicht vergessen:**
-- Tokens rotieren (GitHub PAT: 90 Tage default)
+- Notion Integration Token gemäss deiner Sicherheitsroutine prüfen und bei Bedarf rotieren
+- Workflow-Berechtigungen `contents: write` und `issues: write` beibehalten
 - Notion Integration Token vor GitHub Sharing clearen (1Password etc.)
 - Wenn kompromittiert: GitHub UI → Secret löschen und neu erstellen
 

--- a/notion_to_github.py.instructions.md
+++ b/notion_to_github.py.instructions.md
@@ -22,7 +22,7 @@ The script orchestrates:
 - [ ] Read NOTION_PROPERTIES.md to understand current field mappings
 - [ ] Review GITHUB_PROJECT_HELP.md to understand GitHub integration points
 - [ ] Check requirements.txt for current dependency versions
-- [ ] Verify all environment variables: `NOTION_TOKEN`, `NOTION_DATABASE_ID_CHANGES`, `GH_PAT`, optional `TARGET_GITHUB_REPO`, fallback `GITHUB_REPO`
+- [ ] Verify all environment variables: `NOTION_TOKEN`, `NOTION_DATABASE_ID_CHANGES`, automatic `GITHUB_TOKEN` in Actions (or a local token for manual tests), optional `TARGET_GITHUB_REPO`, fallback `GITHUB_REPO`
 - [ ] Test locally with a **test database** (not production)
 
 ## Critical Patterns
@@ -35,8 +35,9 @@ Always distinguish between:
 
 ### Environment Variable Consistency
 - Use `NOTION_TOKEN` (current workflow convention)
-- Use `GH_PAT` (current workflow convention)
-- Script accepts `NOTION_API_KEY` and `GITHUB_TOKEN` as fallbacks for flexibility, but workflow sends the primary names
+- Use `GITHUB_TOKEN` (current workflow convention; GitHub Actions injects it automatically)
+- Do not add a GitHub repository secret for this same-repository workflow
+- Keep the workflow job permissions `contents: write` and `issues: write`
 - **After any change**: Verify the source is `.github/workflows/tnv_notion_to_github.yml`
 
 ### Concurrency & Idempotency
@@ -82,7 +83,7 @@ Always distinguish between:
 - ✗ Make breaking changes to property mappings without updating NOTION_PROPERTIES.md
 - ✗ Remove error logging or flatten error details
 - ✗ Assume environment is always valid; replicate preflight checks from Notion Sync Agent
-- ✗ Change the primary token variable names in the workflow (NOTION_TOKEN, GH_PAT) without coordination
+- ✗ Change the primary token variable names in the workflow (NOTION_TOKEN, GITHUB_TOKEN) without coordination
 - ✗ Delete or archive GitHub issues without explicit user confirmation in log
 
 ## Preflight Validation (Required)
@@ -93,10 +94,8 @@ def preflight_check():
     """Validate all prerequisites before sync."""
     checks = {
         "NOTION_TOKEN": os.getenv("NOTION_TOKEN"),
-        "GH_PAT": os.getenv("GH_PAT"),
+        "GITHUB_TOKEN": os.getenv("GITHUB_TOKEN"),
         "NOTION_DATABASE_ID_CHANGES": os.getenv("NOTION_DATABASE_ID_CHANGES"),
-        "TARGET_GITHUB_REPO": os.getenv("TARGET_GITHUB_REPO"),
-        "GITHUB_REPO": os.getenv("GITHUB_REPO"),
     }
     for key, value in checks.items():
         if not value:

--- a/scripts/PREFLIGHT_README.md
+++ b/scripts/PREFLIGHT_README.md
@@ -14,13 +14,13 @@ The sync pipeline consists of:
 ### 1. **Secrets Validation**
 Ensures API credentials are configured.
 
-- ✓ `NOTION_API_KEY` is set (or legacy `NOTION_TOKEN` as fallback)
-- ✓ `GH_PAT` is set (or `GITHUB_TOKEN` as fallback)
+- ✓ `NOTION_TOKEN` is set (or compatible `NOTION_API_KEY`)
+- ✓ `GITHUB_TOKEN` is supplied automatically by GitHub Actions, or is set for a manual local run
 
 **Failure Diagnostic**:
 ```
-Missing NOTION_API_KEY (or legacy NOTION_TOKEN)
-→ Solution: Set NOTION_API_KEY env var or .env file
+Missing NOTION_TOKEN (or compatible NOTION_API_KEY)
+→ Solution: Set NOTION_TOKEN in the workflow secret or local environment
 ```
 
 ### 2. **Configuration File Validation**
@@ -52,20 +52,21 @@ Tests actual read access to Notion database.
 | `Notion database not found` | Wrong database ID | Copy correct ID from Notion URL |
 
 ### 4. **GitHub Repository Access**
-Tests read/write access to GitHub repository.
+Tests authenticated access to the GitHub repository and validates the applicable permission model.
 
 - ✓ GitHub API responds
 - ✓ Repository exists and is accessible
-- ✓ Token has write permission (push)
+- ✓ In GitHub Actions, the workflow job retains `contents: write` and `issues: write`
+- ✓ For a local token, repository metadata reports write permission
 
 **Failure Diagnostics**:
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `GitHub auth failed: token invalid or expired` | Wrong/expired token | Regenerate PAT in GitHub settings |
-| `GitHub permission denied: token lacks repo access` | Token has insufficient scopes | Regenerate with `repo` scope |
+| `GitHub auth failed: token invalid or expired` | Missing or invalid GitHub token | Confirm that Actions provides `GITHUB_TOKEN`; for a local run, replace the local token |
+| `GitHub permission denied: token lacks repo access` | Token cannot access the target repository | Verify the target repository and the workflow's GitHub Actions permissions |
 | `GitHub repository not found` | Wrong owner/repo format | Use format: `owner/repo` |
-| `GitHub token lacks write permission to repository` | Token is read-only | Regenerate with `repo` scope (includes write) |
+| `GitHub token lacks write permission to repository` | Local token is read-only or workflow permissions drifted | For Actions, retain `contents: write` and `issues: write`; for local runs, use a token with target-repository write access |
 
 ### 5. **Concurrency Check**
 Prevents multiple sync processes from running simultaneously.
@@ -85,12 +86,19 @@ Another sync process is running.
 |----------|------|--------|--------|
 | `NOTION_TOKEN` | Notion | Workflow | ✓ Currently used |
 | `NOTION_API_KEY` | Notion | Alternative | ⚠️ Flexible fallback |
-| `GH_PAT` | GitHub | Workflow | ✓ Currently used |
-| `GITHUB_TOKEN` | GitHub | Alternative | ⚠️ Flexible fallback |
+| `GITHUB_TOKEN` | GitHub | GitHub Actions automatic token / local environment | ✓ Current workflow |
 | `TARGET_GITHUB_REPO` | GitHub Repo | Secret/Variable/Local env | ✓ Optional override |
 | `GITHUB_REPO` | GitHub Repo | Workflow/local env | ✓ Default/fallback |
 
-**Current Practice**: Workflow sends `NOTION_TOKEN` and `GH_PAT`. Script accepts both the current names and alternatives for flexibility, but expects the workflow names.
+**Current Practice**: The workflow exports `NOTION_TOKEN` and
+`NOTION_DATABASE_ID_CHANGES`; GitHub Actions injects `GITHUB_TOKEN`
+automatically. No separate GitHub repository secret is required for this
+same-repository sync. The workflow job must retain `contents: write` and
+`issues: write`.
+
+**Actions permission note**: When `GITHUB_ACTIONS=true`, successful
+authenticated repository access with those workflow permissions passes
+preflight even if repository metadata reports `permissions.push=false`.
 
 **Repository resolution order**: `TARGET_GITHUB_REPO` → `GITHUB_REPO` → `config/notion_map.json (github_repo)`.
 
@@ -139,8 +147,9 @@ The script stops at the first failure and provides actionable diagnostics.
 
 ### Scenario 1: First-time Setup
 ```bash
-export NOTION_API_KEY=ntn_xxxx...
-export GH_PAT=ghp_xxxx...
+export NOTION_TOKEN=ntn_xxxx...
+# For a local manual run, provide a token with target-repository access.
+export GITHUB_TOKEN=github_token_here
 export NOTION_DATABASE_ID_CHANGES=xxx...
 python scripts/notion_to_github.py
 # Preflight will guide you through any missing config


### PR DESCRIPTION
## Summary
Updates the TNV Notion-to-GitHub sync documentation to use the automatic GitHub Actions `GITHUB_TOKEN` model.

## What changed
- removes the obsolete personal-access-token and 90-day setup guidance
- documents the automatic same-repository `GITHUB_TOKEN`
- documents required job permissions: `contents: write` and `issues: write`
- clarifies local-manual and cross-repository access boundaries

## Validation
- `python scripts/validate_docs.py`
- `python -m unittest discover -s tests -p "test_*.py" -v` (34 passed)
- `git diff --check`
- confirmed no workflow-file diff

## Scope
- documentation and setup material only
- no workflow, script, test, or repository-secret changes
- no merge and no workflow run