### PR TITLE
docs(control-tower): add ChatGPT Work to local Codex bridge test

### DIFF
--- a/.codex/chatgpt-work-bridge-001.json
+++ b/.codex/chatgpt-work-bridge-001.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0",
+  "bridge_id": "CHATGPT-WORK-BRIDGE-001",
+  "activation_mode": "manual-only",
+  "poll_interval_minutes": 10,
+  "polling_enabled": false,
+  "notion_issue_intake": {
+    "enabled": false,
+    "transport": "existing Notion to GitHub issue exporter",
+    "execute_issue_body": false
+  },
+  "codex_exec": {
+    "ephemeral": true,
+    "sandbox": "workspace-write",
+    "approval_policy": "never",
+    "danger_full_access": false,
+    "load_user_config": true,
+    "load_project_rules": true
+  },
+  "publish": {
+    "enabled_by_default": false,
+    "gate_phrase": "PUBLISH CHATGPT-WORK-BRIDGE-001",
+    "remote": "origin",
+    "branch": "codex/chatgpt-work-bridge-001",
+    "merge_allowed": false
+  },
+  "promotion_gate": {
+    "manual_cycles_required": 3,
+    "current_clean_cycles": 0,
+    "automatic_activation_allowed": false
+  }
+}

--- a/docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md
+++ b/docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md
@@ -1,0 +1,112 @@
+# CHATGPT-WORK-BRIDGE-001 — Cloud Work to Local Codex Handoff
+
+Status: `awaiting-local-codex`  
+Date: 2026-07-13  
+Repository: `Terra-Nova-Restore/TerraNova-s-Framework`  
+Branch: `codex/chatgpt-work-bridge-001`  
+Base commit: `e5ddb0e15e342593d5ead8f0e92ffd89a93463ca`  
+Requested by: Silvan Lenhard  
+Created by: ChatGPT Work through the connected GitHub runtime  
+Source of record for this test: GitHub branch and draft PR  
+Mutation policy: GitHub trace only
+
+## Purpose
+
+Verify a bounded, auditable handoff from a cloud ChatGPT Work thread to a
+locally running Codex instance and back through GitHub.
+
+This test does **not** claim a direct runtime or remote-host connection between
+the two agents. It verifies the shared, versioned bridge:
+
+```text
+ChatGPT Work
+-> GitHub request artifact
+-> local Codex
+-> GitHub result artifact
+-> ChatGPT Work verification
+```
+
+The batch extends the existing CAP Control Tower runtime and the earlier
+`PAUSE-001` handoff pattern. It does not introduce a parallel inbox/outbox
+architecture.
+
+## Required reading
+
+Before acting, local Codex must read:
+
+- `docs/governance/public_boundary.md`
+- `docs/governance/chatgpt_connector_runtime_policy.md`
+- `docs/atlas/control-tower/README.md`
+- `docs/atlas/control-tower/local-worktree-cleanup-001.md`
+- `docs/atlas/control-tower/causal-log.pause-001-handoff-2026-05-18.json`
+- `docs/atlas/control-tower/chatgpt-work-bridge-001.request.json`
+
+## Task for local Codex
+
+1. Fetch the remote branch `codex/chatgpt-work-bridge-001`.
+2. Use an existing safe TerraNova worktree or create a new non-destructive
+   worktree for this branch.
+3. Confirm that this request can be read locally.
+4. Perform a metadata-only local verification:
+   - repository is available;
+   - checked-out branch is correct;
+   - the worktree is readable and writable;
+   - the public-boundary documents are present;
+   - the current task can be completed without exposing private local data.
+5. Create these two result artifacts:
+   - `docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json`
+   - `docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json`
+6. Commit and push the two artifacts to the **same branch**.
+7. Do not merge the draft PR. Leave final verification to ChatGPT Work and the
+   human owner.
+
+## Result requirements
+
+The local result must be public-safe and include:
+
+- bridge ID;
+- actor label `local-codex`;
+- UTC observation time;
+- repository full name;
+- branch name;
+- base commit observed;
+- booleans for request readability, worktree readability and branch writability;
+- count of local TerraNova worktrees, without absolute paths;
+- labels for relevant worktree roles, without usernames or private paths;
+- public-boundary check result;
+- list of result files created;
+- final status: `pass`, `partial` or `blocked`;
+- blockers, if any.
+
+## Hard boundaries
+
+Do not include or expose:
+
+- absolute local filesystem paths;
+- usernames, device identifiers or hostnames;
+- environment variables, credentials, cookies or tokens;
+- raw Codex/ChatGPT session history;
+- private prompt or conversation content;
+- raw token-usage databases;
+- raw Notion IDs or private workspace URLs;
+- patent-sensitive, Track C, GODFATHER_LOCK or other protected material.
+
+Do not:
+
+- delete or clean up worktrees;
+- force-reset branches;
+- push directly to `main`;
+- mutate Notion or Zenodo;
+- dispatch workflows;
+- alter existing active worktrees;
+- use Notion AI credits.
+
+## Success condition
+
+The bridge passes when ChatGPT Work can read the two local result artifacts from
+the remote branch without the user copying, pasting or uploading their contents.
+
+## Stop rule
+
+If any required verification would cross the public boundary, record
+`status: blocked` with a redacted reason and stop.

--- a/docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md
+++ b/docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md
@@ -21,14 +21,64 @@ the two agents. It verifies the shared, versioned bridge:
 ```text
 ChatGPT Work
 -> GitHub request artifact
+-> local receiver
 -> local Codex
--> GitHub result artifact
+-> validated GitHub result artifact
 -> ChatGPT Work verification
 ```
 
 The batch extends the existing CAP Control Tower runtime and the earlier
 `PAUSE-001` handoff pattern. It does not introduce a parallel inbox/outbox
 architecture.
+
+## Source review and architecture correction
+
+A targeted Notion and GitHub source review on 2026-07-13 established:
+
+- The production 10-minute workflow is a one-way Notion-to-GitHub issue
+  exporter. It selects database rows with `Export_to_GitHub=true` and an empty
+  `GitHub_Issue_URL`, creates or reuses a GitHub issue, writes the issue URL and
+  export date back to Notion, and stores a shadow record.
+- That workflow is an intake and trace mechanism. It is **not** a Codex runtime
+  trigger and must not be silently redefined as one.
+- The existing local architecture deliberately keeps Codex as the local
+  implementation hand, GitHub as the technical trace, and Notion as the living
+  source of record.
+- Existing Codex handoffs require a Silvan-forward. A laconic instruction is
+  sufficient, but the human dispatch gate remains explicit.
+- `TNC-AUTO-001` already provides local-only, default-deny controller and
+  validation patterns. The limited-live watcher remains manual-gated and has
+  not completed its three clean live-push promotion cycles.
+
+Therefore this trial adds a **manual local receiver** without modifying the
+production Notion sync and without enabling a background loop.
+
+## Local receiver v0.1
+
+Tracked components:
+
+- `.codex/chatgpt-work-bridge-001.json` — activation, Codex and publish policy;
+- `scripts/chatgpt_work_bridge_001.py` — observe, run, validate and publish
+  state machine;
+- `tests/test_chatgpt_work_bridge_001.py` — contract and refusal tests;
+- `docs/atlas/control-tower/chatgpt-work-bridge-001.request.json` — bounded
+  request contract.
+
+Initial state:
+
+```text
+activation_mode: manual-only
+polling_enabled: false
+notion_issue_intake_enabled: false
+publish_enabled_by_default: false
+clean_manual_cycles: 0/3
+```
+
+The receiver uses `codex exec` in ephemeral `workspace-write` mode. It does not
+use `danger-full-access`, does not ignore project rules or user configuration,
+and does not give Codex responsibility for the GitHub push. Codex writes the
+two local result artifacts; the deterministic receiver validates and publishes
+only those files after a separate exact gate.
 
 ## Required reading
 
@@ -41,24 +91,42 @@ Before acting, local Codex must read:
 - `docs/atlas/control-tower/causal-log.pause-001-handoff-2026-05-18.json`
 - `docs/atlas/control-tower/chatgpt-work-bridge-001.request.json`
 
+## Initial manual cycle
+
+Run from a clean checkout of `codex/chatgpt-work-bridge-001`:
+
+```text
+python scripts/chatgpt_work_bridge_001.py observe
+python scripts/chatgpt_work_bridge_001.py run
+python scripts/chatgpt_work_bridge_001.py validate-result
+```
+
+The first three commands perform no GitHub remote mutation. After reviewing the
+two generated files, publish them with the explicit, separately scoped gate:
+
+```text
+python scripts/chatgpt_work_bridge_001.py publish \
+  --gate "PUBLISH CHATGPT-WORK-BRIDGE-001"
+```
+
+The publish step refuses unrelated staged or worktree changes, stages exactly
+the two expected outputs, creates one commit, pushes only to the named branch,
+and never merges.
+
 ## Task for local Codex
 
-1. Fetch the remote branch `codex/chatgpt-work-bridge-001`.
-2. Use an existing safe TerraNova worktree or create a new non-destructive
-   worktree for this branch.
-3. Confirm that this request can be read locally.
-4. Perform a metadata-only local verification:
+1. Confirm that the repository-local request can be read.
+2. Perform a metadata-only local verification:
    - repository is available;
    - checked-out branch is correct;
    - the worktree is readable and writable;
    - the public-boundary documents are present;
    - the current task can be completed without exposing private local data.
-5. Create these two result artifacts:
+3. Create these two result artifacts:
    - `docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json`
    - `docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json`
-6. Commit and push the two artifacts to the **same branch**.
-7. Do not merge the draft PR. Leave final verification to ChatGPT Work and the
-   human owner.
+4. Do not commit, push or merge. Publishing belongs to the receiver's separate
+   exact gate.
 
 ## Result requirements
 
@@ -99,7 +167,19 @@ Do not:
 - mutate Notion or Zenodo;
 - dispatch workflows;
 - alter existing active worktrees;
+- execute a Notion-exported GitHub issue body as a prompt;
+- enable polling or a scheduler during the initial trial;
 - use Notion AI credits.
+
+## Promotion path
+
+The existing 10-minute Notion exporter may become an optional intake signal
+only after three clean manual bridge cycles and a separate activation gate.
+Even then, an issue body remains untrusted data: it may point to a committed,
+validated request contract but is never executed directly.
+
+No scheduler, daemon, self-hosted runner, generic issue trigger or automatic
+publish is authorized by this draft.
 
 ## Success condition
 

--- a/docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-cloud-2026-07-13.json
+++ b/docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-cloud-2026-07-13.json
@@ -1,0 +1,35 @@
+{
+  "log_id": "CAP-LOG-2026-07-13-CHATGPT-WORK-BRIDGE-001-CLOUD-ATTEMPT",
+  "event_id": "CHATGPT-WORK-BRIDGE-001-CLOUD-ATTEMPT-001",
+  "created_at": "2026-07-13T14:25:00Z",
+  "activation": "User instructed ChatGPT Work to inspect PR #94 and execute CHATGPT-WORK-BRIDGE-001 without merging.",
+  "actor": "chatgpt-work",
+  "mode": "explicit execution attempt",
+  "observation": "The GitHub PR and request contract are readable, but no callable local Codex session, desktop remote host, laptop filesystem or local repository checkout is exposed to the active runtime.",
+  "selected_action": "Stopped before local attestation and recorded a public-safe blocked attempt instead of fabricating a local Codex result.",
+  "source_refs": [
+    "GitHub PR #94",
+    "docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md",
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.request.json",
+    "docs/governance/public_boundary.md",
+    "docs/governance/chatgpt_connector_runtime_policy.md"
+  ],
+  "deterministic_boundary": [
+    "No claim of laptop-local execution",
+    "No local path, hostname, username or device identifier recorded",
+    "No raw session or token data read",
+    "No Notion or Zenodo mutation",
+    "No manual workflow dispatch",
+    "No merge"
+  ],
+  "external_mutation": true,
+  "external_mutation_scope": "GitHub trace only",
+  "result": "blocked",
+  "blocker_code": "NO_LOCAL_CODEX_REMOTE_HANDLE",
+  "backpropagation_target": [
+    "CAP Control Tower",
+    "ChatGPT connector runtime policy",
+    "future local Codex handoff"
+  ],
+  "next_recommended_action": "Local Codex consumes PR #94 and writes the two expected local result artifacts, or a supported desktop remote-host surface is exposed to ChatGPT Work."
+}

--- a/docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json
+++ b/docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json
@@ -1,0 +1,41 @@
+{
+  "log_id": "CHATGPT-WORK-BRIDGE-001-LOCAL-2026-07-13",
+  "created_at": "2026-07-13T19:23:45Z",
+  "bridge_id": "CHATGPT-WORK-BRIDGE-001",
+  "actor": "local-codex",
+  "observed_at_utc": "2026-07-13T19:23:45Z",
+  "mode": "BIZ",
+  "activation": "manual",
+  "source_trace": [
+    "docs/governance/public_boundary.md",
+    "docs/governance/chatgpt_connector_runtime_policy.md",
+    "docs/atlas/control-tower/README.md",
+    "docs/atlas/control-tower/local-worktree-cleanup-001.md",
+    "docs/atlas/control-tower/causal-log.pause-001-handoff-2026-05-18.json",
+    "docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md",
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.request.json",
+    ".codex/chatgpt-work-bridge-001.json"
+  ],
+  "observation": "The repository-local request and configuration were readable, the requested base commit was present in branch history, and the named branch was checked out in a separate readable and writable worktree.",
+  "trigger_band": "not_applicable",
+  "trigger_ids": [],
+  "probabilistic_hypothesis": "A validated public-safe result commit can complete the bounded GitHub handoff without a direct runtime connection between the two agents.",
+  "probability_note": "The local conclusion is metadata-only; remote visibility is verified by the gated publish step.",
+  "deterministic_boundary": [
+    "GitHub trace only",
+    "Publish only the two expected result artifacts after the exact gate",
+    "No merge",
+    "No Notion or Zenodo mutation",
+    "No workflow dispatch",
+    "No worktree cleanup or branch reset",
+    "No private local metadata in result artifacts"
+  ],
+  "selected_action": "Created the two public-safe result artifacts for deterministic validation.",
+  "feedback_target": "github_atlas",
+  "backpropagation_result": "Prepared a local pass result for validation and gated publication.",
+  "verification_state": "repo_checked",
+  "result": "pass",
+  "external_mutation": false,
+  "mutation_authorization": "",
+  "blockers": []
+}

--- a/docs/atlas/control-tower/chatgpt-work-bridge-001.cloud-attempt.json
+++ b/docs/atlas/control-tower/chatgpt-work-bridge-001.cloud-attempt.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0",
+  "bridge_id": "CHATGPT-WORK-BRIDGE-001",
+  "attempt_id": "CHATGPT-WORK-BRIDGE-001-CLOUD-ATTEMPT-001",
+  "actor": "chatgpt-work",
+  "observed_at_utc": "2026-07-13T14:25:00Z",
+  "repository_full_name": "Terra-Nova-Restore/TerraNova-s-Framework",
+  "branch": "codex/chatgpt-work-bridge-001",
+  "pull_request": 94,
+  "request_readable": true,
+  "pull_request_readable": true,
+  "local_codex_host_exposed_to_runtime": false,
+  "local_laptop_filesystem_exposed_to_runtime": false,
+  "execution_environment": "isolated-cloud-workspace",
+  "repository_checkout_present_in_execution_environment": false,
+  "github_connector_available": true,
+  "expected_local_outputs_present": false,
+  "public_boundary_check": "pass",
+  "external_mutations": [
+    "GitHub trace artifacts on the test branch",
+    "automatic preconfigured PR preview integrations"
+  ],
+  "manual_workflow_dispatch": false,
+  "status": "blocked",
+  "blocker_code": "NO_LOCAL_CODEX_REMOTE_HANDLE",
+  "blocker": "The ChatGPT Work runtime has no callable local Codex session or connected desktop host. It cannot truthfully execute or attest the laptop-local verification.",
+  "required_condition_to_continue": "A local Codex instance must consume PR #94, or the desktop host must be exposed to this runtime as a callable remote task surface.",
+  "protected_data_read": false,
+  "secrets_read": false,
+  "local_result_fabricated": false
+}

--- a/docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json
+++ b/docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json
@@ -1,0 +1,35 @@
+{
+  "bridge_id": "CHATGPT-WORK-BRIDGE-001",
+  "actor": "local-codex",
+  "observed_at_utc": "2026-07-13T19:23:45Z",
+  "repository_full_name": "Terra-Nova-Restore/TerraNova-s-Framework",
+  "branch": "codex/chatgpt-work-bridge-001",
+  "base_commit_observed": "e5ddb0e15e342593d5ead8f0e92ffd89a93463ca",
+  "request_readable": true,
+  "worktree_readable": true,
+  "branch_writable": true,
+  "terranova_worktree_count": 14,
+  "worktree_role_labels": [
+    "tnc-watch-review",
+    "detached-tool-lane-1",
+    "detached-tool-lane-2",
+    "token-docs",
+    "cei-cycle03",
+    "gumroad-ci-fix",
+    "portal-validator-backlog",
+    "cap-runtime",
+    "tnc-auto-dry-run",
+    "tnc-watch-calibration",
+    "zenodo-legacy-retry",
+    "control-tower-trace",
+    "zenodo-v3-mainline",
+    "bridge-trial"
+  ],
+  "public_boundary_check": "pass",
+  "files_created": [
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json",
+    "docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json"
+  ],
+  "status": "pass",
+  "blockers": []
+}

--- a/docs/atlas/control-tower/chatgpt-work-bridge-001.request.json
+++ b/docs/atlas/control-tower/chatgpt-work-bridge-001.request.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "bridge_id": "CHATGPT-WORK-BRIDGE-001",
   "created_at": "2026-07-13T00:00:00Z",
   "requested_by": "Silvan Lenhard",
@@ -11,6 +11,14 @@
   "status": "awaiting-local-codex",
   "mode": "github-trace-only",
   "purpose": "Verify a bounded two-way artifact handoff between cloud ChatGPT Work and local Codex through GitHub.",
+  "dispatch": {
+    "human_dispatch_authorized": true,
+    "authorization_scope": "reversible bridge trial; GitHub trace only; do not merge",
+    "activation_mode": "manual-only",
+    "polling_enabled": false,
+    "notion_issue_intake_enabled": false,
+    "publish_gate": "PUBLISH CHATGPT-WORK-BRIDGE-001"
+  },
   "required_reads": [
     "docs/governance/public_boundary.md",
     "docs/governance/chatgpt_connector_runtime_policy.md",
@@ -27,8 +35,10 @@
     "fetch the named remote branch",
     "use or create a non-destructive worktree",
     "read repository-local public-safe metadata",
+    "invoke codex exec in ephemeral workspace-write mode",
     "create the two expected result artifacts",
-    "commit and push only to the named branch"
+    "validate the two expected result artifacts",
+    "after a separate exact publish gate, commit and push only the two result artifacts to the named branch"
   ],
   "blocked_actions": [
     "push to main",
@@ -39,6 +49,8 @@
     "read or publish raw token databases",
     "mutate Notion or Zenodo",
     "dispatch workflows",
+    "enable background polling or a scheduler",
+    "execute a Notion-exported GitHub issue body as a prompt",
     "include secrets or protected material"
   ],
   "result_contract": {

--- a/docs/atlas/control-tower/chatgpt-work-bridge-001.request.json
+++ b/docs/atlas/control-tower/chatgpt-work-bridge-001.request.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0",
+  "bridge_id": "CHATGPT-WORK-BRIDGE-001",
+  "created_at": "2026-07-13T00:00:00Z",
+  "requested_by": "Silvan Lenhard",
+  "request_actor": "chatgpt-work",
+  "execution_actor": "local-codex",
+  "repository_full_name": "Terra-Nova-Restore/TerraNova-s-Framework",
+  "branch": "codex/chatgpt-work-bridge-001",
+  "base_commit": "e5ddb0e15e342593d5ead8f0e92ffd89a93463ca",
+  "status": "awaiting-local-codex",
+  "mode": "github-trace-only",
+  "purpose": "Verify a bounded two-way artifact handoff between cloud ChatGPT Work and local Codex through GitHub.",
+  "required_reads": [
+    "docs/governance/public_boundary.md",
+    "docs/governance/chatgpt_connector_runtime_policy.md",
+    "docs/atlas/control-tower/README.md",
+    "docs/atlas/control-tower/local-worktree-cleanup-001.md",
+    "docs/atlas/control-tower/causal-log.pause-001-handoff-2026-05-18.json",
+    "docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md"
+  ],
+  "expected_outputs": [
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json",
+    "docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json"
+  ],
+  "allowed_actions": [
+    "fetch the named remote branch",
+    "use or create a non-destructive worktree",
+    "read repository-local public-safe metadata",
+    "create the two expected result artifacts",
+    "commit and push only to the named branch"
+  ],
+  "blocked_actions": [
+    "push to main",
+    "merge the draft PR",
+    "delete or reset worktrees",
+    "expose absolute local paths or host identifiers",
+    "read or publish private session content",
+    "read or publish raw token databases",
+    "mutate Notion or Zenodo",
+    "dispatch workflows",
+    "include secrets or protected material"
+  ],
+  "result_contract": {
+    "required_fields": [
+      "bridge_id",
+      "actor",
+      "observed_at_utc",
+      "repository_full_name",
+      "branch",
+      "base_commit_observed",
+      "request_readable",
+      "worktree_readable",
+      "branch_writable",
+      "terranova_worktree_count",
+      "worktree_role_labels",
+      "public_boundary_check",
+      "files_created",
+      "status",
+      "blockers"
+    ],
+    "status_enum": [
+      "pass",
+      "partial",
+      "blocked"
+    ],
+    "absolute_paths_allowed": false,
+    "secrets_allowed": false,
+    "private_content_allowed": false
+  },
+  "success_condition": "ChatGPT Work reads both local result artifacts from the remote branch without user copy/paste or upload.",
+  "stop_rule": "If verification would cross the public boundary, write a redacted blocked result and stop."
+}

--- a/scripts/chatgpt_work_bridge_001.py
+++ b/scripts/chatgpt_work_bridge_001.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Bounded local receiver for CHATGPT-WORK-BRIDGE-001.
+
+The receiver validates a repository-local request, can invoke ``codex exec``
+with an ephemeral workspace-write sandbox, validates the two public-safe result
+artifacts, and can publish only those artifacts after an exact human gate.
+
+It is deliberately not a daemon. Polling and Notion-issue intake remain off
+until separate promotion gates are satisfied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+
+BRIDGE_ID = "CHATGPT-WORK-BRIDGE-001"
+REPOSITORY_FULL_NAME = "Terra-Nova-Restore/TerraNova-s-Framework"
+BRANCH = "codex/chatgpt-work-bridge-001"
+PUBLISH_GATE = "PUBLISH CHATGPT-WORK-BRIDGE-001"
+
+DEFAULT_REQUEST = Path(
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.request.json"
+)
+DEFAULT_CONFIG = Path(".codex/chatgpt-work-bridge-001.json")
+EXPECTED_OUTPUTS = (
+    "docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json",
+    "docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json",
+)
+RESULT_STATUSES = {"pass", "partial", "blocked"}
+PUBLIC_BOUNDARY_STATUSES = {"pass", "blocked"}
+REQUIRED_RESULT_FIELDS = {
+    "bridge_id",
+    "actor",
+    "observed_at_utc",
+    "repository_full_name",
+    "branch",
+    "base_commit_observed",
+    "request_readable",
+    "worktree_readable",
+    "branch_writable",
+    "terranova_worktree_count",
+    "worktree_role_labels",
+    "public_boundary_check",
+    "files_created",
+    "status",
+    "blockers",
+}
+FORBIDDEN_KEYS = {
+    "absolute_path",
+    "absolute_paths",
+    "device_id",
+    "environment",
+    "environment_variables",
+    "hostname",
+    "password",
+    "session_history",
+    "token_value",
+    "username",
+}
+SENSITIVE_VALUE_PATTERNS = (
+    re.compile(
+        r"(?:^|\s)(?:[A-Za-z]:[\\/]|\\\\[^\\\s]+[\\/]|/(?:home|Users|workspace|root|mnt|tmp|private/tmp)/)"
+    ),
+    re.compile(r"\b(?:ghp_|github_pat_|secret_|sk-[A-Za-z0-9])"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~-]+", re.IGNORECASE),
+    re.compile(
+        r"https?://(?:(?:www\.)?notion\.so/|app\.notion\.com/p/)[A-Za-z0-9_-]{20,}",
+        re.IGNORECASE,
+    ),
+    re.compile(r"https?://[^\s]*\.notion\.site/[A-Za-z0-9_-]{20,}", re.IGNORECASE),
+)
+
+
+class BridgeError(RuntimeError):
+    """A public-safe bridge refusal or validation failure."""
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BridgeError(f"missing JSON file: {path.as_posix()}") from exc
+    except json.JSONDecodeError as exc:
+        raise BridgeError(f"invalid JSON file: {path.as_posix()}") from exc
+    if not isinstance(payload, dict):
+        raise BridgeError(f"JSON root must be an object: {path.as_posix()}")
+    return payload
+
+
+def run_git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise BridgeError(f"git command failed: {' '.join(args[:2])}")
+    return result
+
+
+def ensure_repo_relative(path: str) -> None:
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise BridgeError(f"request contains non-relative path: {path}")
+
+
+def current_branch(root: Path) -> str:
+    return run_git(root, "branch", "--show-current").stdout.strip()
+
+
+def assert_git_repository(root: Path) -> None:
+    result = run_git(root, "rev-parse", "--is-inside-work-tree", check=False)
+    if result.returncode != 0 or result.stdout.strip() != "true":
+        raise BridgeError("receiver must run inside a Git worktree")
+
+
+def validate_config(config: dict[str, Any]) -> None:
+    if config.get("bridge_id") != BRIDGE_ID:
+        raise BridgeError("config bridge_id mismatch")
+    if config.get("activation_mode") != "manual-only":
+        raise BridgeError("initial activation must remain manual-only")
+    if config.get("polling_enabled") is not False:
+        raise BridgeError("polling must remain disabled for the initial trial")
+
+    notion = config.get("notion_issue_intake")
+    if not isinstance(notion, dict):
+        raise BridgeError("missing notion_issue_intake config")
+    if notion.get("enabled") is not False or notion.get("execute_issue_body") is not False:
+        raise BridgeError("Notion issue intake must remain disabled and non-executable")
+
+    codex = config.get("codex_exec")
+    if not isinstance(codex, dict):
+        raise BridgeError("missing codex_exec config")
+    expected_codex = {
+        "ephemeral": True,
+        "sandbox": "workspace-write",
+        "approval_policy": "never",
+        "danger_full_access": False,
+        "load_user_config": True,
+        "load_project_rules": True,
+    }
+    for key, expected in expected_codex.items():
+        if codex.get(key) != expected:
+            raise BridgeError(f"unsafe or unsupported codex_exec setting: {key}")
+
+    publish = config.get("publish")
+    if not isinstance(publish, dict):
+        raise BridgeError("missing publish config")
+    if publish.get("enabled_by_default") is not False:
+        raise BridgeError("publish must be disabled by default")
+    if publish.get("gate_phrase") != PUBLISH_GATE:
+        raise BridgeError("publish gate mismatch")
+    if publish.get("branch") != BRANCH or publish.get("merge_allowed") is not False:
+        raise BridgeError("publish boundary mismatch")
+
+    promotion = config.get("promotion_gate")
+    if not isinstance(promotion, dict):
+        raise BridgeError("missing promotion_gate config")
+    if promotion.get("manual_cycles_required") != 3:
+        raise BridgeError("initial promotion gate requires three manual cycles")
+    if promotion.get("automatic_activation_allowed") is not False:
+        raise BridgeError("automatic activation is not authorized")
+
+
+def validate_request(request: dict[str, Any], root: Path) -> None:
+    exact = {
+        "bridge_id": BRIDGE_ID,
+        "request_actor": "chatgpt-work",
+        "execution_actor": "local-codex",
+        "repository_full_name": REPOSITORY_FULL_NAME,
+        "branch": BRANCH,
+        "status": "awaiting-local-codex",
+        "mode": "github-trace-only",
+    }
+    for key, expected in exact.items():
+        if request.get(key) != expected:
+            raise BridgeError(f"request field mismatch: {key}")
+
+    dispatch = request.get("dispatch")
+    if not isinstance(dispatch, dict):
+        raise BridgeError("request is missing dispatch gate")
+    if dispatch.get("human_dispatch_authorized") is not True:
+        raise BridgeError("human dispatch is not authorized")
+    if dispatch.get("activation_mode") != "manual-only":
+        raise BridgeError("request activation must remain manual-only")
+    if dispatch.get("polling_enabled") is not False:
+        raise BridgeError("request polling must remain disabled")
+    if dispatch.get("notion_issue_intake_enabled") is not False:
+        raise BridgeError("request Notion intake must remain disabled")
+
+    required_reads = request.get("required_reads")
+    if not isinstance(required_reads, list) or not required_reads:
+        raise BridgeError("request required_reads must be a non-empty list")
+    for rel in required_reads:
+        if not isinstance(rel, str):
+            raise BridgeError("required_reads entries must be strings")
+        ensure_repo_relative(rel)
+        if not (root / rel).is_file():
+            raise BridgeError(f"required read is missing: {rel}")
+
+    outputs = request.get("expected_outputs")
+    if tuple(outputs or ()) != EXPECTED_OUTPUTS:
+        raise BridgeError("request expected_outputs mismatch")
+    for rel in EXPECTED_OUTPUTS:
+        ensure_repo_relative(rel)
+
+    contract = request.get("result_contract")
+    if not isinstance(contract, dict):
+        raise BridgeError("request result_contract is missing")
+    if set(contract.get("required_fields") or ()) != REQUIRED_RESULT_FIELDS:
+        raise BridgeError("request result required_fields mismatch")
+    if set(contract.get("status_enum") or ()) != RESULT_STATUSES:
+        raise BridgeError("request status_enum mismatch")
+    if contract.get("absolute_paths_allowed") is not False:
+        raise BridgeError("absolute paths must remain blocked")
+    if contract.get("secrets_allowed") is not False:
+        raise BridgeError("secrets must remain blocked")
+    if contract.get("private_content_allowed") is not False:
+        raise BridgeError("private content must remain blocked")
+
+
+def iter_payload_items(value: Any, key: str = "") -> Iterable[tuple[str, Any]]:
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            yield child_key, child_value
+            yield from iter_payload_items(child_value, child_key)
+    elif isinstance(value, list):
+        for child_value in value:
+            yield key, child_value
+            yield from iter_payload_items(child_value, key)
+
+
+def validate_public_safe_payload(payload: dict[str, Any]) -> None:
+    for key, value in iter_payload_items(payload):
+        if key.lower() in FORBIDDEN_KEYS:
+            raise BridgeError(f"forbidden result field: {key}")
+        if isinstance(value, str):
+            if any(pattern.search(value) for pattern in SENSITIVE_VALUE_PATTERNS):
+                raise BridgeError("result contains a forbidden path, credential shape or private URL")
+
+
+def validate_result_payload(payload: dict[str, Any]) -> None:
+    missing = REQUIRED_RESULT_FIELDS - set(payload)
+    if missing:
+        raise BridgeError("result is missing required fields: " + ", ".join(sorted(missing)))
+    exact = {
+        "bridge_id": BRIDGE_ID,
+        "actor": "local-codex",
+        "repository_full_name": REPOSITORY_FULL_NAME,
+        "branch": BRANCH,
+    }
+    for key, expected in exact.items():
+        if payload.get(key) != expected:
+            raise BridgeError(f"result field mismatch: {key}")
+    if payload.get("status") not in RESULT_STATUSES:
+        raise BridgeError("invalid result status")
+    if payload.get("public_boundary_check") not in PUBLIC_BOUNDARY_STATUSES:
+        raise BridgeError("invalid public_boundary_check")
+    if not re.fullmatch(r"[0-9a-f]{40}", str(payload.get("base_commit_observed", ""))):
+        raise BridgeError("base_commit_observed must be a full lowercase SHA-1")
+    for key in ("request_readable", "worktree_readable", "branch_writable"):
+        if not isinstance(payload.get(key), bool):
+            raise BridgeError(f"result field must be boolean: {key}")
+    count = payload.get("terranova_worktree_count")
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        raise BridgeError("terranova_worktree_count must be a non-negative integer")
+    labels = payload.get("worktree_role_labels")
+    if not isinstance(labels, list) or not all(
+        isinstance(label, str) and re.fullmatch(r"[a-z0-9._-]{1,64}", label)
+        for label in labels
+    ):
+        raise BridgeError("worktree_role_labels must contain public-safe labels")
+    if tuple(payload.get("files_created") or ()) != EXPECTED_OUTPUTS:
+        raise BridgeError("files_created mismatch")
+    blockers = payload.get("blockers")
+    if not isinstance(blockers, list) or not all(isinstance(item, str) for item in blockers):
+        raise BridgeError("blockers must be a list of strings")
+    validate_public_safe_payload(payload)
+
+
+def validate_causal_log(payload: dict[str, Any]) -> None:
+    expected = {
+        "bridge_id": BRIDGE_ID,
+        "actor": "local-codex",
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise BridgeError(f"causal log field mismatch: {key}")
+    if payload.get("result") not in RESULT_STATUSES:
+        raise BridgeError("causal log result is invalid")
+    if payload.get("external_mutation") is not False:
+        raise BridgeError("causal log must precede publish and report no external mutation")
+    if not isinstance(payload.get("observed_at_utc"), str):
+        raise BridgeError("causal log observed_at_utc is missing")
+    validate_public_safe_payload(payload)
+
+
+def validate_result_files(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    result = load_json(root / EXPECTED_OUTPUTS[0])
+    causal = load_json(root / EXPECTED_OUTPUTS[1])
+    validate_result_payload(result)
+    validate_causal_log(causal)
+    if causal.get("result") != result.get("status"):
+        raise BridgeError("result and causal log statuses disagree")
+    return result, causal
+
+
+def observe(root: Path, request: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    assert_git_repository(root)
+    validate_config(config)
+    validate_request(request, root)
+    branch = current_branch(root)
+    blockers: list[str] = []
+    if branch != BRANCH:
+        blockers.append("WRONG_BRANCH")
+    if shutil.which("codex") is None:
+        blockers.append("CODEX_CLI_NOT_FOUND")
+    if not os.access(root, os.R_OK | os.W_OK):
+        blockers.append("WORKTREE_NOT_READ_WRITE")
+    return {
+        "bridge_id": BRIDGE_ID,
+        "mode": "manual-observe",
+        "request_readable": True,
+        "config_valid": True,
+        "branch_correct": branch == BRANCH,
+        "codex_cli_available": "CODEX_CLI_NOT_FOUND" not in blockers,
+        "polling_enabled": False,
+        "notion_issue_intake_enabled": False,
+        "publish_enabled_by_default": False,
+        "status": "ready" if not blockers else "blocked",
+        "blockers": blockers,
+    }
+
+
+def build_codex_prompt() -> str:
+    result_path, causal_path = EXPECTED_OUTPUTS
+    return f"""Execute {BRIDGE_ID} from the repository-local request contract.
+
+Read the files listed in {DEFAULT_REQUEST.as_posix()} before acting. Perform only
+the metadata-only local verification described there. Do not use network tools,
+do not commit, do not push, do not merge, and do not mutate Notion or Zenodo.
+
+Create exactly these two public-safe JSON artifacts:
+- {result_path}
+- {causal_path}
+
+The result artifact must contain every required field from result_contract.
+Use actor \"local-codex\", repository \"{REPOSITORY_FULL_NAME}\", branch
+\"{BRANCH}\", and a full lowercase 40-character SHA-1 for
+base_commit_observed. Use only public-safe worktree role labels such as
+\"bridge-trial\" or \"main-baseline\"; never include filesystem paths,
+usernames, device/host identifiers, environment variables, credentials, private
+URLs, session content, token databases, or protected material.
+
+The causal log must contain bridge_id, actor, observed_at_utc, result,
+observation, selected_action, deterministic_boundary, external_mutation=false,
+and blockers. Its result must equal the result artifact status.
+
+If any check would cross the public boundary, write status/result \"blocked\"
+with a redacted blocker and stop. Leave publishing to the deterministic receiver.
+"""
+
+
+def build_codex_command(codex_bin: str, root: Path) -> list[str]:
+    return [
+        codex_bin,
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--ephemeral",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        str(root),
+        build_codex_prompt(),
+    ]
+
+
+def execute_codex(root: Path, codex_bin: str, timeout_seconds: int) -> None:
+    resolved = shutil.which(codex_bin)
+    if resolved is None:
+        raise BridgeError("Codex CLI is not available")
+    command = build_codex_command(resolved, root)
+    with tempfile.TemporaryDirectory(prefix="chatgpt-work-bridge-001-") as temp_dir:
+        final_message = Path(temp_dir) / "last-message.txt"
+        command[-1:-1] = ["--output-last-message", str(final_message)]
+        result = subprocess.run(
+            command,
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise BridgeError(f"Codex execution failed with exit code {result.returncode}")
+    validate_result_files(root)
+
+
+def changed_paths(root: Path) -> set[str]:
+    result = run_git(root, "status", "--porcelain=v1", "--untracked-files=all")
+    paths: set[str] = set()
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.add(path)
+    return paths
+
+
+def publish_results(root: Path, gate: str) -> str:
+    if gate != PUBLISH_GATE:
+        raise BridgeError("exact publish gate is required")
+    assert_git_repository(root)
+    if current_branch(root) != BRANCH:
+        raise BridgeError("publish is allowed only from the bridge branch")
+    validate_result_files(root)
+
+    staged_before = {
+        line for line in run_git(root, "diff", "--cached", "--name-only").stdout.splitlines() if line
+    }
+    if staged_before:
+        raise BridgeError("refusing publish because unrelated staged changes exist")
+    dirty = changed_paths(root)
+    unexpected = dirty - set(EXPECTED_OUTPUTS)
+    if unexpected:
+        raise BridgeError("refusing publish because unrelated worktree changes exist")
+    if dirty:
+        if not set(EXPECTED_OUTPUTS).issubset(dirty):
+            raise BridgeError("expected result artifacts are not both pending publication")
+        run_git(root, "add", "--", *EXPECTED_OUTPUTS)
+        staged = {
+            line
+            for line in run_git(root, "diff", "--cached", "--name-only").stdout.splitlines()
+            if line
+        }
+        if staged != set(EXPECTED_OUTPUTS):
+            raise BridgeError("staged publication scope mismatch")
+        run_git(root, "commit", "-m", "docs(control-tower): record local bridge result")
+    else:
+        # A previous push may have failed after the exact result commit was
+        # created. Permit a gated retry only when HEAD contains exactly the two
+        # expected result paths.
+        head_paths = {
+            line
+            for line in run_git(
+                root, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"
+            ).stdout.splitlines()
+            if line
+        }
+        if head_paths != set(EXPECTED_OUTPUTS):
+            raise BridgeError("no pending or retryable exact-scope result commit found")
+    commit_sha = run_git(root, "rev-parse", "HEAD").stdout.strip()
+    try:
+        run_git(root, "push", "origin", f"HEAD:{BRANCH}")
+    except BridgeError as exc:
+        raise BridgeError("local result committed but push failed; retry publish after review") from exc
+    return commit_sha
+
+
+def resolve_path(root: Path, value: str | None, default: Path) -> Path:
+    path = root / default if value is None else Path(value)
+    if not path.is_absolute():
+        path = root / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise BridgeError("request and config paths must stay inside the repository") from exc
+    return resolved
+
+
+def parser() -> argparse.ArgumentParser:
+    command = argparse.ArgumentParser(description=__doc__)
+    command.add_argument("--repo-root", help="Repository root; defaults to the script repository")
+    command.add_argument("--request", help="Request JSON path relative to the repository")
+    command.add_argument("--config", help="Receiver config JSON path relative to the repository")
+    sub = command.add_subparsers(dest="action", required=True)
+
+    sub.add_parser("observe", help="Validate the bridge and report readiness without mutation")
+
+    run = sub.add_parser("run", help="Invoke Codex locally, validate outputs, and stop before publish")
+    run.add_argument("--codex-bin", default="codex")
+    run.add_argument("--timeout-seconds", type=int, default=1800)
+
+    sub.add_parser("validate-result", help="Validate existing local result artifacts")
+
+    publish = sub.add_parser("publish", help="Commit and push only validated result artifacts")
+    publish.add_argument("--gate", required=True)
+    return command
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    root = Path(args.repo_root).resolve() if args.repo_root else repo_root_from_script()
+    request_path = resolve_path(root, args.request, DEFAULT_REQUEST)
+    config_path = resolve_path(root, args.config, DEFAULT_CONFIG)
+
+    try:
+        request = load_json(request_path)
+        config = load_json(config_path)
+        validate_config(config)
+        validate_request(request, root)
+
+        if args.action == "observe":
+            payload = observe(root, request, config)
+        elif args.action == "run":
+            state = observe(root, request, config)
+            if state["status"] != "ready":
+                raise BridgeError("bridge is not ready: " + ", ".join(state["blockers"]))
+            execute_codex(root, args.codex_bin, args.timeout_seconds)
+            result, _ = validate_result_files(root)
+            payload = {
+                "bridge_id": BRIDGE_ID,
+                "status": "local-result-ready",
+                "result_status": result["status"],
+                "publish_performed": False,
+                "next_gate": PUBLISH_GATE,
+            }
+        elif args.action == "validate-result":
+            result, _ = validate_result_files(root)
+            payload = {
+                "bridge_id": BRIDGE_ID,
+                "status": "valid",
+                "result_status": result["status"],
+                "publish_performed": False,
+            }
+        else:
+            commit_sha = publish_results(root, args.gate)
+            payload = {
+                "bridge_id": BRIDGE_ID,
+                "status": "published",
+                "commit_sha": commit_sha,
+                "branch": BRANCH,
+                "merge_performed": False,
+            }
+    except (BridgeError, subprocess.TimeoutExpired) as exc:
+        payload = {
+            "bridge_id": BRIDGE_ID,
+            "status": "blocked",
+            "blocker": str(exc) if isinstance(exc, BridgeError) else "Codex execution timed out",
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 1
+
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chatgpt_work_bridge_001.py
+++ b/tests/test_chatgpt_work_bridge_001.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "chatgpt_work_bridge_001.py"
+SPEC = importlib.util.spec_from_file_location("bridge", SCRIPT)
+assert SPEC and SPEC.loader
+bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bridge)
+
+
+def run(*args: str, cwd: Path) -> None:
+    subprocess.run(args, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+class BridgeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        run("git", "init", "-q", cwd=self.root)
+        run("git", "config", "user.name", "Bridge Test", cwd=self.root)
+        run("git", "config", "user.email", "bridge@example.invalid", cwd=self.root)
+        run("git", "checkout", "-q", "-b", bridge.BRANCH, cwd=self.root)
+
+        required_reads = [
+            "docs/governance/public_boundary.md",
+            "docs/governance/chatgpt_connector_runtime_policy.md",
+            "docs/atlas/control-tower/README.md",
+            "docs/atlas/control-tower/local-worktree-cleanup-001.md",
+            "docs/atlas/control-tower/causal-log.pause-001-handoff-2026-05-18.json",
+            "docs/atlas/control-tower/batch-chatgpt-work-bridge-001.md",
+        ]
+        for rel in required_reads:
+            path = self.root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}\n" if path.suffix == ".json" else "test\n", encoding="utf-8")
+
+        self.request = {
+            "schema_version": "1.1",
+            "bridge_id": bridge.BRIDGE_ID,
+            "created_at": "2026-07-13T00:00:00Z",
+            "requested_by": "Silvan Lenhard",
+            "request_actor": "chatgpt-work",
+            "execution_actor": "local-codex",
+            "repository_full_name": bridge.REPOSITORY_FULL_NAME,
+            "branch": bridge.BRANCH,
+            "base_commit": "e5ddb0e15e342593d5ead8f0e92ffd89a93463ca",
+            "status": "awaiting-local-codex",
+            "mode": "github-trace-only",
+            "purpose": "test",
+            "dispatch": {
+                "human_dispatch_authorized": True,
+                "authorization_scope": "reversible bridge trial; no merge",
+                "activation_mode": "manual-only",
+                "polling_enabled": False,
+                "notion_issue_intake_enabled": False,
+                "publish_gate": bridge.PUBLISH_GATE,
+            },
+            "required_reads": required_reads,
+            "expected_outputs": list(bridge.EXPECTED_OUTPUTS),
+            "allowed_actions": ["read"],
+            "blocked_actions": ["merge"],
+            "result_contract": {
+                "required_fields": sorted(bridge.REQUIRED_RESULT_FIELDS),
+                "status_enum": sorted(bridge.RESULT_STATUSES),
+                "absolute_paths_allowed": False,
+                "secrets_allowed": False,
+                "private_content_allowed": False,
+            },
+            "success_condition": "test",
+            "stop_rule": "stop",
+        }
+        self.config = {
+            "schema_version": "1.0",
+            "bridge_id": bridge.BRIDGE_ID,
+            "activation_mode": "manual-only",
+            "poll_interval_minutes": 10,
+            "polling_enabled": False,
+            "notion_issue_intake": {
+                "enabled": False,
+                "transport": "existing Notion to GitHub issue exporter",
+                "execute_issue_body": False,
+            },
+            "codex_exec": {
+                "ephemeral": True,
+                "sandbox": "workspace-write",
+                "approval_policy": "never",
+                "danger_full_access": False,
+                "load_user_config": True,
+                "load_project_rules": True,
+            },
+            "publish": {
+                "enabled_by_default": False,
+                "gate_phrase": bridge.PUBLISH_GATE,
+                "remote": "origin",
+                "branch": bridge.BRANCH,
+                "merge_allowed": False,
+            },
+            "promotion_gate": {
+                "manual_cycles_required": 3,
+                "current_clean_cycles": 0,
+                "automatic_activation_allowed": False,
+            },
+        }
+        request_path = self.root / bridge.DEFAULT_REQUEST
+        request_path.parent.mkdir(parents=True, exist_ok=True)
+        request_path.write_text(json.dumps(self.request), encoding="utf-8")
+        config_path = self.root / bridge.DEFAULT_CONFIG
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(self.config), encoding="utf-8")
+        run("git", "add", ".", cwd=self.root)
+        run("git", "commit", "-qm", "fixture", cwd=self.root)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def valid_result(self) -> dict[str, object]:
+        return {
+            "bridge_id": bridge.BRIDGE_ID,
+            "actor": "local-codex",
+            "observed_at_utc": "2026-07-13T18:00:00Z",
+            "repository_full_name": bridge.REPOSITORY_FULL_NAME,
+            "branch": bridge.BRANCH,
+            "base_commit_observed": "a" * 40,
+            "request_readable": True,
+            "worktree_readable": True,
+            "branch_writable": True,
+            "terranova_worktree_count": 2,
+            "worktree_role_labels": ["bridge-trial", "main-baseline"],
+            "public_boundary_check": "pass",
+            "files_created": list(bridge.EXPECTED_OUTPUTS),
+            "status": "pass",
+            "blockers": [],
+        }
+
+    def write_results(self, result: dict[str, object] | None = None) -> None:
+        result = result or self.valid_result()
+        result_path = self.root / bridge.EXPECTED_OUTPUTS[0]
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        causal = {
+            "bridge_id": bridge.BRIDGE_ID,
+            "actor": "local-codex",
+            "observed_at_utc": "2026-07-13T18:00:00Z",
+            "result": result["status"],
+            "observation": "bounded local metadata check",
+            "selected_action": "write public-safe result",
+            "deterministic_boundary": ["no merge", "no Notion mutation"],
+            "external_mutation": False,
+            "blockers": [],
+        }
+        causal_path = self.root / bridge.EXPECTED_OUTPUTS[1]
+        causal_path.write_text(json.dumps(causal), encoding="utf-8")
+
+    def test_config_and_request_are_valid(self) -> None:
+        bridge.validate_config(self.config)
+        bridge.validate_request(self.request, self.root)
+
+    def test_observe_is_ready_when_codex_exists(self) -> None:
+        with mock.patch.object(bridge.shutil, "which", return_value="/safe/codex"):
+            state = bridge.observe(self.root, self.request, self.config)
+        self.assertEqual(state["status"], "ready")
+        self.assertFalse(state["polling_enabled"])
+        self.assertFalse(state["publish_enabled_by_default"])
+
+    def test_observe_blocks_without_codex(self) -> None:
+        with mock.patch.object(bridge.shutil, "which", return_value=None):
+            state = bridge.observe(self.root, self.request, self.config)
+        self.assertEqual(state["status"], "blocked")
+        self.assertIn("CODEX_CLI_NOT_FOUND", state["blockers"])
+
+    def test_automatic_polling_is_rejected(self) -> None:
+        config = json.loads(json.dumps(self.config))
+        config["polling_enabled"] = True
+        with self.assertRaises(bridge.BridgeError):
+            bridge.validate_config(config)
+
+    def test_request_requires_human_dispatch(self) -> None:
+        request = json.loads(json.dumps(self.request))
+        request["dispatch"]["human_dispatch_authorized"] = False
+        with self.assertRaises(bridge.BridgeError):
+            bridge.validate_request(request, self.root)
+
+    def test_result_contract_accepts_public_safe_result(self) -> None:
+        self.write_results()
+        result, causal = bridge.validate_result_files(self.root)
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(causal["result"], "pass")
+
+    def test_result_contract_rejects_absolute_local_path(self) -> None:
+        result = self.valid_result()
+        result["blockers"] = ["found /home/example/private-file"]
+        self.write_results(result)
+        with self.assertRaises(bridge.BridgeError):
+            bridge.validate_result_files(self.root)
+
+    def test_result_contract_rejects_credential_shape(self) -> None:
+        result = self.valid_result()
+        result["blockers"] = ["secret_example"]
+        self.write_results(result)
+        with self.assertRaises(bridge.BridgeError):
+            bridge.validate_result_files(self.root)
+
+    def test_result_contract_rejects_private_notion_url(self) -> None:
+        result = self.valid_result()
+        result["blockers"] = [
+            "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+        ]
+        self.write_results(result)
+        with self.assertRaises(bridge.BridgeError):
+            bridge.validate_result_files(self.root)
+
+    def test_codex_command_is_ephemeral_and_least_privilege(self) -> None:
+        command = bridge.build_codex_command("codex", self.root)
+        self.assertIn("--ephemeral", command)
+        self.assertIn("workspace-write", command)
+        self.assertIn("never", command)
+        self.assertNotIn("danger-full-access", command)
+        self.assertNotIn("--ignore-rules", command)
+        self.assertNotIn("--ignore-user-config", command)
+
+    def test_publish_requires_exact_gate_before_git_mutation(self) -> None:
+        self.write_results()
+        with self.assertRaises(bridge.BridgeError):
+            bridge.publish_results(self.root, "los Codex")
+        self.assertEqual(
+            subprocess.run(
+                ["git", "diff", "--cached", "--name-only"],
+                cwd=self.root,
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            ).stdout,
+            "",
+        )
+
+    def test_request_and_config_paths_cannot_escape_repo(self) -> None:
+        with self.assertRaises(bridge.BridgeError):
+            bridge.resolve_path(self.root, "../outside.json", bridge.DEFAULT_REQUEST)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds the bounded `CHATGPT-WORK-BRIDGE-001` Control Tower batch
- adds a machine-readable request contract for local Codex
- reuses the existing CAP runtime, PAUSE-001 handoff and public-boundary rules

## Why

Verify whether cloud ChatGPT Work and a locally running Codex instance can
exchange public-safe, versioned request/result artifacts through GitHub without
manual copy/paste of the result.

## Boundary

- GitHub trace only
- no Notion or Zenodo mutation
- no workflow dispatch
- no local paths, host identifiers, secrets, session content or raw token data
- local Codex must not merge this PR

## Validation

- branch created from main at `e5ddb0e15e342593d5ead8f0e92ffd89a93463ca`
- existing Control Tower and connector governance reviewed
- request JSON is structurally valid
- local execution is intentionally pending

## Expected local outputs

- `docs/atlas/control-tower/chatgpt-work-bridge-001.local-result.json`
- `docs/atlas/control-tower/causal-log.chatgpt-work-bridge-001-local-2026-07-13.json`
