### PR TITLE
feat(observatory): add OAL-001 controlled self-modification sandbox

### DIFF
--- a/.github/workflows/oal-001-validate.yml
+++ b/.github/workflows/oal-001-validate.yml
@@ -1,19 +1,7 @@
 name: Validate OAL-001
 
 on:
-  pull_request:
-    paths:
-      - '.codex/safety_policy.yaml'
-      - '.github/workflows/oal-001-validate.yml'
-      - '.gitignore'
-      - 'config/oal_001.json'
-      - 'docs/governance/oal_001_self_modification_policy.md'
-      - 'schemas/oal_001_mutation_trace.schema.json'
-      - 'scripts/oal_001/**'
-      - 'scripts/validate_oal_001.py'
-      - 'tests/fixtures/observatory/**'
-      - 'tests/test_oal_001_governor.py'
-      - 'tests/test_oal_001_runtime.py'
+  pull_request: {}
 
 permissions:
   contents: read
@@ -24,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
+      OAL_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+      OAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       OAL_SOURCE_BRANCH: ${{ github.head_ref }}
       OAL_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
 
@@ -33,21 +23,16 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ env.OAL_SOURCE_SHA }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Bind source to the governed local branch
+      - name: Bind checkout to the exact pull-request source
         shell: bash
         run: |
           if [[ ! "$OAL_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid pull-request source SHA" >&2
             exit 1
           fi
-          if [[ ! "$OAL_SOURCE_BRANCH" =~ ^codex/observatory-selfmod-[A-Za-z0-9._/-]+$ ]]; then
-            echo "OAL changes require a codex/observatory-selfmod-* source branch" >&2
-            exit 1
-          fi
-          git switch --force-create "$OAL_SOURCE_BRANCH" "$OAL_SOURCE_SHA"
           test "$(git rev-parse HEAD)" = "$OAL_SOURCE_SHA"
 
       - name: Setup CPython 3.11
@@ -223,7 +208,59 @@ jobs:
               raise SystemExit("\n".join(errors))
           PY
 
+      - name: Classify governed OAL changes
+        id: oal_scope
+        shell: bash
+        run: |
+          if [[ ! "$OAL_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid pull-request base SHA" >&2
+            exit 1
+          fi
+          if [[ ! "$OAL_BASE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "Invalid pull-request base repository" >&2
+            exit 1
+          fi
+          git fetch --no-tags \
+            "https://github.com/${OAL_BASE_REPOSITORY}.git" "$OAL_BASE_SHA"
+          test "$(git rev-parse FETCH_HEAD)" = "$OAL_BASE_SHA"
+          merge_base="$(git merge-base "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"
+          if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the pull-request merge base" >&2
+            exit 1
+          fi
+
+          changed_paths="$RUNNER_TEMP/oal-001-changed-paths"
+          git diff --no-renames --name-only -z \
+            "$merge_base" "$OAL_SOURCE_SHA" -- > "$changed_paths"
+          oal_changed=false
+          while IFS= read -r -d '' changed_path; do
+            case "$changed_path" in
+              .codex/safety_policy.yaml|.github/workflows/oal-001-validate.yml|.gitignore|config/oal_001.json)
+                oal_changed=true
+                ;;
+              docs/governance/oal_001_self_modification_policy.md|schemas/oal_001_mutation_trace.schema.json|scripts/validate_oal_001.py)
+                oal_changed=true
+                ;;
+              scripts/oal_001/*|tests/fixtures/observatory/*|tests/test_oal_001_governor.py|tests/test_oal_001_runtime.py)
+                oal_changed=true
+                ;;
+            esac
+          done < "$changed_paths"
+          echo "oal_changed=$oal_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Bind governed changes to an OAL branch
+        if: steps.oal_scope.outputs.oal_changed == 'true'
+        shell: bash
+        run: |
+          if [[ ! "$OAL_SOURCE_BRANCH" =~ ^codex/observatory-selfmod-[A-Za-z0-9._/-]+$ ]]; then
+            echo "OAL changes require a codex/observatory-selfmod-* source branch" >&2
+            exit 1
+          fi
+          git switch --force-create "$OAL_SOURCE_BRANCH" "$OAL_SOURCE_SHA"
+          test "$(git rev-parse HEAD)" = "$OAL_SOURCE_SHA"
+
       - name: Run complete OAL validator
+        if: steps.oal_scope.outputs.oal_changed == 'true'
         run: python -I -S -B scripts/validate_oal_001.py
 
       - name: Confirm no tracked or unignored mutation

--- a/.github/workflows/oal-001-validate.yml
+++ b/.github/workflows/oal-001-validate.yml
@@ -1,0 +1,70 @@
+name: Validate OAL-001
+
+on:
+  pull_request:
+    paths:
+      - '.codex/safety_policy.yaml'
+      - '.github/workflows/oal-001-validate.yml'
+      - '.gitignore'
+      - 'config/oal_001.json'
+      - 'docs/governance/oal_001_self_modification_policy.md'
+      - 'schemas/oal_001_mutation_trace.schema.json'
+      - 'scripts/oal_001/**'
+      - 'scripts/validate_oal_001.py'
+      - 'tests/fixtures/observatory/**'
+      - 'tests/test_oal_001_governor.py'
+      - 'tests/test_oal_001_runtime.py'
+
+permissions:
+  contents: read
+
+jobs:
+  oal-python-311:
+    name: OAL Python 3.11
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PYTHONDONTWRITEBYTECODE: '1'
+      OAL_SOURCE_BRANCH: ${{ github.head_ref }}
+      OAL_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Checkout exact pull-request source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.OAL_SOURCE_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Bind source to the governed local branch
+        shell: bash
+        run: |
+          if [[ ! "$OAL_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid pull-request source SHA" >&2
+            exit 1
+          fi
+          if [[ ! "$OAL_SOURCE_BRANCH" =~ ^codex/observatory-selfmod-[A-Za-z0-9._/-]+$ ]]; then
+            echo "OAL changes require a codex/observatory-selfmod-* source branch" >&2
+            exit 1
+          fi
+          git switch --force-create "$OAL_SOURCE_BRANCH" "$OAL_SOURCE_SHA"
+          test "$(git rev-parse HEAD)" = "$OAL_SOURCE_SHA"
+
+      - name: Setup CPython 3.11
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: '3.11.14'
+
+      - name: Confirm target runtime
+        run: python -c "import sys; assert sys.version_info[:2] == (3, 11), sys.version"
+
+      - name: Run complete OAL validator
+        run: python scripts/validate_oal_001.py
+
+      - name: Confirm no tracked or unignored mutation
+        shell: bash
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"

--- a/.github/workflows/oal-001-validate.yml
+++ b/.github/workflows/oal-001-validate.yml
@@ -223,9 +223,9 @@ jobs:
           git fetch --no-tags \
             "https://github.com/${OAL_BASE_REPOSITORY}.git" "$OAL_BASE_SHA"
           test "$(git rev-parse FETCH_HEAD)" = "$OAL_BASE_SHA"
-          merge_base="$(git merge-base "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"
+          merge_base="$(git merge-base --all "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"
           if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve the pull-request merge base" >&2
+            echo "Could not resolve exactly one pull-request merge base" >&2
             exit 1
           fi
 

--- a/.github/workflows/oal-001-validate.yml
+++ b/.github/workflows/oal-001-validate.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      PYTHONDONTWRITEBYTECODE: '1'
       OAL_SOURCE_BRANCH: ${{ github.head_ref }}
       OAL_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
 
@@ -56,11 +55,176 @@ jobs:
         with:
           python-version: '3.11.14'
 
-      - name: Confirm target runtime
-        run: python -c "import sys; assert sys.version_info[:2] == (3, 11), sys.version"
+      - name: Confirm isolated runtime and import topology
+        shell: bash
+        run: |
+          python -I -S -B - <<'PY'
+          from importlib.machinery import all_suffixes
+          from pathlib import Path
+          import sys
+
+          if sys.version_info[:3] != (3, 11, 14):
+              raise SystemExit(f"Unexpected Python runtime: {sys.version}")
+          if not (
+              sys.flags.isolated
+              and sys.flags.no_site
+              and sys.flags.safe_path
+              and sys.flags.dont_write_bytecode
+          ):
+              raise SystemExit("Isolated Python bootstrap is not active")
+
+          root = Path.cwd()
+          suffixes = tuple(
+              sorted(
+                  {suffix.casefold() for suffix in all_suffixes()}
+                  | {".py", ".pyc", ".pyd", ".pyw", ".so"},
+                  key=len,
+                  reverse=True,
+              )
+          )
+          blocked_modules = {
+              name.casefold() for name in sys.stdlib_module_names
+          } | {"sitecustomize", "usercustomize"}
+
+          def module_name(name):
+              lowered = name.casefold()
+              for suffix in suffixes:
+                  if lowered.endswith(suffix) and len(lowered) > len(suffix):
+                      return lowered[: -len(suffix)].split(".", 1)[0]
+              return None
+
+          def cached_module_name(name):
+              lowered = name.casefold()
+              if not lowered.endswith(".pyc") or len(lowered) <= len(".pyc"):
+                  return None
+              return lowered[: -len(".pyc")].split(".", 1)[0]
+
+          def has_package_initializer(path):
+              try:
+                  return path.is_dir() and any(
+                      module_name(child.name) == "__init__"
+                      for child in path.iterdir()
+                  )
+              except OSError:
+                  return True
+
+          expected_directories = ("scripts", "tests", "scripts/oal_001")
+          expected_files = (
+              "scripts/oal_001/__init__.py",
+              "scripts/oal_001/__main__.py",
+              "scripts/oal_001/git_read.py",
+              "scripts/oal_001/governor.py",
+              "scripts/oal_001/observatory.py",
+              "scripts/oal_001/runtime.py",
+              "scripts/validate_oal_001.py",
+              "tests/test_oal_001_governor.py",
+              "tests/test_oal_001_runtime.py",
+          )
+
+          errors = []
+          for relative in expected_directories:
+              path = root / relative
+              if not path.is_dir() or path.is_symlink():
+                  errors.append(f"Invalid Python import topology: {relative}")
+
+          for relative in expected_files:
+              path = root / relative
+              try:
+                  invalid_file = (
+                      not path.is_file()
+                      or path.is_symlink()
+                      or path.stat().st_nlink != 1
+                  )
+              except OSError:
+                  invalid_file = True
+              if invalid_file:
+                  errors.append(f"Invalid Python import topology: {relative}")
+
+          protected_slots = {}
+          for relative in expected_directories:
+              path = Path(relative)
+              parent = "" if path.parent.as_posix() == "." else path.parent.as_posix()
+              protected_slots.setdefault(parent, {})[
+                  path.name.casefold()
+              ] = relative
+          for relative in expected_files:
+              path = Path(relative)
+              parent = "" if path.parent.as_posix() == "." else path.parent.as_posix()
+              protected_slots.setdefault(parent, {})[
+                  path.stem.casefold()
+              ] = relative
+
+          problems = set()
+          for base_relative, expected_slots in protected_slots.items():
+              base = root / base_relative
+              if not base.is_dir() or base.is_symlink():
+                  continue
+              try:
+                  entries = tuple(base.iterdir())
+              except OSError:
+                  errors.append(
+                      f"Could not inspect Python import topology: {base_relative or '.'}"
+                  )
+                  continue
+              for entry in entries:
+                  candidate = module_name(entry.name)
+                  relative = entry.relative_to(root).as_posix()
+                  directory_name = entry.name.casefold()
+                  if base_relative in {"", "scripts"}:
+                      if candidate in blocked_modules:
+                          problems.add(relative)
+                      if directory_name in blocked_modules and (
+                          entry.is_symlink() or has_package_initializer(entry)
+                      ):
+                          problems.add(relative)
+
+                  slot_candidates = {candidate}
+                  if entry.is_dir() or entry.is_symlink():
+                      slot_candidates.add(directory_name)
+                  for slot in slot_candidates - {None}:
+                      expected_path = expected_slots.get(slot)
+                      if expected_path is not None and relative != expected_path:
+                          problems.add(relative)
+
+                  if directory_name != "__pycache__":
+                      continue
+                  if entry.is_symlink() or not entry.is_dir():
+                      problems.add(relative)
+                      continue
+                  try:
+                      cache_entries = tuple(entry.iterdir())
+                  except OSError:
+                      errors.append(
+                          f"Could not inspect Python bytecode cache: {relative}"
+                      )
+                      continue
+                  for cache_entry in cache_entries:
+                      if cached_module_name(cache_entry.name) in expected_slots:
+                          problems.add(cache_entry.relative_to(root).as_posix())
+
+          for namespace_relative in ("scripts", "tests"):
+              namespace = root / namespace_relative
+              if not namespace.is_dir() or namespace.is_symlink():
+                  continue
+              try:
+                  entries = tuple(namespace.iterdir())
+              except OSError:
+                  errors.append(
+                      f"Could not inspect Python namespace topology: {namespace_relative}"
+                  )
+                  continue
+              for entry in entries:
+                  if module_name(entry.name) == "__init__":
+                      problems.add(entry.relative_to(root).as_posix())
+
+          for problem in sorted(problems):
+              errors.append(f"Forbidden Python import-shadowing path: {problem}")
+          if errors:
+              raise SystemExit("\n".join(errors))
+          PY
 
       - name: Run complete OAL validator
-        run: python scripts/validate_oal_001.py
+        run: python -I -S -B scripts/validate_oal_001.py
 
       - name: Confirm no tracked or unignored mutation
         shell: bash

--- a/config/oal_001.json
+++ b/config/oal_001.json
@@ -16,6 +16,7 @@
     "schemas/oal_001_mutation_trace.schema.json",
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
+    "scripts/oal_001/git_read.py",
     "scripts/oal_001/governor.py",
     "scripts/oal_001/runtime.py",
     "scripts/validate_oal_001.py",

--- a/config/oal_001.json
+++ b/config/oal_001.json
@@ -9,6 +9,7 @@
   "protected_paths": [
     ".codex",
     ".git",
+    ".github/workflows/oal-001-validate.yml",
     ".gitignore",
     "config/oal_001.json",
     "docs/governance",

--- a/config/oal_001.json
+++ b/config/oal_001.json
@@ -1,0 +1,34 @@
+{
+  "policy_id": "OAL-001-GOVERNOR",
+  "schema_version": "OAL-1.0",
+  "mode": "local_dry_run",
+  "branch_pattern": "codex/observatory-selfmod-*",
+  "mutable_paths": [
+    "scripts/oal_001/observatory.py"
+  ],
+  "protected_paths": [
+    ".codex",
+    ".git",
+    ".gitignore",
+    "config/oal_001.json",
+    "docs/governance",
+    "raw/exports",
+    "schemas/oal_001_mutation_trace.schema.json",
+    "scripts/oal_001/__init__.py",
+    "scripts/oal_001/__main__.py",
+    "scripts/oal_001/governor.py",
+    "scripts/oal_001/runtime.py",
+    "scripts/validate_oal_001.py",
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py"
+  ],
+  "authorizing_test_paths": [
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py"
+  ],
+  "fixture_path": "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+  "output_root": "raw/exports/local-private/oal-001",
+  "minimum_exploration_share": 0.25,
+  "external_mutation_count": 0,
+  "historical_fixture_status": "unavailable"
+}

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -91,7 +91,13 @@ promotion gate.
 
 The dedicated `OAL Python 3.11` pull-request check runs the complete validator
 on the exact PR head in an ephemeral, read-only GitHub Actions job. It persists
-no checkout credentials, receives no secrets and publishes no evidence.
+no checkout credentials, receives no secrets and publishes no evidence. Before
+repository Python is loaded, an exact workflow-bound standard-library preflight
+rejects import-shadowing files, cached bytecode for protected module slots and
+unexpected package topology. The validator, its authorizing tests and its
+dry-run child all execute with isolated mode, site initialization disabled and
+bytecode writes disabled; the repository root is appended only after the
+standard-library import paths.
 
 All Git observations pass through a protected typed read-only adapter. It uses
 a fixed system Git executable, disables optional locks and filesystem monitors,

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -1,0 +1,82 @@
+# OAL-001 Controlled Self-Modification Policy
+
+Status: BIZ / local dry-run bootstrap policy
+Source: Notion design baseline `IPERKA — Autodidaktisches Observatory / Codex Runtime (OAL-1.0)` and GitHub Issue #97
+Trace: GitHub Issue #97; `config/oal_001.json`; `schemas/oal_001_mutation_trace.schema.json`
+Boundary: Local candidate sandbox only; no external, remote, Notion, ledger, publication, payment or production mutation
+Mode: BIZ / local dry-run
+GitHub sync state: prepared on the isolated local branch `codex/observatory-selfmod-001`; promotion remains human-gated
+Notion source awareness: the design baseline was inspected read-only before implementation; this mirror contains no Notion object IDs and performs no Notion write
+
+## Purpose
+
+This policy defines the first reversible implementation slice for OAL-001. It
+separates a baseline-only Governor from one explicitly mutable Observatory
+example and proves candidate isolation, replay, evaluation and rollback.
+
+The bootstrap commit that creates the Governor and its authorizing tests is a
+human-gated implementation action. It is not itself an autonomous
+self-modification cycle. Candidate cycles created by the runtime remain subject
+to the Governor.
+
+## Immutable Governor
+
+The same candidate cycle may not change:
+
+- human gates, branch or worktree boundaries;
+- secret handling or external-mutation defaults;
+- audit, trace, replay, determinism or rollback logic;
+- the Governor, runtime, validator, configuration or trace schema;
+- a control rule together with the test that authorizes that rule.
+
+Any proposed path outside the exact mutable allowlist is rejected before a
+candidate file is written. Absolute paths, traversal, symlinks and shared
+hard-linked files are refused.
+
+## Mutable Observatory
+
+The first slice permits exactly one candidate target:
+
+```text
+scripts/oal_001/observatory.py
+```
+
+The harmless example adjusts only synthetic strategy weights. It activates no
+connector or productive function. The candidate is copied from the baseline
+through an explicit managed-path allowlist; the repository tree is never copied
+or scanned wholesale.
+
+## Candidate Lifecycle
+
+```text
+baseline hash
+  -> Governor preflight
+  -> temporary allowlisted candidate copy
+  -> deterministic source patch
+  -> AST-constrained replay
+  -> baseline/candidate comparison
+  -> retain-or-reject decision
+  -> candidate rollback
+  -> workspace discard
+  -> mutation trace and local report
+```
+
+The candidate source is parsed as data. Arbitrary candidate code is not
+executed in this slice. A retained decision means the candidate satisfied the
+technical gates; it does not promote or activate the candidate.
+
+## Evidence and Promotion
+
+Run evidence is written only below the gitignored path
+`raw/exports/local-private/oal-001/`. It must record the trigger, hypothesis,
+expected effect, fallback criterion, hashes, diff identity, replay results,
+evaluator decision, rollback proof, Git status and zero external mutations.
+Evidence files are replaced atomically. A run remains `INCOMPLETE` until the
+validator has reconstructed the cross-artifact evidence and written a final
+completion marker that binds the SHA-256 digest of every other artifact.
+
+No real predecessor Hubble or ALMA cycle is present in the repository at this
+bootstrap point. The included replay fixture is explicitly synthetic and may
+not be represented as historical evidence. Admission of real predecessor
+fixtures, broader engines, a ledger writer, three controlled cycles and any
+live ledger append are separate human-gated follow-up work.

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -89,15 +89,32 @@ A semantically valid dirty bundle remains `promotion_ready=false` and
 `VERIFIED_NOT_PROMOTION_READY` with a non-zero exit instead of exposing a false
 promotion gate.
 
-The dedicated `OAL Python 3.11` pull-request check runs the complete validator
-on the exact PR head in an ephemeral, read-only GitHub Actions job. It persists
-no checkout credentials, receives no secrets and publishes no evidence. Before
-repository Python is loaded, an exact workflow-bound standard-library preflight
-rejects import-shadowing files, cached bytecode for protected module slots and
+The dedicated `OAL Python 3.11` workflow is configured on `pull_request`
+without explicit path, branch or activity-type filters. Consequently,
+security-topology-only diffs are not excluded by those workflow filters. Its
+standard-library topology preflight runs before repository Python or the OAL
+branch gate. A fail-closed base-to-head classifier then runs the complete OAL
+validator only for governed OAL paths and requires those changes to originate
+from a `codex/observatory-selfmod-*` branch; unrelated pull requests finish
+after the topology preflight instead of failing the OAL branch rule.
+
+GitHub still controls whether a `pull_request` event is scheduled. For example,
+merge conflicts, workflow availability on the default branch and repository
+rules can affect execution. Independent enforcement therefore requires the
+check to be enabled and required by repository rules outside this PR-controlled
+workflow. The job persists no checkout credentials, receives no secrets and
+publishes no evidence.
+
+Before repository Python is loaded, the exact workflow-bound preflight rejects
+import-shadowing files, cached bytecode for protected module slots and
 unexpected package topology. The validator, its authorizing tests and its
 dry-run child all execute with isolated mode, site initialization disabled and
 bytecode writes disabled; the repository root is appended only after the
-standard-library import paths.
+standard-library import paths. Protected interpreter import state may not be
+aliased, rebound or mutated outside that exact bootstrap, and an imported
+validator entry point refuses execution instead of bypassing the CLI boundary.
+The static AST boundary is defense in depth and is not a Python sandbox; the
+isolated interpreter remains the execution trust boundary.
 
 All Git observations pass through a protected typed read-only adapter. It uses
 a fixed system Git executable, disables optional locks and filesystem monitors,

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -114,11 +114,14 @@ dry-run child all execute with isolated mode, site initialization disabled and
 bytecode writes disabled; the repository root is appended only after the
 standard-library import paths. Protected interpreter import state may not be
 aliased, rebound or mutated outside that exact bootstrap. Direct writes to
-`sys` attributes are refused, and dynamic attribute calls are limited to the
-fixed reparse-point compatibility lookup. Governor scalar checks use explicit
-attribute bindings. An imported validator entry point refuses execution instead
-of bypassing the CLI boundary. The static AST boundary is defense in depth and
-is not a Python sandbox; the isolated interpreter remains the execution trust
+`sys` attributes are refused. The direct built-in `getattr` exception is bound
+to the exact module-level `_is_reparse_point` AST in the validator, Governor,
+runtime and typed Git reader, with one unaliased `stat` import and the integer
+literal `0` as its side-effect-free default; every other `getattr` binding,
+reference or call is refused. Governor scalar checks use explicit attribute
+bindings. An imported validator entry point refuses execution instead of
+bypassing the CLI boundary. The static AST boundary is defense in depth and is
+not a Python sandbox; the isolated interpreter remains the execution trust
 boundary.
 
 All Git observations pass through a protected typed read-only adapter. It uses

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -26,7 +26,7 @@ The same candidate cycle may not change:
 - human gates, branch or worktree boundaries;
 - secret handling or external-mutation defaults;
 - audit, trace, replay, determinism or rollback logic;
-- the Governor, runtime, validator, configuration or trace schema;
+- the Governor, runtime, validator, CI workflow, configuration or trace schema;
 - a control rule together with the test that authorizes that rule.
 
 Any proposed path outside the exact mutable allowlist is rejected before a
@@ -71,14 +71,27 @@ Run evidence is written only below the gitignored path
 `raw/exports/local-private/oal-001/`. It must record the trigger, hypothesis,
 expected effect, fallback criterion, hashes, diff identity, replay results,
 evaluator decision, rollback proof, Git status and zero external mutations.
+The Git snapshots contain only canonical `porcelain=v1` dirty entries with all
+untracked files expanded, submodule changes included and rename detection fixed
+off. Branch, HEAD and dirty state remain separate bindings;
+upstream names and ahead/behind counters never enter the trace or run identity.
 Evidence files are replaced atomically. A run remains `INCOMPLETE` until the
 validator has reconstructed the cross-artifact evidence and written a final
 completion marker that binds the SHA-256 digest of every other artifact.
 Semantic validation and digest binding use the same immutable in-memory byte
 snapshot. The write-free `--verify-existing <run-id>` path reconstructs the
 final bundle from one fresh snapshot and performs no test, dry-run or evidence
-write. Only a final `PASS` produced under Python 3.11 is promotion-ready;
+write. A final `PASS` produced under Python 3.11 is promotion-ready only when
+the canonical dirty-state snapshots are empty and the boundary status is `PASS`;
 `PASS_WITH_RUNTIME_GAP` is valid local evidence but blocks promotion.
+A semantically valid dirty bundle remains `promotion_ready=false` and
+`evidence_complete=false`; read-only verification reports
+`VERIFIED_NOT_PROMOTION_READY` with a non-zero exit instead of exposing a false
+promotion gate.
+
+The dedicated `OAL Python 3.11` pull-request check runs the complete validator
+on the exact PR head in an ephemeral, read-only GitHub Actions job. It persists
+no checkout credentials, receives no secrets and publishes no evidence.
 
 All Git observations pass through a protected typed read-only adapter. It uses
 a fixed system Git executable, disables optional locks and filesystem monitors,

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -74,6 +74,15 @@ evaluator decision, rollback proof, Git status and zero external mutations.
 Evidence files are replaced atomically. A run remains `INCOMPLETE` until the
 validator has reconstructed the cross-artifact evidence and written a final
 completion marker that binds the SHA-256 digest of every other artifact.
+Semantic validation and digest binding use the same immutable in-memory byte
+snapshot. The write-free `--verify-existing <run-id>` path reconstructs the
+final bundle from one fresh snapshot and performs no test, dry-run or evidence
+write. Only a final `PASS` produced under Python 3.11 is promotion-ready;
+`PASS_WITH_RUNTIME_GAP` is valid local evidence but blocks promotion.
+
+All Git observations pass through a protected typed read-only adapter. It uses
+a fixed system Git executable, disables optional locks and filesystem monitors,
+and supplies a minimal child environment without arbitrary inherited values.
 
 No real predecessor Hubble or ALMA cycle is present in the repository at this
 bootstrap point. The included replay fixture is explicitly synthetic and may

--- a/docs/governance/oal_001_self_modification_policy.md
+++ b/docs/governance/oal_001_self_modification_policy.md
@@ -93,10 +93,12 @@ The dedicated `OAL Python 3.11` workflow is configured on `pull_request`
 without explicit path, branch or activity-type filters. Consequently,
 security-topology-only diffs are not excluded by those workflow filters. Its
 standard-library topology preflight runs before repository Python or the OAL
-branch gate. A fail-closed base-to-head classifier then runs the complete OAL
-validator only for governed OAL paths and requires those changes to originate
-from a `codex/observatory-selfmod-*` branch; unrelated pull requests finish
-after the topology preflight instead of failing the OAL branch rule.
+branch gate. A fail-closed base-to-head classifier requires exactly one best
+merge base; a missing or ambiguous merge base stops classification. It then
+runs the complete OAL validator only for governed OAL paths and requires those
+changes to originate from a `codex/observatory-selfmod-*` branch; unrelated pull
+requests finish after the topology preflight instead of failing the OAL branch
+rule.
 
 GitHub still controls whether a `pull_request` event is scheduled. For example,
 merge conflicts, workflow availability on the default branch and repository
@@ -111,10 +113,13 @@ unexpected package topology. The validator, its authorizing tests and its
 dry-run child all execute with isolated mode, site initialization disabled and
 bytecode writes disabled; the repository root is appended only after the
 standard-library import paths. Protected interpreter import state may not be
-aliased, rebound or mutated outside that exact bootstrap, and an imported
-validator entry point refuses execution instead of bypassing the CLI boundary.
-The static AST boundary is defense in depth and is not a Python sandbox; the
-isolated interpreter remains the execution trust boundary.
+aliased, rebound or mutated outside that exact bootstrap. Direct writes to
+`sys` attributes are refused, and dynamic attribute calls are limited to the
+fixed reparse-point compatibility lookup. Governor scalar checks use explicit
+attribute bindings. An imported validator entry point refuses execution instead
+of bypassing the CLI boundary. The static AST boundary is defense in depth and
+is not a Python sandbox; the isolated interpreter remains the execution trust
+boundary.
 
 All Git observations pass through a protected typed read-only adapter. It uses
 a fixed system Git executable, disables optional locks and filesystem monitors,

--- a/schemas/oal_001_mutation_trace.schema.json
+++ b/schemas/oal_001_mutation_trace.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:terranova:oal-001:mutation-trace:1.0",
+  "title": "OAL-001 Mutation Trace",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "cycle_id",
+    "mode",
+    "base_sha",
+    "branch",
+    "source_state",
+    "source_manifest_sha256",
+    "fixture",
+    "trigger",
+    "hypothesis",
+    "expected_effect",
+    "fallback_criterion",
+    "target_path",
+    "changed_paths",
+    "baseline_sha256",
+    "candidate_sha256",
+    "diff_sha256",
+    "diff",
+    "governor",
+    "isolation",
+    "replay",
+    "evaluation",
+    "rollback",
+    "git_status",
+    "external_mutation_count",
+    "not_actions"
+  ],
+  "properties": {
+    "schema_version": {"const": "OAL-1.0"},
+    "run_id": {"type": "string", "pattern": "^OAL-001-[A-F0-9]{16}$"},
+    "cycle_id": {"type": "string", "minLength": 1},
+    "mode": {"const": "local_dry_run"},
+    "base_sha": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "branch": {"type": "string", "pattern": "^codex/observatory-selfmod-.+$"},
+    "source_state": {"enum": ["clean_commit", "working_tree_manifest"]},
+    "source_manifest_sha256": {"$ref": "#/$defs/sha256"},
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fixture_id", "fixture_kind", "historical_evidence", "historical_fixture_status"],
+      "properties": {
+        "fixture_id": {"type": "string", "minLength": 1},
+        "fixture_kind": {"const": "synthetic_current_slice"},
+        "historical_evidence": {"const": false},
+        "historical_fixture_status": {"const": "unavailable"}
+      }
+    },
+    "trigger": {"type": "string", "minLength": 1},
+    "hypothesis": {"type": "string", "minLength": 1},
+    "expected_effect": {"type": "string", "minLength": 1},
+    "fallback_criterion": {"type": "string", "minLength": 1},
+    "target_path": {"const": "scripts/oal_001/observatory.py"},
+    "changed_paths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string"}
+    },
+    "baseline_sha256": {"$ref": "#/$defs/sha256"},
+    "candidate_sha256": {"$ref": "#/$defs/sha256"},
+    "diff_sha256": {"$ref": "#/$defs/sha256"},
+    "diff": {"type": "string", "minLength": 1},
+    "governor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved", "reasons", "immutable_surface"],
+      "properties": {
+        "approved": {"type": "boolean"},
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "immutable_surface": {"const": "baseline_only"}
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_workspace", "managed_paths", "running_version_overwritten"],
+      "properties": {
+        "candidate_workspace": {"const": "temporary_allowlist_copy"},
+        "managed_paths": {"type": "array", "items": {"type": "string"}},
+        "running_version_overwritten": {"const": false}
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline_deterministic", "candidate_deterministic", "before_artifact", "after_artifact"],
+      "properties": {
+        "baseline_deterministic": {"type": "boolean"},
+        "candidate_deterministic": {"type": "boolean"},
+        "before_artifact": {"const": "replay_before.json"},
+        "after_artifact": {"const": "replay_after.json"}
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "reasons", "checks"],
+      "properties": {
+        "decision": {"enum": ["retain", "reject"]},
+        "reasons": {"type": "array", "items": {"type": "string"}},
+        "checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "governor_approved",
+            "baseline_deterministic",
+            "candidate_deterministic",
+            "baseline_expected_share",
+            "candidate_expected_share",
+            "exploration_floor_preserved",
+            "expected_replay_delta",
+            "baseline_unchanged",
+            "synthetic_fixture_only",
+            "external_mutation_count_zero",
+            "rollback_verified",
+            "managed_baseline_unchanged",
+            "candidate_workspace_removed"
+          ],
+          "properties": {
+            "governor_approved": {"type": "boolean"},
+            "baseline_deterministic": {"type": "boolean"},
+            "candidate_deterministic": {"type": "boolean"},
+            "baseline_expected_share": {"type": "boolean"},
+            "candidate_expected_share": {"type": "boolean"},
+            "exploration_floor_preserved": {"type": "boolean"},
+            "expected_replay_delta": {"type": "boolean"},
+            "baseline_unchanged": {"type": "boolean"},
+            "synthetic_fixture_only": {"type": "boolean"},
+            "external_mutation_count_zero": {"type": "boolean"},
+            "rollback_verified": {"type": "boolean"},
+            "managed_baseline_unchanged": {"type": "boolean"},
+            "candidate_workspace_removed": {"type": "boolean"}
+          }
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "candidate_restored", "baseline_unchanged", "candidate_workspace_removed"],
+      "properties": {
+        "status": {"enum": ["verified", "failed"]},
+        "candidate_restored": {"type": "boolean"},
+        "baseline_unchanged": {"type": "boolean"},
+        "candidate_workspace_removed": {"type": "boolean"}
+      }
+    },
+    "git_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after", "unchanged", "clean_worktree"],
+      "properties": {
+        "before": {"type": "string"},
+        "after": {"type": "string"},
+        "unchanged": {"type": "boolean"},
+        "clean_worktree": {"type": "boolean"}
+      }
+    },
+    "external_mutation_count": {"const": 0},
+    "not_actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string"}
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[A-F0-9]{64}$"
+    }
+  }
+}

--- a/schemas/oal_001_mutation_trace.schema.json
+++ b/schemas/oal_001_mutation_trace.schema.json
@@ -158,8 +158,16 @@
       "additionalProperties": false,
       "required": ["before", "after", "unchanged", "clean_worktree"],
       "properties": {
-        "before": {"type": "string"},
-        "after": {"type": "string"},
+        "before": {
+          "type": "string",
+          "description": "Branch-header-free Git porcelain v1 dirty entries before the cycle; empty means clean.",
+          "not": {"pattern": "(^|\\n)## "}
+        },
+        "after": {
+          "type": "string",
+          "description": "Branch-header-free Git porcelain v1 dirty entries after the cycle; empty means clean.",
+          "not": {"pattern": "(^|\\n)## "}
+        },
         "unchanged": {"type": "boolean"},
         "clean_worktree": {"type": "boolean"}
       }

--- a/scripts/oal_001/__init__.py
+++ b/scripts/oal_001/__init__.py
@@ -1,0 +1,21 @@
+"""OAL-001 controlled self-modification sandbox."""
+
+from .governor import Governor, GovernorDecision, GovernorPolicy, PatchSpec, load_policy
+from .runtime import (
+    CycleResult,
+    execute_cycle,
+    validate_trace_payload,
+    write_cycle_artifacts,
+)
+
+__all__ = [
+    "CycleResult",
+    "Governor",
+    "GovernorDecision",
+    "GovernorPolicy",
+    "PatchSpec",
+    "execute_cycle",
+    "load_policy",
+    "validate_trace_payload",
+    "write_cycle_artifacts",
+]

--- a/scripts/oal_001/__main__.py
+++ b/scripts/oal_001/__main__.py
@@ -4,43 +4,23 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
 from .governor import load_policy
+from .git_read import current_branch, head_sha
 from .runtime import execute_cycle, write_cycle_artifacts
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-FIXED_GIT_READ_COMMANDS = {
-    ("git", "branch", "--show-current"),
-    ("git", "rev-parse", "HEAD"),
-}
-
-
-def _run_fixed_git_read(command: list[str]) -> str:
-    if tuple(command) not in FIXED_GIT_READ_COMMANDS:
-        raise ValueError("Git command is outside the fixed read-only allowlist")
-    result = subprocess.run(
-        command,
-        cwd=REPO_ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"{' '.join(command)} failed: {result.stderr.strip()}")
-    return result.stdout.strip()
 
 
 def git_branch() -> str:
-    return _run_fixed_git_read(["git", "branch", "--show-current"])
+    return current_branch(REPO_ROOT)
 
 
 def git_head() -> str:
-    return _run_fixed_git_read(["git", "rev-parse", "HEAD"])
+    return head_sha(REPO_ROOT)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/oal_001/__main__.py
+++ b/scripts/oal_001/__main__.py
@@ -1,0 +1,86 @@
+"""Command-line entry point for the OAL-001 harmless local dry-run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .governor import load_policy
+from .runtime import execute_cycle, write_cycle_artifacts
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXED_GIT_READ_COMMANDS = {
+    ("git", "branch", "--show-current"),
+    ("git", "rev-parse", "HEAD"),
+}
+
+
+def _run_fixed_git_read(command: list[str]) -> str:
+    if tuple(command) not in FIXED_GIT_READ_COMMANDS:
+        raise ValueError("Git command is outside the fixed read-only allowlist")
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(command)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def git_branch() -> str:
+    return _run_fixed_git_read(["git", "branch", "--show-current"])
+
+
+def git_head() -> str:
+    return _run_fixed_git_read(["git", "rev-parse", "HEAD"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the OAL-001 controlled self-modification dry-run."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the deterministic result summary as JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        policy = load_policy(REPO_ROOT)
+        branch = git_branch()
+        base_sha = git_head()
+        result = execute_cycle(REPO_ROOT, policy, branch, base_sha)
+        output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+    except (OSError, ValueError, PermissionError, RuntimeError) as exc:
+        print(f"[oal-001] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    summary = {
+        "run_id": result.run_id,
+        "decision": result.trace["evaluation"]["decision"],
+        "rollback_status": result.rollback_proof["status"],
+        "external_mutation_count": result.trace["external_mutation_count"],
+        "output_dir": output_dir.relative_to(REPO_ROOT).as_posix(),
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+    else:
+        print(f"[oal-001] run_id={summary['run_id']}")
+        print(f"[oal-001] decision={summary['decision']}")
+        print(f"[oal-001] rollback_status={summary['rollback_status']}")
+        print("[oal-001] external_mutation_count=0")
+        print(f"[oal-001] output_dir={summary['output_dir']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/oal_001/git_read.py
+++ b/scripts/oal_001/git_read.py
@@ -1,0 +1,194 @@
+"""Hardened, typed and read-only Git observations for OAL-001."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path, PurePosixPath
+
+
+TRUSTED_GIT_CANDIDATES = (
+    r"C:\Program Files\Git\cmd\git.exe",
+    r"C:\Program Files\Git\bin\git.exe",
+    r"C:\Program Files (x86)\Git\cmd\git.exe",
+    "/usr/bin/git",
+)
+FIXED_GIT_READ_ARGUMENTS = {
+    ("branch", "--show-current"),
+    ("rev-parse", "HEAD"),
+    ("status", "--short", "--branch"),
+}
+GIT_SHA_PATTERN = re.compile(r"^[a-f0-9]{40}$")
+BRANCH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+_PASSTHROUGH_ENVIRONMENT = (
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+)
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _contains_link_component(path: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        if current.is_symlink() or _is_reparse_point(current):
+            return True
+    return False
+
+
+def _resolve_git_executable(repo_root: Path) -> Path:
+    resolved_repo = repo_root.resolve(strict=True)
+    if not resolved_repo.is_dir():
+        raise RuntimeError("repository root is not a directory")
+    for raw_candidate in TRUSTED_GIT_CANDIDATES:
+        candidate = Path(raw_candidate)
+        if not candidate.is_absolute() or _contains_link_component(candidate):
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (FileNotFoundError, OSError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            resolved.relative_to(resolved_repo)
+        except ValueError:
+            return resolved
+    raise RuntimeError("no fixed trusted Git executable is available")
+
+
+def _sanitized_environment(git_executable: Path) -> dict[str, str]:
+    environment: dict[str, str] = {}
+    for key in _PASSTHROUGH_ENVIRONMENT:
+        value = os.getenv(key)
+        if value:
+            environment[key] = value
+    environment.update(
+        {
+            "PATH": str(git_executable.parent),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_PAGER": "cat",
+            "LC_ALL": "C",
+        }
+    )
+    return environment
+
+
+def _validate_relative_path(relative_path: str) -> str:
+    if (
+        not relative_path
+        or "\\" in relative_path
+        or "\x00" in relative_path
+        or re.match(r"^[A-Za-z]:", relative_path)
+        or relative_path.startswith(":")
+        or any(character in relative_path for character in "*?[")
+    ):
+        raise ValueError("Git path must be a non-empty normalized repository path")
+    parsed = PurePosixPath(relative_path)
+    if (
+        parsed.is_absolute()
+        or any(part in {"", ".", ".."} for part in parsed.parts)
+        or parsed.as_posix() != relative_path
+    ):
+        raise ValueError("Git path must stay within the repository")
+    return relative_path
+
+
+def _run_git(
+    repo_root: Path,
+    arguments: tuple[str, ...],
+    allowed_return_codes: frozenset[int] = frozenset({0}),
+) -> tuple[int, str, str]:
+    is_fixed_read = arguments in FIXED_GIT_READ_ARGUMENTS
+    is_check_ignore = (
+        len(arguments) == 4
+        and arguments[:3] == ("check-ignore", "-q", "--")
+        and arguments[3] == _validate_relative_path(arguments[3])
+    )
+    if not is_fixed_read and not is_check_ignore:
+        raise ValueError("Git operation is outside the typed read-only API")
+
+    resolved_repo = repo_root.resolve(strict=True)
+    git_executable = _resolve_git_executable(resolved_repo)
+    command = [
+        str(git_executable),
+        "--no-pager",
+        "--no-optional-locks",
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        f"core.hooksPath={os.devnull}",
+        *arguments,
+    ]
+    result = subprocess.run(
+        command,
+        cwd=resolved_repo,
+        env=_sanitized_environment(git_executable),
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode not in allowed_return_codes:
+        detail = result.stderr.strip() or "no diagnostic output"
+        raise RuntimeError(f"read-only Git observation failed: {detail}")
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def current_branch(repo_root: Path) -> str:
+    """Return the current branch through the fixed read-only Git boundary."""
+
+    _, output, _ = _run_git(repo_root, ("branch", "--show-current"))
+    if not output or not BRANCH_PATTERN.fullmatch(output):
+        raise RuntimeError("Git branch observation returned an invalid branch")
+    return output
+
+
+def head_sha(repo_root: Path) -> str:
+    """Return the current commit SHA through the fixed read-only Git boundary."""
+
+    _, output, _ = _run_git(repo_root, ("rev-parse", "HEAD"))
+    if not GIT_SHA_PATTERN.fullmatch(output):
+        raise RuntimeError("Git HEAD observation returned an invalid SHA")
+    return output
+
+
+def worktree_status(repo_root: Path) -> str:
+    """Return porcelain status without optional index writes or fsmonitor hooks."""
+
+    _, output, _ = _run_git(repo_root, ("status", "--short", "--branch"))
+    if not output.startswith("## ") or "\x00" in output:
+        raise RuntimeError("Git status observation returned an invalid payload")
+    return output
+
+
+def is_ignored(repo_root: Path, relative_path: str) -> bool:
+    """Return whether one validated repository-relative path is ignored."""
+
+    normalized = _validate_relative_path(relative_path)
+    return_code, _, _ = _run_git(
+        repo_root,
+        ("check-ignore", "-q", "--", normalized),
+        allowed_return_codes=frozenset({0, 1}),
+    )
+    return return_code == 0

--- a/scripts/oal_001/git_read.py
+++ b/scripts/oal_001/git_read.py
@@ -18,10 +18,18 @@ TRUSTED_GIT_CANDIDATES = (
 FIXED_GIT_READ_ARGUMENTS = {
     ("branch", "--show-current"),
     ("rev-parse", "HEAD"),
-    ("status", "--short", "--branch"),
+    (
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--ignore-submodules=none",
+        "--no-renames",
+    ),
 }
 GIT_SHA_PATTERN = re.compile(r"^[a-f0-9]{40}$")
 BRANCH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+PORCELAIN_INDEX_STATUS_CHARACTERS = frozenset(" MTADRCU?")
+PORCELAIN_WORKTREE_STATUS_CHARACTERS = frozenset(" MTADRCU?m")
 _PASSTHROUGH_ENVIRONMENT = (
     "SYSTEMROOT",
     "WINDIR",
@@ -92,6 +100,14 @@ def _sanitized_environment(git_executable: Path) -> dict[str, str]:
     return environment
 
 
+def _remove_terminal_newline(value: str) -> str:
+    if value.endswith("\r\n"):
+        return value[:-2]
+    if value.endswith("\n"):
+        return value[:-1]
+    return value
+
+
 def _validate_relative_path(relative_path: str) -> str:
     if (
         not relative_path
@@ -135,6 +151,12 @@ def _run_git(
         "-c",
         "core.fsmonitor=false",
         "-c",
+        "core.quotePath=true",
+        "-c",
+        "core.untrackedCache=false",
+        "-c",
+        "status.branch=false",
+        "-c",
         f"core.hooksPath={os.devnull}",
         *arguments,
     ]
@@ -152,7 +174,11 @@ def _run_git(
     if result.returncode not in allowed_return_codes:
         detail = result.stderr.strip() or "no diagnostic output"
         raise RuntimeError(f"read-only Git observation failed: {detail}")
-    return result.returncode, result.stdout.strip(), result.stderr.strip()
+    return (
+        result.returncode,
+        _remove_terminal_newline(result.stdout),
+        _remove_terminal_newline(result.stderr),
+    )
 
 
 def current_branch(repo_root: Path) -> str:
@@ -173,13 +199,41 @@ def head_sha(repo_root: Path) -> str:
     return output
 
 
-def worktree_status(repo_root: Path) -> str:
-    """Return porcelain status without optional index writes or fsmonitor hooks."""
+def validate_worktree_status(status: str) -> str:
+    """Validate branch-header-free Git porcelain v1 dirty-state entries."""
 
-    _, output, _ = _run_git(repo_root, ("status", "--short", "--branch"))
-    if not output.startswith("## ") or "\x00" in output:
+    if not isinstance(status, str):
+        raise RuntimeError("Git status observation returned a non-string payload")
+    if "\x00" in status or "\r" in status or status.endswith("\n"):
         raise RuntimeError("Git status observation returned an invalid payload")
-    return output
+    for line in status.split("\n") if status else ():
+        if (
+            len(line) < 4
+            or line.startswith("## ")
+            or line[2] != " "
+            or line[:2] == "  "
+            or line[0] not in PORCELAIN_INDEX_STATUS_CHARACTERS
+            or line[1] not in PORCELAIN_WORKTREE_STATUS_CHARACTERS
+            or (line[0] == "?" and line[1] != "?")
+        ):
+            raise RuntimeError("Git status observation returned an invalid payload")
+    return status
+
+
+def worktree_status(repo_root: Path) -> str:
+    """Return canonical dirty entries without branch or tracking metadata."""
+
+    _, output, _ = _run_git(
+        repo_root,
+        (
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+            "--no-renames",
+        ),
+    )
+    return validate_worktree_status(output)
 
 
 def is_ignored(repo_root: Path, relative_path: str) -> bool:

--- a/scripts/oal_001/governor.py
+++ b/scripts/oal_001/governor.py
@@ -177,17 +177,25 @@ def load_policy(repo_root: Path) -> GovernorPolicy:
         normalize_relative_path(candidate)
     if set(policy.mutable_paths) & set(policy.protected_paths):
         raise PolicyError("mutable_paths and protected_paths must not overlap exactly")
-    expected_scalars = {
-        "policy_id": "OAL-001-GOVERNOR",
-        "schema_version": "OAL-1.0",
-        "mode": "local_dry_run",
-        "branch_pattern": "codex/observatory-selfmod-*",
-        "fixture_path": "tests/fixtures/observatory/synthetic_harmless_cycle.json",
-        "output_root": "raw/exports/local-private/oal-001",
-        "historical_fixture_status": "unavailable",
-    }
-    for field, expected in expected_scalars.items():
-        if getattr(policy, field) != expected:
+    scalar_checks = (
+        ("policy_id", policy.policy_id, "OAL-001-GOVERNOR"),
+        ("schema_version", policy.schema_version, "OAL-1.0"),
+        ("mode", policy.mode, "local_dry_run"),
+        ("branch_pattern", policy.branch_pattern, "codex/observatory-selfmod-*"),
+        (
+            "fixture_path",
+            policy.fixture_path,
+            "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+        ),
+        ("output_root", policy.output_root, "raw/exports/local-private/oal-001"),
+        (
+            "historical_fixture_status",
+            policy.historical_fixture_status,
+            "unavailable",
+        ),
+    )
+    for field, actual, expected in scalar_checks:
+        if actual != expected:
             raise PolicyError(f"{field} must remain {expected}")
     if policy.mutable_paths != EXPECTED_MUTABLE_PATHS:
         raise PolicyError("mutable_paths must remain the exact first-slice allowlist")

--- a/scripts/oal_001/governor.py
+++ b/scripts/oal_001/governor.py
@@ -23,6 +23,7 @@ EXPECTED_PROTECTED_PATHS = (
     "schemas/oal_001_mutation_trace.schema.json",
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
+    "scripts/oal_001/git_read.py",
     "scripts/oal_001/governor.py",
     "scripts/oal_001/runtime.py",
     "scripts/validate_oal_001.py",

--- a/scripts/oal_001/governor.py
+++ b/scripts/oal_001/governor.py
@@ -16,6 +16,7 @@ EXPECTED_MUTABLE_PATHS = ("scripts/oal_001/observatory.py",)
 EXPECTED_PROTECTED_PATHS = (
     ".codex",
     ".git",
+    ".github/workflows/oal-001-validate.yml",
     ".gitignore",
     "config/oal_001.json",
     "docs/governance",

--- a/scripts/oal_001/governor.py
+++ b/scripts/oal_001/governor.py
@@ -1,0 +1,320 @@
+"""Baseline-only Governor for OAL-001 candidate mutations."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+SHA256_PATTERN = re.compile(r"^[A-Fa-f0-9]{64}$")
+EXPECTED_MUTABLE_PATHS = ("scripts/oal_001/observatory.py",)
+EXPECTED_PROTECTED_PATHS = (
+    ".codex",
+    ".git",
+    ".gitignore",
+    "config/oal_001.json",
+    "docs/governance",
+    "raw/exports",
+    "schemas/oal_001_mutation_trace.schema.json",
+    "scripts/oal_001/__init__.py",
+    "scripts/oal_001/__main__.py",
+    "scripts/oal_001/governor.py",
+    "scripts/oal_001/runtime.py",
+    "scripts/validate_oal_001.py",
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+)
+EXPECTED_AUTHORIZING_TEST_PATHS = (
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+)
+SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(?:api[_-]?key|access[_-]?token|password)\s*[:=]\s*['\"][^'\"]{8,}['\"]"
+    ),
+    re.compile(r"\bAKIA[A-Z0-9]{16}\b"),
+)
+
+
+class PolicyError(ValueError):
+    """Raised when the immutable policy is malformed."""
+
+
+@dataclass(frozen=True)
+class GovernorPolicy:
+    policy_id: str
+    schema_version: str
+    mode: str
+    branch_pattern: str
+    mutable_paths: tuple[str, ...]
+    protected_paths: tuple[str, ...]
+    authorizing_test_paths: tuple[str, ...]
+    fixture_path: str
+    output_root: str
+    minimum_exploration_share: float
+    external_mutation_count: int
+    historical_fixture_status: str
+
+
+@dataclass(frozen=True)
+class PatchSpec:
+    cycle_id: str
+    target_path: str
+    changed_paths: tuple[str, ...]
+    expected_before_sha256: str
+    replacement_text: str
+    trigger: str
+    hypothesis: str
+    expected_effect: str
+    fallback_criterion: str
+
+
+@dataclass(frozen=True)
+class GovernorDecision:
+    approved: bool
+    reasons: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "approved": self.approved,
+            "reasons": list(self.reasons),
+            "immutable_surface": "baseline_only",
+        }
+
+
+def _string_list(payload: dict[str, object], key: str) -> tuple[str, ...]:
+    value = payload.get(key)
+    if (
+        not isinstance(value, list)
+        or not value
+        or not all(isinstance(item, str) and item for item in value)
+    ):
+        raise PolicyError(f"{key} must be a non-empty string list")
+    return tuple(value)
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def load_policy(repo_root: Path) -> GovernorPolicy:
+    root = repo_root.resolve()
+    path = root / "config" / "oal_001.json"
+    current = root
+    for part in ("config", "oal_001.json"):
+        current = current / part
+        if current.is_symlink() or _is_reparse_point(current):
+            raise PolicyError(
+                "immutable policy path must not contain links or reparse points"
+            )
+    try:
+        path.resolve().relative_to(root)
+    except ValueError as exc:
+        raise PolicyError("immutable policy path escapes repository root") from exc
+    if not path.is_file() or path.stat().st_nlink > 1:
+        raise PolicyError("immutable policy must be one regular, non-hard-linked file")
+    payload = json.loads(path.read_bytes().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise PolicyError("policy root must be an object")
+
+    required_strings = (
+        "policy_id",
+        "schema_version",
+        "mode",
+        "branch_pattern",
+        "fixture_path",
+        "output_root",
+        "historical_fixture_status",
+    )
+    for key in required_strings:
+        if not isinstance(payload.get(key), str) or not payload[key]:
+            raise PolicyError(f"{key} must be a non-empty string")
+
+    minimum = payload.get("minimum_exploration_share")
+    if (
+        not isinstance(minimum, (int, float))
+        or isinstance(minimum, bool)
+        or not 0 <= float(minimum) <= 1
+    ):
+        raise PolicyError("minimum_exploration_share must be between 0 and 1")
+    mutation_count = payload.get("external_mutation_count")
+    if mutation_count != 0:
+        raise PolicyError("external_mutation_count must be zero")
+
+    policy = GovernorPolicy(
+        policy_id=payload["policy_id"],
+        schema_version=payload["schema_version"],
+        mode=payload["mode"],
+        branch_pattern=payload["branch_pattern"],
+        mutable_paths=_string_list(payload, "mutable_paths"),
+        protected_paths=_string_list(payload, "protected_paths"),
+        authorizing_test_paths=_string_list(payload, "authorizing_test_paths"),
+        fixture_path=payload["fixture_path"],
+        output_root=payload["output_root"],
+        minimum_exploration_share=float(minimum),
+        external_mutation_count=mutation_count,
+        historical_fixture_status=payload["historical_fixture_status"],
+    )
+    for candidate in (
+        *policy.mutable_paths,
+        *policy.protected_paths,
+        *policy.authorizing_test_paths,
+        policy.fixture_path,
+        policy.output_root,
+    ):
+        normalize_relative_path(candidate)
+    if set(policy.mutable_paths) & set(policy.protected_paths):
+        raise PolicyError("mutable_paths and protected_paths must not overlap exactly")
+    expected_scalars = {
+        "policy_id": "OAL-001-GOVERNOR",
+        "schema_version": "OAL-1.0",
+        "mode": "local_dry_run",
+        "branch_pattern": "codex/observatory-selfmod-*",
+        "fixture_path": "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+        "output_root": "raw/exports/local-private/oal-001",
+        "historical_fixture_status": "unavailable",
+    }
+    for field, expected in expected_scalars.items():
+        if getattr(policy, field) != expected:
+            raise PolicyError(f"{field} must remain {expected}")
+    if policy.mutable_paths != EXPECTED_MUTABLE_PATHS:
+        raise PolicyError("mutable_paths must remain the exact first-slice allowlist")
+    if policy.protected_paths != EXPECTED_PROTECTED_PATHS:
+        raise PolicyError(
+            "protected_paths must remain the exact first-slice protected surface"
+        )
+    if policy.authorizing_test_paths != EXPECTED_AUTHORIZING_TEST_PATHS:
+        raise PolicyError("authorizing_test_paths must remain independently protected")
+    if policy.minimum_exploration_share != 0.25:
+        raise PolicyError("minimum_exploration_share must remain 0.25")
+    return policy
+
+
+def normalize_relative_path(value: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise PolicyError(f"path must be a non-empty POSIX relative path: {value!r}")
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or re.match(r"^[A-Za-z]:/", value)
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise PolicyError(f"path must not be absolute or contain traversal: {value}")
+    normalized = path.as_posix()
+    if normalized != value:
+        raise PolicyError(f"path is not normalized: {value}")
+    return normalized
+
+
+def path_is_within(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def contains_secret_marker(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_PATTERNS)
+
+
+class Governor:
+    """Review candidate metadata and paths before any candidate write."""
+
+    def __init__(self, policy: GovernorPolicy):
+        self.policy = policy
+
+    def review(self, patch: PatchSpec, branch: str) -> GovernorDecision:
+        reasons: list[str] = []
+        metadata = {
+            "cycle_id": patch.cycle_id,
+            "trigger": patch.trigger,
+            "hypothesis": patch.hypothesis,
+            "expected_effect": patch.expected_effect,
+            "fallback_criterion": patch.fallback_criterion,
+        }
+        for key, value in metadata.items():
+            if not isinstance(value, str) or not value.strip():
+                reasons.append(f"missing_metadata:{key}")
+
+        if not fnmatch.fnmatchcase(branch, self.policy.branch_pattern):
+            reasons.append("branch_outside_allowed_lane")
+        if not SHA256_PATTERN.fullmatch(patch.expected_before_sha256):
+            reasons.append("invalid_expected_before_sha256")
+        if not patch.replacement_text:
+            reasons.append("empty_replacement")
+        elif contains_secret_marker(patch.replacement_text):
+            reasons.append("secret_like_content")
+
+        paths = tuple(dict.fromkeys(patch.changed_paths))
+        if patch.target_path not in paths:
+            reasons.append("target_missing_from_changed_paths")
+        if len(paths) != len(patch.changed_paths):
+            reasons.append("duplicate_changed_path")
+
+        normalized_paths: list[str] = []
+        for value in paths:
+            try:
+                normalized_paths.append(normalize_relative_path(value))
+            except PolicyError:
+                reasons.append(f"invalid_path:{value}")
+
+        protected_changed = [
+            value
+            for value in normalized_paths
+            if any(
+                path_is_within(value, prefix) for prefix in self.policy.protected_paths
+            )
+        ]
+        authorizing_test_changed = [
+            value
+            for value in normalized_paths
+            if any(
+                path_is_within(value, prefix)
+                for prefix in self.policy.authorizing_test_paths
+            )
+        ]
+        control_changed = [
+            value
+            for value in protected_changed
+            if not any(
+                path_is_within(value, prefix)
+                for prefix in self.policy.authorizing_test_paths
+            )
+        ]
+        if control_changed and authorizing_test_changed:
+            reasons.append("same_cycle_control_and_authorizing_test_change")
+
+        for value in normalized_paths:
+            if any(
+                path_is_within(value, prefix) for prefix in self.policy.protected_paths
+            ):
+                reasons.append(f"protected_path:{value}")
+            if value not in self.policy.mutable_paths:
+                reasons.append(f"path_not_mutable:{value}")
+
+        return GovernorDecision(
+            approved=not reasons, reasons=tuple(sorted(set(reasons)))
+        )
+
+    def require_approval(self, patch: PatchSpec, branch: str) -> GovernorDecision:
+        decision = self.review(patch, branch)
+        if not decision.approved:
+            raise PermissionError(
+                "Governor rejected candidate: " + ", ".join(decision.reasons)
+            )
+        return decision
+
+
+def protected_changes(policy: GovernorPolicy, paths: Iterable[str]) -> tuple[str, ...]:
+    return tuple(
+        path
+        for path in paths
+        if any(path_is_within(path, prefix) for prefix in policy.protected_paths)
+    )

--- a/scripts/oal_001/observatory.py
+++ b/scripts/oal_001/observatory.py
@@ -1,0 +1,10 @@
+"""Mutable Observatory example for the OAL-001 synthetic dry-run slice.
+
+This file contains data-only strategy weights. The sandbox parses the literal
+assignment with ``ast.literal_eval`` and never executes candidate source.
+"""
+
+STRATEGY_WEIGHTS = {
+    "primary": 0.75,
+    "exploration": 0.25,
+}

--- a/scripts/oal_001/runtime.py
+++ b/scripts/oal_001/runtime.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Mapping
 
 from .governor import Governor, GovernorDecision, GovernorPolicy, PatchSpec
-from .git_read import is_ignored, worktree_status
+from .git_read import is_ignored, validate_worktree_status, worktree_status
 
 
 TARGET_PATH = "scripts/oal_001/observatory.py"
@@ -45,6 +45,7 @@ NOT_ACTIONS = (
 )
 MANAGED_SOURCE_PATHS = (
     ".codex/safety_policy.yaml",
+    ".github/workflows/oal-001-validate.yml",
     ".gitignore",
     "config/oal_001.json",
     "docs/governance/oal_001_self_modification_policy.md",
@@ -527,6 +528,8 @@ def derive_run_id(
     fixture_id: str,
     source_manifest: list[dict[str, object]],
 ) -> str:
+    git_status_before = validate_worktree_status(git_status_before)
+    git_status_after = validate_worktree_status(git_status_after)
     material = {
         "base_sha": base_sha,
         "branch": branch,
@@ -557,6 +560,9 @@ def execute_cycle(
         raise ValueError("base_sha must be a lowercase 40-character Git SHA")
     if git_status_before is None:
         git_status_before = _git_status(repo_root)
+    git_status_before = validate_worktree_status(git_status_before)
+    if git_status_after is not None:
+        git_status_after = validate_worktree_status(git_status_after)
     source_manifest_before = source_manifest_for_repo(repo_root)
     managed_manifest_sha256_before = sha256_text(canonical_json(source_manifest_before))
     fixture = load_fixture(repo_root, policy.fixture_path)
@@ -599,6 +605,7 @@ def execute_cycle(
     )
     if git_status_after is None:
         git_status_after = _git_status(repo_root)
+    git_status_after = validate_worktree_status(git_status_after)
     rollback_proof = {
         "status": "verified"
         if rollback_partial["candidate_restored"]
@@ -1097,7 +1104,13 @@ def validate_trace_payload(trace: Mapping[str, object]) -> list[str]:
             errors.append("git status snapshots must be strings")
         else:
             expected_unchanged = before == after
-            expected_clean = git_status_is_clean(before) and git_status_is_clean(after)
+            try:
+                expected_clean = git_status_is_clean(before) and git_status_is_clean(
+                    after
+                )
+            except RuntimeError as exc:
+                errors.append(str(exc))
+                expected_clean = False
             if git_status.get("unchanged") is not expected_unchanged:
                 errors.append("git_status unchanged flag does not match snapshots")
             if git_status.get("clean_worktree") is not expected_clean:
@@ -1134,8 +1147,7 @@ def _git_status(repo_root: Path) -> str:
 
 
 def git_status_is_clean(status: str) -> bool:
-    lines = [line for line in status.splitlines() if line]
-    return len(lines) == 1 and lines[0].startswith("## ")
+    return validate_worktree_status(status) == ""
 
 
 def _prepare_output_dir(repo_root: Path, policy: GovernorPolicy, run_id: str) -> Path:

--- a/scripts/oal_001/runtime.py
+++ b/scripts/oal_001/runtime.py
@@ -9,13 +9,13 @@ import json
 import os
 import re
 import stat
-import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
 from .governor import Governor, GovernorDecision, GovernorPolicy, PatchSpec
+from .git_read import is_ignored, worktree_status
 
 
 TARGET_PATH = "scripts/oal_001/observatory.py"
@@ -51,6 +51,7 @@ MANAGED_SOURCE_PATHS = (
     "schemas/oal_001_mutation_trace.schema.json",
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
+    "scripts/oal_001/git_read.py",
     "scripts/oal_001/governor.py",
     TARGET_PATH,
     "scripts/oal_001/runtime.py",
@@ -1125,28 +1126,11 @@ def validate_trace_payload(trace: Mapping[str, object]) -> list[str]:
 
 
 def _git_check_ignored(repo_root: Path, rel_path: str) -> bool:
-    result = subprocess.run(
-        ["git", "check-ignore", "-q", rel_path],
-        cwd=repo_root,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
-    return result.returncode == 0
+    return is_ignored(repo_root, rel_path)
 
 
 def _git_status(repo_root: Path) -> str:
-    result = subprocess.run(
-        ["git", "status", "--short", "--branch"],
-        cwd=repo_root,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError("git status failed: " + result.stderr.strip())
-    return result.stdout.strip()
+    return worktree_status(repo_root)
 
 
 def git_status_is_clean(status: str) -> bool:

--- a/scripts/oal_001/runtime.py
+++ b/scripts/oal_001/runtime.py
@@ -1,0 +1,1265 @@
+"""Deterministic candidate, replay, evaluation and rollback runtime for OAL-001."""
+
+from __future__ import annotations
+
+import ast
+import difflib
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from .governor import Governor, GovernorDecision, GovernorPolicy, PatchSpec
+
+
+TARGET_PATH = "scripts/oal_001/observatory.py"
+CYCLE_ID = "OAL-001-SYNTHETIC-CURRENT-SLICE-001"
+TRIGGER = "GitHub Issue #97 first-slice controlled self-modification dry-run"
+HYPOTHESIS = (
+    "Increasing the synthetic exploration share from 0.25 to 0.30 improves secondary-path "
+    "coverage while preserving deterministic routing and all Governor boundaries."
+)
+EXPECTED_EFFECT = "One additional synthetic observation is routed to exploration in a 20-observation replay."
+FALLBACK_CRITERION = (
+    "Reject and restore the candidate if parsing, determinism, the 25 percent floor, the expected replay delta, "
+    "baseline integrity or any Governor boundary fails."
+)
+NOT_ACTIONS = (
+    "git_push",
+    "pull_request",
+    "merge",
+    "main_write",
+    "remote_branch_mutation",
+    "notion_write",
+    "learning_ledger_write",
+    "workflow_execution",
+    "publication",
+    "payment_mutation",
+    "zenodo_mutation",
+)
+MANAGED_SOURCE_PATHS = (
+    ".codex/safety_policy.yaml",
+    ".gitignore",
+    "config/oal_001.json",
+    "docs/governance/oal_001_self_modification_policy.md",
+    "schemas/oal_001_mutation_trace.schema.json",
+    "scripts/oal_001/__init__.py",
+    "scripts/oal_001/__main__.py",
+    "scripts/oal_001/governor.py",
+    TARGET_PATH,
+    "scripts/oal_001/runtime.py",
+    "scripts/validate_oal_001.py",
+    "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+)
+TRACE_REQUIRED_FIELDS = {
+    "schema_version",
+    "run_id",
+    "cycle_id",
+    "mode",
+    "base_sha",
+    "branch",
+    "source_state",
+    "source_manifest_sha256",
+    "fixture",
+    "trigger",
+    "hypothesis",
+    "expected_effect",
+    "fallback_criterion",
+    "target_path",
+    "changed_paths",
+    "baseline_sha256",
+    "candidate_sha256",
+    "diff_sha256",
+    "diff",
+    "governor",
+    "isolation",
+    "replay",
+    "evaluation",
+    "rollback",
+    "git_status",
+    "external_mutation_count",
+    "not_actions",
+}
+EVALUATION_CHECK_NAMES = {
+    "governor_approved",
+    "baseline_deterministic",
+    "candidate_deterministic",
+    "baseline_expected_share",
+    "candidate_expected_share",
+    "exploration_floor_preserved",
+    "expected_replay_delta",
+    "baseline_unchanged",
+    "synthetic_fixture_only",
+    "external_mutation_count_zero",
+    "rollback_verified",
+    "managed_baseline_unchanged",
+    "candidate_workspace_removed",
+}
+SHA256_PATTERN = re.compile(r"^[A-F0-9]{64}$")
+GIT_SHA_PATTERN = re.compile(r"^[a-f0-9]{40}$")
+
+
+class CandidateBoundaryError(ValueError):
+    """Raised before unsafe candidate filesystem access."""
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    fixture_id: str
+    fixture_kind: str
+    historical_evidence: bool
+    source_sha256: str
+    observation_count: int
+    strategy_weights: dict[str, float]
+    route_counts: dict[str, int]
+    routing_digest: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "fixture_id": self.fixture_id,
+            "fixture_kind": self.fixture_kind,
+            "historical_evidence": self.historical_evidence,
+            "source_sha256": self.source_sha256,
+            "observation_count": self.observation_count,
+            "strategy_weights": self.strategy_weights,
+            "route_counts": self.route_counts,
+            "routing_digest": self.routing_digest,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    decision: str
+    reasons: tuple[str, ...]
+    checks: dict[str, bool]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "decision": self.decision,
+            "reasons": list(self.reasons),
+            "checks": self.checks,
+        }
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    trace: dict[str, object]
+    source_manifest: list[dict[str, object]]
+    replay_before: dict[str, object]
+    replay_after: dict[str, object]
+    comparison: dict[str, object]
+    rollback_proof: dict[str, object]
+    boundary_report: dict[str, object]
+    risk_report: dict[str, object]
+    run_report: str
+
+    @property
+    def run_id(self) -> str:
+        return str(self.trace["run_id"])
+
+
+def canonical_json(payload: object) -> str:
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest().upper()
+
+
+def sha256_text(text: str) -> str:
+    return sha256_bytes(text.encode("utf-8"))
+
+
+def read_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path.name}")
+    return payload
+
+
+def _ensure_within(root: Path, path: Path, label: str) -> Path:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise CandidateBoundaryError(f"{label} escapes its allowed root") from exc
+    return resolved_path
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _reject_symlink_components(root: Path, path: Path, label: str) -> None:
+    resolved_root = root.resolve()
+    try:
+        relative = path.absolute().relative_to(resolved_root)
+    except ValueError as exc:
+        raise CandidateBoundaryError(f"{label} escapes its allowed root") from exc
+    current = resolved_root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink() or _is_reparse_point(current):
+            raise CandidateBoundaryError(
+                f"{label} must not contain links or reparse-point components"
+            )
+
+
+def read_managed_source(repo_root: Path, rel_path: str) -> bytes:
+    source = repo_root / rel_path
+    _reject_symlink_components(repo_root, source, "managed source")
+    resolved = _ensure_within(repo_root, source, "managed source")
+    if not resolved.is_file():
+        raise CandidateBoundaryError(
+            f"managed source is not a regular file: {rel_path}"
+        )
+    if resolved.stat().st_nlink > 1:
+        raise CandidateBoundaryError(
+            f"managed source must not be hard-linked: {rel_path}"
+        )
+    return resolved.read_bytes()
+
+
+def _validate_writable_target(root: Path, path: Path, label: str) -> Path:
+    _reject_symlink_components(root, path, label)
+    resolved = _ensure_within(root, path, label)
+    if resolved.exists():
+        if not resolved.is_file():
+            raise CandidateBoundaryError(f"{label} is not a regular file")
+        if resolved.stat().st_nlink > 1:
+            raise CandidateBoundaryError(f"{label} must not be hard-linked")
+    return resolved
+
+
+def parse_strategy_bytes(
+    source_bytes: bytes, filename: str = "observatory.py"
+) -> dict[str, float]:
+    source = source_bytes.decode("utf-8")
+    tree = ast.parse(source, filename=filename)
+    weights_node: ast.AST | None = None
+    for index, node in enumerate(tree.body):
+        if (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+        ):
+            if isinstance(node.value.value, str):
+                continue
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "STRATEGY_WEIGHTS"
+        ):
+            if weights_node is not None:
+                raise ValueError("STRATEGY_WEIGHTS must be assigned exactly once")
+            weights_node = node.value
+            continue
+        raise ValueError(
+            "candidate Observatory source contains executable or unsupported syntax"
+        )
+
+    if weights_node is None:
+        raise ValueError("candidate Observatory source is missing STRATEGY_WEIGHTS")
+    value = ast.literal_eval(weights_node)
+    if not isinstance(value, dict) or set(value) != {"primary", "exploration"}:
+        raise ValueError("STRATEGY_WEIGHTS must contain only primary and exploration")
+    if not all(
+        isinstance(item, (int, float)) and not isinstance(item, bool)
+        for item in value.values()
+    ):
+        raise ValueError("strategy weights must be numeric")
+    weights = {key: float(item) for key, item in value.items()}
+    if any(item < 0 or item > 1 for item in weights.values()):
+        raise ValueError("strategy weights must be between zero and one")
+    if abs(sum(weights.values()) - 1.0) > 1e-12:
+        raise ValueError("strategy weights must sum to one")
+    return weights
+
+
+def parse_strategy_source(path: Path) -> dict[str, float]:
+    return parse_strategy_bytes(path.read_bytes(), filename=path.name)
+
+
+def load_fixture(repo_root: Path, rel_path: str) -> dict[str, object]:
+    raw = read_managed_source(repo_root, rel_path)
+    fixture = json.loads(raw.decode("utf-8"))
+    if not isinstance(fixture, dict):
+        raise ValueError("fixture root must be an object")
+    required = {
+        "fixture_id",
+        "fixture_kind",
+        "historical_evidence",
+        "observations",
+        "expected_baseline_exploration_share",
+        "expected_candidate_exploration_share",
+    }
+    if set(fixture) != required:
+        raise ValueError(
+            "synthetic fixture fields do not match the first-slice contract"
+        )
+    if (
+        fixture["fixture_kind"] != "synthetic_current_slice"
+        or fixture["historical_evidence"] is not False
+    ):
+        raise ValueError("fixture must be explicitly synthetic and non-historical")
+    observations = fixture["observations"]
+    if (
+        not isinstance(observations, list)
+        or not observations
+        or not all(isinstance(item, str) for item in observations)
+    ):
+        raise ValueError("fixture observations must be a non-empty string list")
+    if len(set(observations)) != len(observations):
+        raise ValueError("fixture observations must be unique")
+    return fixture
+
+
+class ReplayHarness:
+    def __init__(self, fixture: Mapping[str, object]):
+        self.fixture = fixture
+
+    def replay(self, source_path: Path) -> ReplayResult:
+        return self.replay_bytes(source_path.read_bytes(), filename=source_path.name)
+
+    def replay_bytes(
+        self, source_bytes: bytes, filename: str = "observatory.py"
+    ) -> ReplayResult:
+        weights = parse_strategy_bytes(source_bytes, filename=filename)
+        observations = list(self.fixture["observations"])
+        exploration_count = round(len(observations) * weights["exploration"])
+        primary_count = len(observations) - exploration_count
+        routes = [
+            {
+                "observation": observation,
+                "route": "primary" if index < primary_count else "exploration",
+            }
+            for index, observation in enumerate(observations)
+        ]
+        return ReplayResult(
+            fixture_id=str(self.fixture["fixture_id"]),
+            fixture_kind=str(self.fixture["fixture_kind"]),
+            historical_evidence=bool(self.fixture["historical_evidence"]),
+            source_sha256=sha256_bytes(source_bytes),
+            observation_count=len(observations),
+            strategy_weights=weights,
+            route_counts={"primary": primary_count, "exploration": exploration_count},
+            routing_digest=sha256_text(canonical_json(routes)),
+        )
+
+
+class CandidateWorkspace:
+    """Temporary copy of one Governor-approved mutable path."""
+
+    def __init__(
+        self, repo_root: Path, target_path: str, temp_parent: Path | None = None
+    ):
+        self.repo_root = repo_root.resolve()
+        self.target_path = target_path
+        self.temp_parent = temp_parent
+        self._temporary: tempfile.TemporaryDirectory[str] | None = None
+        self.root: Path | None = None
+        self.baseline_bytes: bytes | None = None
+
+    def __enter__(self) -> "CandidateWorkspace":
+        self.baseline_bytes = read_managed_source(self.repo_root, self.target_path)
+        if self.temp_parent is not None:
+            self.temp_parent.mkdir(parents=True, exist_ok=True)
+        self._temporary = tempfile.TemporaryDirectory(
+            prefix="oal-001-candidate-", dir=self.temp_parent
+        )
+        self.root = Path(self._temporary.name)
+        candidate = self.path
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_bytes(self.baseline_bytes)
+        return self
+
+    @property
+    def path(self) -> Path:
+        if self.root is None:
+            raise RuntimeError("candidate workspace is not active")
+        return self.root / self.target_path
+
+    def apply(self, patch: PatchSpec) -> tuple[str, str]:
+        if patch.target_path != self.target_path or patch.changed_paths != (
+            self.target_path,
+        ):
+            raise CandidateBoundaryError(
+                "candidate workspace accepts exactly one approved target"
+            )
+        if self.baseline_bytes is None or self.root is None:
+            raise RuntimeError("candidate workspace is not active")
+        actual = sha256_bytes(self.path.read_bytes())
+        if actual != patch.expected_before_sha256.upper():
+            raise CandidateBoundaryError(
+                "candidate baseline hash does not match PatchSpec"
+            )
+        target = _validate_writable_target(self.root, self.path, "candidate target")
+        target.write_text(patch.replacement_text, encoding="utf-8", newline="\n")
+        candidate_text = target.read_text(encoding="utf-8")
+        baseline_text = self.baseline_bytes.decode("utf-8")
+        diff = "".join(
+            difflib.unified_diff(
+                baseline_text.splitlines(keepends=True),
+                candidate_text.splitlines(keepends=True),
+                fromfile=f"a/{self.target_path}",
+                tofile=f"b/{self.target_path}",
+            )
+        )
+        if not diff:
+            raise ValueError("candidate patch produced no diff")
+        return diff, sha256_bytes(target.read_bytes())
+
+    def rollback(self) -> dict[str, object]:
+        if self.baseline_bytes is None or self.root is None:
+            raise RuntimeError("candidate workspace is not active")
+        target = _validate_writable_target(
+            self.root, self.path, "candidate rollback target"
+        )
+        target.write_bytes(self.baseline_bytes)
+        restored = sha256_bytes(target.read_bytes()) == sha256_bytes(
+            self.baseline_bytes
+        )
+        return {
+            "candidate_restored": restored,
+            "restored_sha256": sha256_bytes(target.read_bytes()),
+        }
+
+    def snapshot(self) -> bytes:
+        if self.root is None:
+            raise RuntimeError("candidate workspace is not active")
+        target = _validate_writable_target(self.root, self.path, "candidate snapshot")
+        return target.read_bytes()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        if self._temporary is not None:
+            self._temporary.cleanup()
+
+
+class PatchEvaluator:
+    def __init__(self, policy: GovernorPolicy, fixture: Mapping[str, object]):
+        self.policy = policy
+        self.fixture = fixture
+
+    def evaluate(
+        self,
+        governor_decision: GovernorDecision,
+        before_first: ReplayResult,
+        before_second: ReplayResult,
+        after_first: ReplayResult,
+        after_second: ReplayResult,
+        baseline_unchanged: bool,
+    ) -> EvaluationResult:
+        before_payload = before_first.as_dict()
+        after_payload = after_first.as_dict()
+        checks = {
+            "governor_approved": governor_decision.approved,
+            "baseline_deterministic": before_payload == before_second.as_dict(),
+            "candidate_deterministic": after_payload == after_second.as_dict(),
+            "baseline_expected_share": before_first.strategy_weights["exploration"]
+            == float(self.fixture["expected_baseline_exploration_share"]),
+            "candidate_expected_share": after_first.strategy_weights["exploration"]
+            == float(self.fixture["expected_candidate_exploration_share"]),
+            "exploration_floor_preserved": after_first.strategy_weights["exploration"]
+            >= self.policy.minimum_exploration_share,
+            "expected_replay_delta": after_first.route_counts["exploration"]
+            == before_first.route_counts["exploration"] + 1,
+            "baseline_unchanged": baseline_unchanged,
+            "synthetic_fixture_only": after_first.fixture_kind
+            == "synthetic_current_slice"
+            and not after_first.historical_evidence,
+            "external_mutation_count_zero": self.policy.external_mutation_count == 0,
+        }
+        failed = tuple(sorted(name for name, passed in checks.items() if not passed))
+        if failed:
+            return EvaluationResult("reject", failed, checks)
+        return EvaluationResult("retain", ("all_first_slice_checks_passed",), checks)
+
+
+def build_harmless_patch(source_text: str, baseline_sha256: str) -> PatchSpec:
+    replacements = (
+        ('"primary": 0.75', '"primary": 0.70'),
+        ('"exploration": 0.25', '"exploration": 0.30'),
+    )
+    candidate = source_text
+    for before, after in replacements:
+        if candidate.count(before) != 1:
+            raise ValueError(f"harmless patch marker must occur exactly once: {before}")
+        candidate = candidate.replace(before, after)
+    return PatchSpec(
+        cycle_id=CYCLE_ID,
+        target_path=TARGET_PATH,
+        changed_paths=(TARGET_PATH,),
+        expected_before_sha256=baseline_sha256,
+        replacement_text=candidate,
+        trigger=TRIGGER,
+        hypothesis=HYPOTHESIS,
+        expected_effect=EXPECTED_EFFECT,
+        fallback_criterion=FALLBACK_CRITERION,
+    )
+
+
+def derive_run_id(
+    base_sha: str,
+    branch: str,
+    git_status_before: str,
+    git_status_after: str,
+    cycle_id: str,
+    target_path: str,
+    baseline_sha256: str,
+    candidate_sha256: str,
+    fixture_id: str,
+    source_manifest: list[dict[str, object]],
+) -> str:
+    material = {
+        "base_sha": base_sha,
+        "branch": branch,
+        "git_status_before": git_status_before,
+        "git_status_after": git_status_after,
+        "cycle_id": cycle_id,
+        "target_path": target_path,
+        "baseline_sha256": baseline_sha256,
+        "candidate_sha256": candidate_sha256,
+        "fixture_id": fixture_id,
+        "source_manifest": source_manifest,
+    }
+    digest = sha256_text(canonical_json(material))[:16]
+    return f"OAL-001-{digest}"
+
+
+def execute_cycle(
+    repo_root: Path,
+    policy: GovernorPolicy,
+    branch: str,
+    base_sha: str,
+    git_status_before: str | None = None,
+    git_status_after: str | None = None,
+    temp_parent: Path | None = None,
+) -> CycleResult:
+    repo_root = repo_root.resolve()
+    if not GIT_SHA_PATTERN.fullmatch(base_sha):
+        raise ValueError("base_sha must be a lowercase 40-character Git SHA")
+    if git_status_before is None:
+        git_status_before = _git_status(repo_root)
+    source_manifest_before = source_manifest_for_repo(repo_root)
+    managed_manifest_sha256_before = sha256_text(canonical_json(source_manifest_before))
+    fixture = load_fixture(repo_root, policy.fixture_path)
+    source_bytes = read_managed_source(repo_root, TARGET_PATH)
+    baseline_sha256 = sha256_bytes(source_bytes)
+    patch = build_harmless_patch(source_bytes.decode("utf-8"), baseline_sha256)
+    governor_decision = Governor(policy).require_approval(patch, branch)
+    harness = ReplayHarness(fixture)
+    before_first = harness.replay_bytes(source_bytes)
+    before_second = harness.replay_bytes(source_bytes)
+    active_hash_before = sha256_bytes(read_managed_source(repo_root, TARGET_PATH))
+
+    workspace_root: Path | None = None
+    with CandidateWorkspace(
+        repo_root, TARGET_PATH, temp_parent=temp_parent
+    ) as workspace:
+        workspace_root = workspace.root
+        diff, candidate_sha256 = workspace.apply(patch)
+        candidate_snapshot = workspace.snapshot()
+        after_first = harness.replay_bytes(candidate_snapshot)
+        after_second = harness.replay_bytes(candidate_snapshot)
+        active_hash_during = sha256_bytes(read_managed_source(repo_root, TARGET_PATH))
+        source_manifest_during = source_manifest_for_repo(repo_root)
+        provisional_evaluation = PatchEvaluator(policy, fixture).evaluate(
+            governor_decision,
+            before_first,
+            before_second,
+            after_first,
+            after_second,
+            active_hash_before == active_hash_during,
+        )
+        rollback_partial = workspace.rollback()
+
+    workspace_removed = bool(workspace_root is not None and not workspace_root.exists())
+    active_hash_after = sha256_bytes(read_managed_source(repo_root, TARGET_PATH))
+    source_manifest_after = source_manifest_for_repo(repo_root)
+    managed_manifest_sha256_after = sha256_text(canonical_json(source_manifest_after))
+    managed_baseline_unchanged = (
+        source_manifest_before == source_manifest_during == source_manifest_after
+    )
+    if git_status_after is None:
+        git_status_after = _git_status(repo_root)
+    rollback_proof = {
+        "status": "verified"
+        if rollback_partial["candidate_restored"]
+        and active_hash_before == active_hash_after
+        and managed_baseline_unchanged
+        and workspace_removed
+        else "failed",
+        "candidate_restored": bool(rollback_partial["candidate_restored"]),
+        "restored_sha256": rollback_partial["restored_sha256"],
+        "baseline_sha256_before": active_hash_before,
+        "baseline_sha256_after": active_hash_after,
+        "managed_manifest_sha256_before": managed_manifest_sha256_before,
+        "managed_manifest_sha256_after": managed_manifest_sha256_after,
+        "baseline_unchanged": managed_baseline_unchanged,
+        "candidate_workspace_removed": workspace_removed,
+    }
+    final_checks = dict(provisional_evaluation.checks)
+    final_checks.update(
+        {
+            "rollback_verified": rollback_proof["status"] == "verified",
+            "managed_baseline_unchanged": managed_baseline_unchanged,
+            "candidate_workspace_removed": workspace_removed,
+        }
+    )
+    failed_checks = tuple(
+        sorted(name for name, passed in final_checks.items() if not passed)
+    )
+    evaluation = (
+        EvaluationResult("reject", failed_checks, final_checks)
+        if failed_checks
+        else EvaluationResult(
+            "retain", ("all_first_slice_checks_passed",), final_checks
+        )
+    )
+    git_status_unchanged = git_status_before == git_status_after
+    clean_worktree = git_status_is_clean(git_status_before) and git_status_is_clean(
+        git_status_after
+    )
+    source_state = "clean_commit" if clean_worktree else "working_tree_manifest"
+    source_manifest_sha256 = sha256_text(canonical_json(source_manifest_before))
+    run_id = derive_run_id(
+        base_sha,
+        branch,
+        git_status_before,
+        git_status_after,
+        patch.cycle_id,
+        patch.target_path,
+        patch.expected_before_sha256,
+        candidate_sha256,
+        str(fixture["fixture_id"]),
+        source_manifest_before,
+    )
+    rollback_proof["run_id"] = run_id
+    comparison = {
+        "run_id": run_id,
+        "baseline": before_first.as_dict(),
+        "candidate": after_first.as_dict(),
+        "delta": {
+            "exploration_share": round(
+                after_first.strategy_weights["exploration"]
+                - before_first.strategy_weights["exploration"],
+                12,
+            ),
+            "exploration_routes": after_first.route_counts["exploration"]
+            - before_first.route_counts["exploration"],
+        },
+        "evaluation": evaluation.as_dict(),
+    }
+    trace = {
+        "schema_version": policy.schema_version,
+        "run_id": run_id,
+        "cycle_id": patch.cycle_id,
+        "mode": policy.mode,
+        "base_sha": base_sha,
+        "branch": branch,
+        "source_state": source_state,
+        "source_manifest_sha256": source_manifest_sha256,
+        "fixture": {
+            "fixture_id": fixture["fixture_id"],
+            "fixture_kind": fixture["fixture_kind"],
+            "historical_evidence": fixture["historical_evidence"],
+            "historical_fixture_status": policy.historical_fixture_status,
+        },
+        "trigger": patch.trigger,
+        "hypothesis": patch.hypothesis,
+        "expected_effect": patch.expected_effect,
+        "fallback_criterion": patch.fallback_criterion,
+        "target_path": patch.target_path,
+        "changed_paths": list(patch.changed_paths),
+        "baseline_sha256": baseline_sha256,
+        "candidate_sha256": candidate_sha256,
+        "diff_sha256": sha256_text(diff),
+        "diff": diff,
+        "governor": governor_decision.as_dict(),
+        "isolation": {
+            "candidate_workspace": "temporary_allowlist_copy",
+            "managed_paths": list(patch.changed_paths),
+            "running_version_overwritten": False,
+        },
+        "replay": {
+            "baseline_deterministic": before_first.as_dict() == before_second.as_dict(),
+            "candidate_deterministic": after_first.as_dict() == after_second.as_dict(),
+            "before_artifact": "replay_before.json",
+            "after_artifact": "replay_after.json",
+        },
+        "evaluation": evaluation.as_dict(),
+        "rollback": {
+            "status": rollback_proof["status"],
+            "candidate_restored": rollback_proof["candidate_restored"],
+            "baseline_unchanged": rollback_proof["baseline_unchanged"],
+            "candidate_workspace_removed": rollback_proof[
+                "candidate_workspace_removed"
+            ],
+        },
+        "git_status": {
+            "before": git_status_before,
+            "after": git_status_after,
+            "unchanged": git_status_unchanged,
+            "clean_worktree": clean_worktree,
+        },
+        "external_mutation_count": policy.external_mutation_count,
+        "not_actions": list(NOT_ACTIONS),
+    }
+    boundary_checks = {
+        "governor_approved": governor_decision.approved,
+        "exact_mutable_allowlist": patch.changed_paths == policy.mutable_paths,
+        "candidate_workspace_removed": workspace_removed,
+        "running_version_overwritten": False,
+        "baseline_unchanged": managed_baseline_unchanged,
+        "candidate_source_executed": False,
+        "external_mutation_count_zero": policy.external_mutation_count == 0,
+        "historical_claim_fabricated": False,
+        "git_status_unchanged": git_status_unchanged,
+        "clean_worktree": clean_worktree,
+    }
+    boundary_pass = all(
+        boundary_checks[name]
+        for name in (
+            "governor_approved",
+            "exact_mutable_allowlist",
+            "candidate_workspace_removed",
+            "baseline_unchanged",
+            "external_mutation_count_zero",
+            "git_status_unchanged",
+        )
+    ) and not any(
+        boundary_checks[name]
+        for name in (
+            "running_version_overwritten",
+            "candidate_source_executed",
+            "historical_claim_fabricated",
+        )
+    )
+    boundary_report = {
+        "run_id": run_id,
+        "status": (
+            "PASS"
+            if boundary_pass and clean_worktree
+            else "PASS_PREPARED"
+            if boundary_pass
+            else "FAIL"
+        ),
+        "checks": boundary_checks,
+        "external_mutation_count": policy.external_mutation_count,
+    }
+    remaining_risks = [
+        "No verified historical Hubble or ALMA fixture is admitted to the configured runtime slice.",
+        "Candidate source is AST-parsed but not executed; executable candidate sandboxing is deferred.",
+        "Broad Observatory engines, connector operations and ledger writing are not implemented.",
+        "Cross-platform filesystem checks reduce but cannot eliminate check/open race conditions.",
+        "A retain decision is technical evidence only and does not promote or activate the candidate.",
+    ]
+    if not clean_worktree:
+        remaining_risks.insert(
+            0,
+            "Managed sources are bound by manifest but are not yet represented by the recorded Git HEAD.",
+        )
+    risk_report = {
+        "run_id": run_id,
+        "status": (
+            "FAIL"
+            if not boundary_pass
+            or evaluation.decision != "retain"
+            or rollback_proof["status"] != "verified"
+            else "PASS_WITH_DEFERRED_SCOPE"
+            if clean_worktree
+            else "PREPARED_WITH_DEFERRED_SCOPE"
+        ),
+        "remaining_risks": remaining_risks,
+        "deferred_scope": [
+            "continuity_reader",
+            "hubble_engine",
+            "alma_engine",
+            "evidence_classifier",
+            "patch_generator",
+            "ledger_writer",
+            "three_controlled_cycles",
+            "live_ledger_append",
+        ],
+    }
+    run_report = render_run_report(
+        trace, comparison, rollback_proof, boundary_report, risk_report
+    )
+    errors = validate_trace_payload(trace)
+    if errors:
+        raise ValueError("invalid mutation trace: " + "; ".join(errors))
+    return CycleResult(
+        trace=trace,
+        source_manifest=source_manifest_before,
+        replay_before=before_first.as_dict(),
+        replay_after=after_first.as_dict(),
+        comparison=comparison,
+        rollback_proof=rollback_proof,
+        boundary_report=boundary_report,
+        risk_report=risk_report,
+        run_report=run_report,
+    )
+
+
+def render_run_report(
+    trace: Mapping[str, object],
+    comparison: Mapping[str, object],
+    rollback: Mapping[str, object],
+    boundary: Mapping[str, object],
+    risk: Mapping[str, object],
+) -> str:
+    evaluation = trace["evaluation"]
+    before = comparison["baseline"]
+    after = comparison["candidate"]
+    final_pass = (
+        evaluation["decision"] == "retain"
+        and rollback["status"] == "verified"
+        and boundary["status"] in {"PASS", "PASS_PREPARED"}
+    )
+    clean_commit = trace["source_state"] == "clean_commit"
+    if not final_pass:
+        status_line = "Status: BLOCKED / failed local dry-run evidence"
+        mode_line = "Mode: STUDIO / blocked"
+        sync_line = (
+            "GitHub sync state: no commit recommendation; repair and revalidate locally"
+        )
+        next_gate = "`FIX_OAL_001_LOCAL_FAILURE` — repair the failed evaluator, boundary or rollback proof before any commit."
+    elif clean_commit:
+        status_line = "Status: BIZ / clean local dry-run evidence"
+        mode_line = "Mode: BIZ / local dry-run"
+        sync_line = "GitHub sync state: local commit evidence; no push or pull request"
+        next_gate = "`REVIEW_OAL_001_LOCAL_COMMIT` — review the local commit, trace, test results and rollback proof."
+    else:
+        status_line = "Status: STUDIO / manifest-bound pre-commit evidence"
+        mode_line = "Mode: STUDIO / local dry-run bootstrap"
+        sync_line = "GitHub sync state: prepared but not yet represented by the recorded Git HEAD"
+        next_gate = "`COMPLETE_OAL_001_LOCAL_COMMIT` — commit the exact validated scope, then rerun on the clean local commit."
+    return (
+        "# OAL-001 Local Self-Modification Run Report\n\n"
+        f"{status_line}\n"
+        "Source: GitHub Issue #97 and the inspected OAL-1.0 Notion design baseline\n"
+        f"Trace: `{trace['run_id']}` on `{trace['branch']}` from `{trace['base_sha']}`\n"
+        "Boundary: Local candidate sandbox only; no external, remote, Notion, ledger, publication or payment mutation\n"
+        f"{mode_line}\n"
+        f"{sync_line}\n"
+        "Notion source awareness: read-only design alignment; no Notion write\n\n"
+        "## Outcome\n\n"
+        f"- Governor: `{'APPROVED' if trace['governor']['approved'] else 'REJECTED'}`\n"
+        f"- Evaluator: `{evaluation['decision'].upper()}`\n"
+        f"- Boundary report: `{boundary['status']}`\n"
+        f"- Rollback: `{rollback['status'].upper()}`\n"
+        f"- Source state: `{trace['source_state']}`\n"
+        f"- External mutation count: `{trace['external_mutation_count']}` "
+        "(static allowlisted runtime-path observation)\n\n"
+        "## Baseline vs Candidate\n\n"
+        f"- Baseline exploration: `{before['strategy_weights']['exploration']}` "
+        f"({before['route_counts']['exploration']} of {before['observation_count']} synthetic observations)\n"
+        f"- Candidate exploration: `{after['strategy_weights']['exploration']}` "
+        f"({after['route_counts']['exploration']} of {after['observation_count']} synthetic observations)\n"
+        f"- Exploration delta: `{comparison['delta']['exploration_share']}` / "
+        f"`{comparison['delta']['exploration_routes']}` route\n"
+        f"- Baseline SHA-256: `{trace['baseline_sha256']}`\n"
+        f"- Candidate SHA-256: `{trace['candidate_sha256']}`\n"
+        f"- Diff SHA-256: `{trace['diff_sha256']}`\n\n"
+        "## Isolation and Rollback\n\n"
+        f"- Running baseline overwritten: `{str(trace['isolation']['running_version_overwritten']).lower()}`\n"
+        f"- Baseline unchanged: `{str(rollback['baseline_unchanged']).lower()}`\n"
+        f"- Candidate restored: `{str(rollback['candidate_restored']).lower()}`\n"
+        f"- Candidate workspace removed: `{str(rollback['candidate_workspace_removed']).lower()}`\n"
+        "- Candidate source executed: `false` (AST-constrained data replay only)\n\n"
+        "## Evidence Status\n\n"
+        "The fixture is `synthetic_current_slice` with `historical_evidence=false`. "
+        "No predecessor Hubble or ALMA cycle is claimed.\n\n"
+        "## Remaining Scope\n\n"
+        + "\n".join(f"- {item}" for item in risk["remaining_risks"])
+        + "\n\n## Recommended Next Gate\n\n"
+        + next_gate
+        + " "
+        "Any push, PR, executable candidate sandbox, historical fixture admission or live ledger work requires a new explicit gate.\n"
+    )
+
+
+def validate_trace_payload(trace: Mapping[str, object]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(TRACE_REQUIRED_FIELDS - set(trace))
+    extra = sorted(set(trace) - TRACE_REQUIRED_FIELDS)
+    if missing:
+        errors.append("missing fields: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected fields: " + ", ".join(extra))
+    if trace.get("schema_version") != "OAL-1.0":
+        errors.append("schema_version must be OAL-1.0")
+    if not isinstance(trace.get("run_id"), str) or not re.fullmatch(
+        r"OAL-001-[A-F0-9]{16}", str(trace.get("run_id"))
+    ):
+        errors.append("run_id must match the deterministic OAL-001 format")
+    if trace.get("cycle_id") != CYCLE_ID:
+        errors.append("cycle_id must match the first-slice cycle")
+    if trace.get("mode") != "local_dry_run":
+        errors.append("mode must be local_dry_run")
+    if trace.get("external_mutation_count") != 0:
+        errors.append("external_mutation_count must be zero")
+    if not isinstance(trace.get("base_sha"), str) or not GIT_SHA_PATTERN.fullmatch(
+        str(trace.get("base_sha"))
+    ):
+        errors.append("base_sha must be a Git SHA")
+    if not isinstance(trace.get("branch"), str) or not re.fullmatch(
+        r"codex/observatory-selfmod-.+", str(trace.get("branch"))
+    ):
+        errors.append("branch must stay in the observatory self-modification lane")
+    if trace.get("source_state") not in {"clean_commit", "working_tree_manifest"}:
+        errors.append("source_state must describe clean or manifest-bound sources")
+    for field in (
+        "source_manifest_sha256",
+        "baseline_sha256",
+        "candidate_sha256",
+        "diff_sha256",
+    ):
+        if not isinstance(trace.get(field), str) or not SHA256_PATTERN.fullmatch(
+            str(trace.get(field))
+        ):
+            errors.append(f"{field} must be an uppercase SHA-256")
+    if trace.get("baseline_sha256") == trace.get("candidate_sha256"):
+        errors.append("candidate SHA-256 must differ from baseline")
+    if trace.get("target_path") != TARGET_PATH:
+        errors.append("target_path must remain the one mutable Observatory path")
+    if trace.get("changed_paths") != [TARGET_PATH]:
+        errors.append("changed_paths must contain exactly the mutable Observatory path")
+    for field in ("trigger", "hypothesis", "expected_effect", "fallback_criterion"):
+        if not isinstance(trace.get(field), str) or not str(trace.get(field)).strip():
+            errors.append(f"{field} must be a non-empty string")
+    diff = trace.get("diff")
+    if not isinstance(diff, str) or not diff:
+        errors.append("diff must be a non-empty string")
+    elif trace.get("diff_sha256") != sha256_text(diff):
+        errors.append("diff_sha256 does not match diff content")
+
+    fixture = trace.get("fixture")
+    fixture_keys = {
+        "fixture_id",
+        "fixture_kind",
+        "historical_evidence",
+        "historical_fixture_status",
+    }
+    if not isinstance(fixture, dict) or set(fixture) != fixture_keys:
+        errors.append("fixture fields do not match the trace contract")
+    else:
+        if fixture.get("fixture_id") != CYCLE_ID:
+            errors.append("fixture_id must match the synthetic first-slice fixture")
+        if fixture.get("fixture_kind") != "synthetic_current_slice":
+            errors.append("fixture_kind must be synthetic_current_slice")
+        if fixture.get("historical_evidence") is not False:
+            errors.append("fixture must explicitly deny historical evidence")
+        if fixture.get("historical_fixture_status") != "unavailable":
+            errors.append("historical_fixture_status must be unavailable")
+
+    governor = trace.get("governor")
+    if not isinstance(governor, dict) or set(governor) != {
+        "approved",
+        "reasons",
+        "immutable_surface",
+    }:
+        errors.append("governor fields do not match the trace contract")
+    else:
+        if not isinstance(governor.get("approved"), bool):
+            errors.append("governor approved must be boolean")
+        if not isinstance(governor.get("reasons"), list) or not all(
+            isinstance(item, str) for item in governor.get("reasons", [])
+        ):
+            errors.append("governor reasons must be a string list")
+        if governor.get("immutable_surface") != "baseline_only":
+            errors.append("governor immutable_surface must be baseline_only")
+        if governor.get("approved") is True and governor.get("reasons"):
+            errors.append("approved Governor trace must not contain rejection reasons")
+        if governor.get("approved") is False and not governor.get("reasons"):
+            errors.append("rejected Governor trace must contain rejection reasons")
+
+    isolation = trace.get("isolation")
+    if not isinstance(isolation, dict) or set(isolation) != {
+        "candidate_workspace",
+        "managed_paths",
+        "running_version_overwritten",
+    }:
+        errors.append("isolation fields do not match the trace contract")
+    else:
+        if isolation.get("candidate_workspace") != "temporary_allowlist_copy":
+            errors.append("candidate workspace must be the temporary allowlist copy")
+        if isolation.get("managed_paths") != [TARGET_PATH]:
+            errors.append("isolation managed_paths must match the mutable allowlist")
+        if isolation.get("running_version_overwritten") is not False:
+            errors.append("running version must not be overwritten")
+
+    replay = trace.get("replay")
+    if not isinstance(replay, dict) or set(replay) != {
+        "baseline_deterministic",
+        "candidate_deterministic",
+        "before_artifact",
+        "after_artifact",
+    }:
+        errors.append("replay fields do not match the trace contract")
+    else:
+        if replay.get("before_artifact") != "replay_before.json":
+            errors.append("before replay artifact name is invalid")
+        if replay.get("after_artifact") != "replay_after.json":
+            errors.append("after replay artifact name is invalid")
+        if not isinstance(replay.get("baseline_deterministic"), bool) or not isinstance(
+            replay.get("candidate_deterministic"), bool
+        ):
+            errors.append("replay determinism fields must be boolean")
+
+    evaluation = trace.get("evaluation")
+    if not isinstance(evaluation, dict) or set(evaluation) != {
+        "decision",
+        "reasons",
+        "checks",
+    }:
+        errors.append("evaluation fields do not match the trace contract")
+    else:
+        decision = evaluation.get("decision")
+        checks = evaluation.get("checks")
+        reasons = evaluation.get("reasons")
+        if decision not in {"retain", "reject"}:
+            errors.append("evaluation decision must be retain or reject")
+        if (
+            not isinstance(reasons, list)
+            or not reasons
+            or not all(isinstance(item, str) for item in reasons)
+        ):
+            errors.append("evaluation reasons must be a non-empty string list")
+        if not isinstance(checks, dict) or set(checks) != EVALUATION_CHECK_NAMES:
+            errors.append(
+                "evaluation checks must match the exact first-slice check set"
+            )
+        elif not all(
+            isinstance(name, str) and isinstance(passed, bool)
+            for name, passed in checks.items()
+        ):
+            errors.append("evaluation checks must be boolean")
+        elif decision == "retain" and not all(checks.values()):
+            errors.append("retain decision requires every evaluation check to pass")
+        elif decision == "reject" and all(checks.values()):
+            errors.append(
+                "reject decision requires at least one failed evaluation check"
+            )
+
+    rollback = trace.get("rollback")
+    rollback_keys = {
+        "status",
+        "candidate_restored",
+        "baseline_unchanged",
+        "candidate_workspace_removed",
+    }
+    if not isinstance(rollback, dict) or set(rollback) != rollback_keys:
+        errors.append("rollback fields do not match the trace contract")
+    else:
+        flags = [
+            rollback.get("candidate_restored"),
+            rollback.get("baseline_unchanged"),
+            rollback.get("candidate_workspace_removed"),
+        ]
+        if not all(isinstance(flag, bool) for flag in flags):
+            errors.append("rollback proof flags must be boolean")
+        if rollback.get("status") == "verified" and not all(flags):
+            errors.append("verified rollback requires every rollback proof flag")
+        if rollback.get("status") == "failed" and all(flags):
+            errors.append("failed rollback requires at least one failed proof flag")
+        if rollback.get("status") not in {"verified", "failed"}:
+            errors.append("rollback status must be verified or failed")
+        if isinstance(evaluation, dict) and evaluation.get("decision") == "retain":
+            if rollback.get("status") != "verified":
+                errors.append("retain decision requires verified rollback")
+
+    git_status = trace.get("git_status")
+    git_status_keys = {"before", "after", "unchanged", "clean_worktree"}
+    if not isinstance(git_status, dict) or set(git_status) != git_status_keys:
+        errors.append("git_status fields do not match the trace contract")
+    else:
+        before = git_status.get("before")
+        after = git_status.get("after")
+        if not isinstance(before, str) or not isinstance(after, str):
+            errors.append("git status snapshots must be strings")
+        else:
+            expected_unchanged = before == after
+            expected_clean = git_status_is_clean(before) and git_status_is_clean(after)
+            if git_status.get("unchanged") is not expected_unchanged:
+                errors.append("git_status unchanged flag does not match snapshots")
+            if git_status.get("clean_worktree") is not expected_clean:
+                errors.append("git_status clean_worktree flag does not match snapshots")
+            expected_state = (
+                "clean_commit" if expected_clean else "working_tree_manifest"
+            )
+            if trace.get("source_state") != expected_state:
+                errors.append("source_state does not match git cleanliness")
+
+    if trace.get("not_actions") != list(NOT_ACTIONS):
+        errors.append(
+            "not_actions must match the complete first-slice prohibition list"
+        )
+    if isinstance(evaluation, dict) and evaluation.get("decision") == "retain":
+        if not isinstance(governor, dict) or governor.get("approved") is not True:
+            errors.append("retain decision requires Governor approval")
+        if not isinstance(replay, dict) or not (
+            replay.get("baseline_deterministic") is True
+            and replay.get("candidate_deterministic") is True
+        ):
+            errors.append(
+                "retain decision requires deterministic baseline and candidate replay"
+            )
+    return errors
+
+
+def _git_check_ignored(repo_root: Path, rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", rel_path],
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _git_status(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "status", "--short", "--branch"],
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("git status failed: " + result.stderr.strip())
+    return result.stdout.strip()
+
+
+def git_status_is_clean(status: str) -> bool:
+    lines = [line for line in status.splitlines() if line]
+    return len(lines) == 1 and lines[0].startswith("## ")
+
+
+def _prepare_output_dir(repo_root: Path, policy: GovernorPolicy, run_id: str) -> Path:
+    output_root = repo_root / policy.output_root
+    output_dir = output_root / run_id
+    _reject_symlink_components(repo_root, output_dir, "output directory")
+    resolved = _ensure_within(repo_root, output_dir, "output directory")
+    expected_root = _ensure_within(repo_root, output_root, "output root")
+    try:
+        resolved.relative_to(expected_root)
+    except ValueError as exc:
+        raise CandidateBoundaryError(
+            "output directory must stay below configured output root"
+        ) from exc
+    rel_path = resolved.relative_to(repo_root.resolve()).as_posix()
+    if not _git_check_ignored(repo_root, rel_path):
+        raise CandidateBoundaryError(
+            f"output directory must be gitignored before writing: {rel_path}"
+        )
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    target = _validate_writable_target(path.parent, path, "evidence target")
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, target)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _write_json(path: Path, payload: object) -> None:
+    content = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    _atomic_write_bytes(path, content.encode("utf-8"))
+
+
+def _write_text(path: Path, content: str) -> None:
+    _atomic_write_bytes(path, content.encode("utf-8"))
+
+
+def source_manifest_for_repo(repo_root: Path) -> list[dict[str, object]]:
+    manifest: list[dict[str, object]] = []
+    for rel_path in MANAGED_SOURCE_PATHS:
+        data = read_managed_source(repo_root, rel_path)
+        manifest.append(
+            {"path": rel_path, "bytes": len(data), "sha256": sha256_bytes(data)}
+        )
+    return manifest
+
+
+def write_cycle_artifacts(
+    repo_root: Path, policy: GovernorPolicy, result: CycleResult
+) -> Path:
+    output_dir = _prepare_output_dir(repo_root.resolve(), policy, result.run_id)
+    _write_json(
+        output_dir / "validation_complete.json",
+        {
+            "schema_version": "OAL-1.0",
+            "run_id": result.run_id,
+            "status": "INCOMPLETE",
+        },
+    )
+    _write_json(
+        output_dir / "test_result.json",
+        {
+            "schema_version": "OAL-1.0",
+            "run_id": result.run_id,
+            "status": "NOT_RUN",
+            "evidence_complete": False,
+        },
+    )
+    payloads = {
+        "mutation_trace.json": result.trace,
+        "replay_before.json": result.replay_before,
+        "replay_after.json": result.replay_after,
+        "baseline_candidate_comparison.json": result.comparison,
+        "rollback_proof.json": result.rollback_proof,
+        "boundary_report.json": result.boundary_report,
+        "risk_report.json": result.risk_report,
+        "source_manifest.json": result.source_manifest,
+        "claim_ledger.json": [
+            {
+                "claim": "The synthetic candidate increased exploration routing by one observation.",
+                "status": "technical_measurement",
+                "evidence": "baseline_candidate_comparison.json",
+            },
+            {
+                "claim": "The managed running-source manifest remained byte-identical and the candidate workspace was removed.",
+                "status": "technical_measurement",
+                "evidence": "rollback_proof.json",
+            },
+            {
+                "claim": "No historical Hubble or ALMA fixture is admitted to this configured runtime slice.",
+                "status": "configuration_observation",
+                "evidence": "source_manifest.json",
+            },
+        ],
+    }
+    for name, payload in payloads.items():
+        _write_json(output_dir / name, payload)
+    _write_text(output_dir / "run_report.md", result.run_report)
+    return output_dir

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -160,6 +160,170 @@ EXPECTED_SUBPROCESS_IMPORT_FILES = frozenset(
         "scripts/validate_oal_001.py",
     }
 )
+EXPECTED_OS_IMPORT_FILES = frozenset(
+    {
+        "scripts/oal_001/git_read.py",
+        "scripts/oal_001/runtime.py",
+        "scripts/validate_oal_001.py",
+        "tests/test_oal_001_runtime.py",
+    }
+)
+EXPECTED_OS_REFERENCE_CONTRACTS = {
+    "scripts/oal_001/git_read.py": (
+        (
+            "body[17].body[1].body[0].value.func.value",
+            "getenv",
+            "BDE0856D1FCF67C42E511223F97A6E1C797DBB02E2C4E55808C5EB2E2F5774CF",
+        ),
+        (
+            "body[17].body[2].value.args[0].values[2].value",
+            "devnull",
+            "DBB6DEE5EB1414768D5910DCF4D3F772A1D73AFB8A5812E51996AF5E73612867",
+        ),
+        (
+            "body[17].body[2].value.args[0].values[3].value",
+            "devnull",
+            "DBB6DEE5EB1414768D5910DCF4D3F772A1D73AFB8A5812E51996AF5E73612867",
+        ),
+        (
+            "body[20].body[5].value.elts[12].values[1].value.value",
+            "devnull",
+            "98035CF20A9746B0ECD5EC2CFE4642833C3B39F1D2EEF641E2DBA478672694F6",
+        ),
+    ),
+    "scripts/oal_001/runtime.py": (
+        (
+            "body[55].body[3].body[0].body[2].value.func.value",
+            "fsync",
+            "E34538123523C03C35D2BEFB4CE7BAC9F2592995F083A03145B4345A8B87DD28",
+        ),
+        (
+            "body[55].body[3].body[0].items[0].context_expr.func.value",
+            "fdopen",
+            "EE0F7D97282CF09062161ED7BDBC1005A5A3CF791D4995F55EC64261BC01235A",
+        ),
+        (
+            "body[55].body[3].body[1].value.func.value",
+            "replace",
+            "D4CCD80E02471EFBA4A3405B740F8FF21056A08B589BA528155D6790EB5335A4",
+        ),
+    ),
+    "scripts/validate_oal_001.py": (
+        (
+            "body[127].body[5].body[0].body[2].value.func.value",
+            "fsync",
+            "E34538123523C03C35D2BEFB4CE7BAC9F2592995F083A03145B4345A8B87DD28",
+        ),
+        (
+            "body[127].body[5].body[0].items[0].context_expr.func.value",
+            "fdopen",
+            "E91D009D3BB014DC1D837C8372BACF88591FC4984334ADB9A9CE48E98A69D1DD",
+        ),
+        (
+            "body[127].body[5].body[1].value.func.value",
+            "replace",
+            "125ED1C8D1D16A59A24A6D0E42939DAAA168BA6D472E0860AEB467A138EB661E",
+        ),
+    ),
+    "tests/test_oal_001_runtime.py": (
+        (
+            "body[20].value.test.left.value",
+            "name",
+            "94334B13C8E4543D8EA1059F2B8AEE2E0F49D5FEC73BAFCF2BFCC88213979348",
+        ),
+        (
+            "body[21].body[19].body[0].body[5].body[0].value.func.value",
+            "link",
+            "F2BB99267D5EDE9DD03602012488981C35715DB895F41F615D5B6E0C9362766E",
+        ),
+        (
+            "body[21].body[36].body[2].items[2].context_expr.args[0].value",
+            "environ",
+            "2593BAF1EFD4860291EEDFA5D2349EA22EF1B8F97353E23EBC6AB5C509A8F75E",
+        ),
+    ),
+}
+OS_REFERENCE_STATEMENT_HASH_ALGORITHM = "sha256"
+EXPECTED_SUBPROCESS_RUN_STATEMENTS = {
+    "scripts/oal_001/git_read.py": (
+        (
+            "_run_git",
+            6,
+            ast.dump(
+                ast.parse(
+                    """result = subprocess.run(
+    command,
+    cwd=resolved_repo,
+    env=_sanitized_environment(git_executable),
+    text=True,
+    encoding="utf-8",
+    errors="strict",
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    check=False,
+)
+""",
+                    feature_version=(3, 11),
+                ).body[0],
+                include_attributes=False,
+            ),
+        ),
+    ),
+    "scripts/validate_oal_001.py": (
+        (
+            "run_unit_tests",
+            0,
+            ast.dump(
+                ast.parse(
+                    """result = subprocess.run(
+    [
+        sys.executable,
+        "-I",
+        "-S",
+        "-B",
+        VALIDATOR_PATH,
+        "--_internal-unit-tests",
+    ],
+    cwd=REPO_ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    check=False,
+)
+""",
+                    feature_version=(3, 11),
+                ).body[0],
+                include_attributes=False,
+            ),
+        ),
+        (
+            "run_dry_run",
+            0,
+            ast.dump(
+                ast.parse(
+                    """result = subprocess.run(
+    [
+        sys.executable,
+        "-I",
+        "-S",
+        "-B",
+        VALIDATOR_PATH,
+        "--_internal-dry-run",
+    ],
+    cwd=REPO_ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    check=False,
+)
+""",
+                    feature_version=(3, 11),
+                ).body[0],
+                include_attributes=False,
+            ),
+        ),
+    ),
+}
 EXPECTED_REPARSE_POINT_FUNCTION_AST = ast.dump(
     ast.parse(
         """def _is_reparse_point(path: Path) -> bool:
@@ -310,7 +474,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 68
+MINIMUM_OAL_TEST_COUNT = 70
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -540,24 +704,6 @@ def _blocked_network_imports(tree: ast.AST) -> list[str]:
             ):
                 found.append(module)
     return sorted(set(found))
-
-
-def _call_signature(argument: ast.AST) -> tuple[str, ...] | None:
-    if isinstance(argument, ast.Name):
-        return (f"${argument.id}",)
-    if not isinstance(argument, (ast.List, ast.Tuple)):
-        return None
-    values: list[str] = []
-    for element in argument.elts:
-        if isinstance(element, ast.Constant) and isinstance(element.value, str):
-            values.append(element.value)
-        elif isinstance(element, ast.Name):
-            values.append(f"${element.id}")
-        elif isinstance(element, ast.Attribute) and isinstance(element.value, ast.Name):
-            values.append(f"${element.value.id}.{element.attr}")
-        else:
-            return None
-    return tuple(values)
 
 
 def _pull_request_trigger_errors(workflow_source: bytes) -> list[str]:
@@ -1030,9 +1176,125 @@ def _is_process_api_name(name: str) -> bool:
     )
 
 
+def _is_direct_subprocess_run_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "subprocess"
+        and node.func.attr == "run"
+    )
+
+
+def _canonical_os_reference_contract(
+    rel_path: str,
+    tree: ast.AST,
+    parents: Mapping[ast.AST, ast.AST],
+) -> list[str]:
+    contract_error = f"canonical os reference contract does not match in {rel_path}"
+    if not isinstance(tree, ast.Module):
+        return [contract_error]
+
+    node_paths: dict[ast.AST, tuple[str, ...]] = {}
+
+    def visit(node: ast.AST, path: tuple[str, ...]) -> None:
+        node_paths[node] = path
+        for field, value in ast.iter_fields(node):
+            if isinstance(value, ast.AST):
+                visit(value, (*path, field))
+            elif isinstance(value, list):
+                for index, child in enumerate(value):
+                    if isinstance(child, ast.AST):
+                        visit(child, (*path, f"{field}[{index}]"))
+
+    visit(tree, ())
+    actual_contract: list[tuple[str, str, str]] = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Name)
+            and node.id == "os"
+            and isinstance(node.ctx, ast.Load)
+        ):
+            continue
+        attribute = parents.get(node)
+        attribute_name = (
+            attribute.attr
+            if isinstance(attribute, ast.Attribute) and attribute.value is node
+            else "<bare>"
+        )
+        statement: ast.AST = node
+        while not isinstance(statement, ast.stmt):
+            parent = parents.get(statement)
+            if parent is None:
+                return [contract_error]
+            statement = parent
+        statement_ast = ast.dump(statement, include_attributes=False).encode("utf-8")
+        statement_digest = (
+            hashlib.new(OS_REFERENCE_STATEMENT_HASH_ALGORITHM, statement_ast)
+            .hexdigest()
+            .upper()
+        )
+        actual_contract.append(
+            (".".join(node_paths[node]), attribute_name, statement_digest)
+        )
+
+    if tuple(sorted(actual_contract)) != EXPECTED_OS_REFERENCE_CONTRACTS.get(
+        rel_path, ()
+    ):
+        return [contract_error]
+    return []
+
+
+def _canonical_subprocess_run_contract(
+    rel_path: str, tree: ast.AST
+) -> tuple[frozenset[ast.Call], list[str]]:
+    contract_error = f"canonical subprocess.run contract does not match in {rel_path}"
+    if not isinstance(tree, ast.Module):
+        return frozenset(), [contract_error]
+
+    expected_contract = EXPECTED_SUBPROCESS_RUN_STATEMENTS.get(rel_path, ())
+    allowed_calls: list[ast.Call] = []
+    for function_name, body_index, expected_statement_ast in expected_contract:
+        matching_functions = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ]
+        if (
+            len(matching_functions) != 1
+            or not isinstance(matching_functions[0], ast.FunctionDef)
+            or matching_functions[0] not in tree.body
+        ):
+            return frozenset(), [contract_error]
+        function = matching_functions[0]
+        if body_index >= len(function.body):
+            return frozenset(), [contract_error]
+        statement = function.body[body_index]
+        statement_calls = [
+            node for node in ast.walk(statement) if _is_direct_subprocess_run_call(node)
+        ]
+        if (
+            ast.dump(statement, include_attributes=False) != expected_statement_ast
+            or len(statement_calls) != 1
+            or not isinstance(statement, ast.Assign)
+            or statement.value is not statement_calls[0]
+        ):
+            return frozenset(), [contract_error]
+        allowed_calls.append(statement_calls[0])
+
+    all_calls = [
+        node for node in ast.walk(tree) if _is_direct_subprocess_run_call(node)
+    ]
+    if len(all_calls) != len(allowed_calls) or any(
+        node not in allowed_calls for node in all_calls
+    ):
+        return frozenset(), [contract_error]
+    return frozenset(allowed_calls), []
+
+
 def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
     errors: list[str] = []
-    signatures: list[tuple[str, ...] | None] = []
     canonical_imports = (
         [
             node
@@ -1059,11 +1321,38 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         tree, "subprocess", allowed_import=allowed_subprocess_import
     ):
         errors.append(f"subprocess rebinding is forbidden in {rel_path}")
+    canonical_os_imports = (
+        [
+            node
+            for node in tree.body
+            if isinstance(node, ast.Import)
+            and len(node.names) == 1
+            and node.names[0].name == "os"
+            and node.names[0].asname is None
+        ]
+        if isinstance(tree, ast.Module)
+        else []
+    )
+    expected_os_import_count = int(rel_path in EXPECTED_OS_IMPORT_FILES)
+    if len(canonical_os_imports) != expected_os_import_count:
+        errors.append(f"canonical os import contract does not match in {rel_path}")
+    allowed_os_import = (
+        canonical_os_imports[0]
+        if expected_os_import_count == 1 and len(canonical_os_imports) == 1
+        else None
+    )
+    if _has_forbidden_name_binding(tree, "os", allowed_import=allowed_os_import):
+        errors.append(f"os rebinding is forbidden in {rel_path}")
     parents: dict[ast.AST, ast.AST] = {
         child: parent
         for parent in ast.walk(tree)
         for child in ast.iter_child_nodes(parent)
     }
+    errors.extend(_canonical_os_reference_contract(rel_path, tree, parents))
+    allowed_subprocess_calls, subprocess_contract_errors = (
+        _canonical_subprocess_run_contract(rel_path, tree)
+    )
+    errors.extend(subprocess_contract_errors)
     allowed_getattr_calls, _ = _canonical_reparse_getattr_contract(rel_path, tree)
     if _has_forbidden_name_binding(tree, "getattr"):
         errors.append(f"getattr rebinding is forbidden in {rel_path}")
@@ -1086,10 +1375,8 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         elif isinstance(node, ast.ImportFrom):
             if node.module == "subprocess":
                 errors.append(f"from-subprocess imports are forbidden in {rel_path}")
-            if node.module == "os" and any(
-                _is_process_api_name(alias.name) for alias in node.names
-            ):
-                errors.append(f"process imports from os are forbidden in {rel_path}")
+            if node.module == "os":
+                errors.append(f"from-os imports are forbidden in {rel_path}")
             if node.module == "sys" and any(
                 alias.name in {"modules", "__dict__"} for alias in node.names
             ):
@@ -1183,10 +1470,8 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
             continue
         owner = node.func.value
         if isinstance(owner, ast.Name) and owner.id == "subprocess":
-            if node.func.attr != "run" or not node.args:
+            if node.func.attr != "run" or node not in allowed_subprocess_calls:
                 errors.append(f"non-allowlisted subprocess API in {rel_path}")
-            else:
-                signatures.append(_call_signature(node.args[0]))
         if (
             isinstance(owner, ast.Name)
             and owner.id == "os"
@@ -1194,33 +1479,6 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         ):
             errors.append(f"process execution API is forbidden in {rel_path}")
 
-    expected: dict[str, list[tuple[str, ...]]] = {
-        "scripts/oal_001/__main__.py": [],
-        "scripts/oal_001/git_read.py": [("$command",)],
-        "scripts/oal_001/runtime.py": [],
-        "scripts/validate_oal_001.py": [
-            (
-                "$sys.executable",
-                "-I",
-                "-S",
-                "-B",
-                "$VALIDATOR_PATH",
-                "--_internal-unit-tests",
-            ),
-            (
-                "$sys.executable",
-                "-I",
-                "-S",
-                "-B",
-                "$VALIDATOR_PATH",
-                "--_internal-dry-run",
-            ),
-        ],
-    }
-    if signatures != expected.get(rel_path, []):
-        errors.append(
-            f"subprocess calls do not match the fixed read-only allowlist in {rel_path}"
-        )
     if rel_path == "scripts/oal_001/git_read.py":
         fixed_commands: object | None = None
         for node in tree.body:

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -154,6 +154,12 @@ EXPECTED_REPARSE_POINT_GETATTR_FILES = frozenset(
         "scripts/validate_oal_001.py",
     }
 )
+EXPECTED_SUBPROCESS_IMPORT_FILES = frozenset(
+    {
+        "scripts/oal_001/git_read.py",
+        "scripts/validate_oal_001.py",
+    }
+)
 EXPECTED_REPARSE_POINT_FUNCTION_AST = ast.dump(
     ast.parse(
         """def _is_reparse_point(path: Path) -> bool:
@@ -304,7 +310,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 66
+MINIMUM_OAL_TEST_COUNT = 68
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -922,6 +928,8 @@ def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
             errors.append(f"sys rebinding is forbidden in {rel_path}")
         elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name == "sys":
             errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, ast.MatchMapping) and node.rest == "sys":
+            errors.append(f"sys rebinding is forbidden in {rel_path}")
         elif isinstance(node, (ast.Global, ast.Nonlocal)) and "sys" in node.names:
             errors.append(f"sys rebinding is forbidden in {rel_path}")
 
@@ -1025,6 +1033,32 @@ def _is_process_api_name(name: str) -> bool:
 def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
     errors: list[str] = []
     signatures: list[tuple[str, ...] | None] = []
+    canonical_imports = (
+        [
+            node
+            for node in tree.body
+            if isinstance(node, ast.Import)
+            and len(node.names) == 1
+            and node.names[0].name == "subprocess"
+            and node.names[0].asname is None
+        ]
+        if isinstance(tree, ast.Module)
+        else []
+    )
+    expected_import_count = int(rel_path in EXPECTED_SUBPROCESS_IMPORT_FILES)
+    if len(canonical_imports) != expected_import_count:
+        errors.append(
+            f"canonical subprocess import contract does not match in {rel_path}"
+        )
+    allowed_subprocess_import = (
+        canonical_imports[0]
+        if expected_import_count == 1 and len(canonical_imports) == 1
+        else None
+    )
+    if _has_forbidden_name_binding(
+        tree, "subprocess", allowed_import=allowed_subprocess_import
+    ):
+        errors.append(f"subprocess rebinding is forbidden in {rel_path}")
     parents: dict[ast.AST, ast.AST] = {
         child: parent
         for parent in ast.walk(tree)

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -77,7 +77,7 @@ RUNTIME_ISOLATION_READY = (
 
 OAL_CI_WORKFLOW_PATH = ".github/workflows/oal-001-validate.yml"
 EXPECTED_OAL_CI_WORKFLOW_SHA256 = (
-    "FF6C9CFB8CA67235FF91FBEFD37B02876DE248131257450DEACAF0E8FF07F1E9"
+    "FE26F0AEBCE82D61126AF83A17193C6E8EBCDD34A80E9B33D1E4BB00887D9725"
 )
 ISOLATED_UNIT_TEST_COMMAND = (
     "python -I -S -B scripts/validate_oal_001.py --_internal-unit-tests"
@@ -283,7 +283,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 61
+MINIMUM_OAL_TEST_COUNT = 64
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -565,6 +565,24 @@ def _pull_request_trigger_errors(workflow_source: bytes) -> list[str]:
     return []
 
 
+def _pull_request_merge_base_errors(workflow_source: bytes) -> list[str]:
+    try:
+        workflow = workflow_source.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return [f"OAL workflow is not valid UTF-8: {exc}"]
+
+    exact_contract = """          merge_base="$(git merge-base --all "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"
+          if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve exactly one pull-request merge base" >&2
+            exit 1
+          fi"""
+    if workflow.count(exact_contract) != 1:
+        return [
+            "OAL workflow must fail closed unless exactly one pull-request merge base exists"
+        ]
+    return []
+
+
 def _sys_import_state_attribute(node: ast.AST) -> str | None:
     if (
         isinstance(node, ast.Attribute)
@@ -611,26 +629,15 @@ def _module_statement(
 
 
 def _is_allowlisted_getattr_call(node: ast.Call) -> bool:
-    if not (
+    return (
         isinstance(node.func, ast.Name)
         and node.func.id == "getattr"
         and not node.keywords
-    ):
-        return False
-    if (
-        len(node.args) == 3
+        and len(node.args) == 3
         and isinstance(node.args[0], ast.Name)
         and node.args[0].id == "stat"
         and isinstance(node.args[1], ast.Constant)
         and node.args[1].value == "FILE_ATTRIBUTE_REPARSE_POINT"
-    ):
-        return True
-    return (
-        len(node.args) == 2
-        and isinstance(node.args[0], ast.Name)
-        and node.args[0].id == "policy"
-        and isinstance(node.args[1], ast.Name)
-        and node.args[1].id == "field"
     )
 
 
@@ -726,9 +733,13 @@ def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
             isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)
             and node.value.id == "sys"
-            and node.attr not in ALLOWED_SYS_ATTRIBUTES
         ):
-            errors.append(f"sys attribute {node.attr!r} is forbidden in {rel_path}")
+            if not isinstance(node.ctx, ast.Load):
+                errors.append(
+                    f"sys attribute {node.attr!r} mutation is forbidden in {rel_path}"
+                )
+            elif node.attr not in ALLOWED_SYS_ATTRIBUTES:
+                errors.append(f"sys attribute {node.attr!r} is forbidden in {rel_path}")
         elif isinstance(node, ast.Attribute) and node.attr in {"sys", "_sys"}:
             errors.append(f"indirect sys attribute access is forbidden in {rel_path}")
         elif (
@@ -906,12 +917,7 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
                 errors.append(
                     f"dynamic execution or namespace access is forbidden in {rel_path}"
                 )
-            if (
-                node.func.id == "getattr"
-                and node.args
-                and isinstance(node.args[0], ast.Name)
-                and node.args[0].id in {"os", "subprocess", "sys"}
-            ):
+            if node.func.id == "getattr" and not _is_allowlisted_getattr_call(node):
                 errors.append(f"indirect process API access is forbidden in {rel_path}")
         elif isinstance(node, ast.Name) and node.id == "__builtins__":
             errors.append(f"__builtins__ access is forbidden in {rel_path}")
@@ -1109,6 +1115,7 @@ def static_errors() -> list[str]:
     workflow_source = _read_repo_file(OAL_CI_WORKFLOW_PATH)
     normalized_workflow = workflow_source.replace(b"\r\n", b"\n")
     errors.extend(_pull_request_trigger_errors(normalized_workflow))
+    errors.extend(_pull_request_merge_base_errors(normalized_workflow))
     if (
         b"\r" in normalized_workflow
         or hashlib.sha256(normalized_workflow).hexdigest().upper()

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -1,0 +1,1230 @@
+#!/usr/bin/env python3
+"""Validate OAL-001 boundaries, tests, dry-run and cross-artifact evidence."""
+
+from __future__ import annotations
+
+import ast
+import difflib
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+PACKAGE_FILES = (
+    "scripts/oal_001/__init__.py",
+    "scripts/oal_001/__main__.py",
+    "scripts/oal_001/governor.py",
+    "scripts/oal_001/observatory.py",
+    "scripts/oal_001/runtime.py",
+)
+PYTHON_FILES = (
+    *PACKAGE_FILES,
+    "scripts/validate_oal_001.py",
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+)
+REQUIRED_FILES = (
+    ".codex/safety_policy.yaml",
+    ".gitignore",
+    "config/oal_001.json",
+    "docs/governance/oal_001_self_modification_policy.md",
+    "schemas/oal_001_mutation_trace.schema.json",
+    "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+    *PYTHON_FILES,
+)
+EVIDENCE_ARTIFACTS = {
+    "mutation_trace.json",
+    "replay_before.json",
+    "replay_after.json",
+    "baseline_candidate_comparison.json",
+    "rollback_proof.json",
+    "boundary_report.json",
+    "risk_report.json",
+    "source_manifest.json",
+    "claim_ledger.json",
+    "run_report.md",
+    "test_result.json",
+    "validation_complete.json",
+}
+EXPECTED_MUTABLE_PATHS = ["scripts/oal_001/observatory.py"]
+EXPECTED_PROTECTED_PATHS = [
+    ".codex",
+    ".git",
+    ".gitignore",
+    "config/oal_001.json",
+    "docs/governance",
+    "raw/exports",
+    "schemas/oal_001_mutation_trace.schema.json",
+    "scripts/oal_001/__init__.py",
+    "scripts/oal_001/__main__.py",
+    "scripts/oal_001/governor.py",
+    "scripts/oal_001/runtime.py",
+    "scripts/validate_oal_001.py",
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+]
+EXPECTED_AUTHORIZING_TEST_PATHS = [
+    "tests/test_oal_001_governor.py",
+    "tests/test_oal_001_runtime.py",
+]
+EXPECTED_POLICY = {
+    "policy_id": "OAL-001-GOVERNOR",
+    "schema_version": "OAL-1.0",
+    "mode": "local_dry_run",
+    "branch_pattern": "codex/observatory-selfmod-*",
+    "mutable_paths": EXPECTED_MUTABLE_PATHS,
+    "protected_paths": EXPECTED_PROTECTED_PATHS,
+    "authorizing_test_paths": EXPECTED_AUTHORIZING_TEST_PATHS,
+    "fixture_path": "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+    "output_root": "raw/exports/local-private/oal-001",
+    "minimum_exploration_share": 0.25,
+    "external_mutation_count": 0,
+    "historical_fixture_status": "unavailable",
+}
+EXPECTED_TRACE_FIELDS = {
+    "schema_version",
+    "run_id",
+    "cycle_id",
+    "mode",
+    "base_sha",
+    "branch",
+    "source_state",
+    "source_manifest_sha256",
+    "fixture",
+    "trigger",
+    "hypothesis",
+    "expected_effect",
+    "fallback_criterion",
+    "target_path",
+    "changed_paths",
+    "baseline_sha256",
+    "candidate_sha256",
+    "diff_sha256",
+    "diff",
+    "governor",
+    "isolation",
+    "replay",
+    "evaluation",
+    "rollback",
+    "git_status",
+    "external_mutation_count",
+    "not_actions",
+}
+EXPECTED_EVALUATION_CHECKS = {
+    "governor_approved",
+    "baseline_deterministic",
+    "candidate_deterministic",
+    "baseline_expected_share",
+    "candidate_expected_share",
+    "exploration_floor_preserved",
+    "expected_replay_delta",
+    "baseline_unchanged",
+    "synthetic_fixture_only",
+    "external_mutation_count_zero",
+    "rollback_verified",
+    "managed_baseline_unchanged",
+    "candidate_workspace_removed",
+}
+EXPECTED_SAFETY_SCALARS = {
+    "default_external_mutation": "deny",
+    "default_git_remote_mutation": "deny",
+    "default_notion_mutation": "deny",
+    "default_publication": "deny",
+    "default_payment_mutation": "deny",
+}
+BLOCKED_NETWORK_MODULES = {"requests", "urllib", "http.client", "socket"}
+FORBIDDEN_SOURCE_SNIPPETS = (
+    "copytree(",
+    "raw/exports/private",
+    ".env",
+    "os.environ",
+    "exec(",
+)
+RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
+MINIMUM_OAL_TEST_COUNT = 37
+VALIDATOR_FIXED_GIT_READ_COMMANDS = {
+    ("git", "branch", "--show-current"),
+    ("git", "rev-parse", "HEAD"),
+    ("git", "status", "--short", "--branch"),
+}
+
+
+class DuplicateJsonKeyError(ValueError):
+    """Raised when evidence or control JSON contains duplicate object keys."""
+
+
+def error(message: str) -> None:
+    print(f"[validate-oal-001] ERROR: {message}", file=sys.stderr)
+
+
+def _strict_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DuplicateJsonKeyError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def strict_json_bytes(data: bytes) -> object:
+    return json.loads(data.decode("utf-8"), object_pairs_hook=_strict_object)
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _reject_link_components(root: Path, path: Path, label: str) -> None:
+    absolute_root = root.absolute()
+    try:
+        relative = path.absolute().relative_to(absolute_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes repository root") from exc
+    current = absolute_root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink() or _is_reparse_point(current):
+            raise ValueError(f"{label} contains a link or reparse-point component")
+
+
+def _regular_file(path: Path, root: Path, label: str) -> Path:
+    _reject_link_components(root, path, label)
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(root.resolve())
+    except (FileNotFoundError, ValueError) as exc:
+        raise ValueError(f"{label} is missing or outside repository root") from exc
+    if not resolved.is_file():
+        raise ValueError(f"{label} is not a regular file")
+    if resolved.stat().st_nlink > 1:
+        raise ValueError(f"{label} must not be hard-linked")
+    return resolved
+
+
+def _read_repo_file(rel_path: str) -> bytes:
+    return _regular_file(REPO_ROOT / rel_path, REPO_ROOT, rel_path).read_bytes()
+
+
+def _load_repo_json(rel_path: str) -> object:
+    return strict_json_bytes(_read_repo_file(rel_path))
+
+
+def _blocked_network_imports(tree: ast.AST) -> list[str]:
+    found: list[str] = []
+    for node in ast.walk(tree):
+        modules: list[str] = []
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.append(node.module)
+        for module in modules:
+            if any(
+                module == blocked or module.startswith(f"{blocked}.")
+                for blocked in BLOCKED_NETWORK_MODULES
+            ):
+                found.append(module)
+    return sorted(set(found))
+
+
+def _call_signature(argument: ast.AST) -> tuple[str, ...] | None:
+    if isinstance(argument, ast.Name):
+        return (f"${argument.id}",)
+    if not isinstance(argument, (ast.List, ast.Tuple)):
+        return None
+    values: list[str] = []
+    for element in argument.elts:
+        if isinstance(element, ast.Constant) and isinstance(element.value, str):
+            values.append(element.value)
+        elif isinstance(element, ast.Name):
+            values.append(f"${element.id}")
+        elif isinstance(element, ast.Attribute) and isinstance(element.value, ast.Name):
+            values.append(f"${element.value.id}.{element.attr}")
+        else:
+            return None
+    return tuple(values)
+
+
+def _is_process_api_name(name: str) -> bool:
+    return (
+        name in {"fork", "forkpty", "popen", "startfile", "system"}
+        or name.startswith("exec")
+        or name.startswith("posix_spawn")
+        or name.startswith("spawn")
+    )
+
+
+def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
+    errors: list[str] = []
+    signatures: list[tuple[str, ...] | None] = []
+    parents: dict[ast.AST, ast.AST] = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess" and alias.asname not in {
+                    None,
+                    "subprocess",
+                }:
+                    errors.append(f"subprocess import alias is forbidden in {rel_path}")
+                if alias.name == "os" and alias.asname not in {None, "os"}:
+                    errors.append(f"os import alias is forbidden in {rel_path}")
+                if alias.name == "sys" and alias.asname not in {None, "sys"}:
+                    errors.append(f"sys import alias is forbidden in {rel_path}")
+                if alias.name == "importlib":
+                    errors.append(f"dynamic import support is forbidden in {rel_path}")
+                if alias.name == "builtins":
+                    errors.append(f"builtins import is forbidden in {rel_path}")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "subprocess":
+                errors.append(f"from-subprocess imports are forbidden in {rel_path}")
+            if node.module == "os" and any(
+                _is_process_api_name(alias.name) for alias in node.names
+            ):
+                errors.append(f"process imports from os are forbidden in {rel_path}")
+            if node.module == "sys" and any(
+                alias.name in {"modules", "__dict__"} for alias in node.names
+            ):
+                errors.append(
+                    f"process-capable sys imports are forbidden in {rel_path}"
+                )
+            if node.module == "importlib":
+                errors.append(f"dynamic import support is forbidden in {rel_path}")
+            if node.module == "builtins":
+                errors.append(f"builtins imports are forbidden in {rel_path}")
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in {
+                "__import__",
+                "compile",
+                "eval",
+                "exec",
+                "globals",
+                "locals",
+                "vars",
+            }:
+                errors.append(
+                    f"dynamic execution or namespace access is forbidden in {rel_path}"
+                )
+            if (
+                node.func.id == "getattr"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in {"os", "subprocess", "sys"}
+            ):
+                errors.append(f"indirect process API access is forbidden in {rel_path}")
+        elif isinstance(node, ast.Name) and node.id == "__builtins__":
+            errors.append(f"__builtins__ access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "sys"
+            and node.attr in {"__dict__", "modules"}
+        ):
+            errors.append(f"dynamic sys namespace access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+            and node.attr == "__dict__"
+        ):
+            errors.append(f"dynamic os namespace access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Name)
+            and node.id == "subprocess"
+            and isinstance(node.ctx, ast.Load)
+        ):
+            attribute = parents.get(node)
+            direct_call = parents.get(attribute) if attribute is not None else None
+            keyword = parents.get(attribute) if attribute is not None else None
+            keyword_call = parents.get(keyword) if keyword is not None else None
+            is_direct_run = (
+                isinstance(attribute, ast.Attribute)
+                and attribute.attr == "run"
+                and isinstance(direct_call, ast.Call)
+                and direct_call.func is attribute
+            )
+            is_safe_run_constant = (
+                isinstance(attribute, ast.Attribute)
+                and attribute.attr in {"DEVNULL", "PIPE", "STDOUT"}
+                and isinstance(keyword, ast.keyword)
+                and isinstance(keyword_call, ast.Call)
+                and isinstance(keyword_call.func, ast.Attribute)
+                and isinstance(keyword_call.func.value, ast.Name)
+                and keyword_call.func.value.id == "subprocess"
+                and keyword_call.func.attr == "run"
+            )
+            if not is_direct_run and not is_safe_run_constant:
+                errors.append(f"indirect subprocess access is forbidden in {rel_path}")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        owner = node.func.value
+        if isinstance(owner, ast.Name) and owner.id == "subprocess":
+            if node.func.attr != "run" or not node.args:
+                errors.append(f"non-allowlisted subprocess API in {rel_path}")
+            else:
+                signatures.append(_call_signature(node.args[0]))
+        if (
+            isinstance(owner, ast.Name)
+            and owner.id == "os"
+            and _is_process_api_name(node.func.attr)
+        ):
+            errors.append(f"process execution API is forbidden in {rel_path}")
+
+    expected: dict[str, list[tuple[str, ...]]] = {
+        "scripts/oal_001/__main__.py": [("$command",)],
+        "scripts/oal_001/runtime.py": [
+            ("git", "check-ignore", "-q", "$rel_path"),
+            ("git", "status", "--short", "--branch"),
+        ],
+        "scripts/validate_oal_001.py": [
+            ("git", "check-ignore", "-q", "$rel_path"),
+            ("$command",),
+            (
+                "$sys.executable",
+                "-m",
+                "unittest",
+                "tests.test_oal_001_governor",
+                "tests.test_oal_001_runtime",
+                "-v",
+            ),
+            ("$sys.executable", "-m", "scripts.oal_001", "--json"),
+        ],
+    }
+    if signatures != expected.get(rel_path, []):
+        errors.append(
+            f"subprocess calls do not match the fixed read-only allowlist in {rel_path}"
+        )
+    if rel_path == "scripts/oal_001/__main__.py":
+        fixed_commands: object | None = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == "FIXED_GIT_READ_COMMANDS"
+                for target in node.targets
+            ):
+                fixed_commands = ast.literal_eval(node.value)
+        if fixed_commands != {
+            ("git", "branch", "--show-current"),
+            ("git", "rev-parse", "HEAD"),
+        }:
+            errors.append("CLI Git reads do not match the exact fixed allowlist")
+    if rel_path == "scripts/validate_oal_001.py":
+        fixed_commands = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name)
+                and target.id == "VALIDATOR_FIXED_GIT_READ_COMMANDS"
+                for target in node.targets
+            ):
+                fixed_commands = ast.literal_eval(node.value)
+        if fixed_commands != {
+            ("git", "branch", "--show-current"),
+            ("git", "rev-parse", "HEAD"),
+            ("git", "status", "--short", "--branch"),
+        }:
+            errors.append("validator Git reads do not match the exact fixed allowlist")
+    return errors
+
+
+def _parse_strategy_static(source: bytes) -> dict[str, float]:
+    tree = ast.parse(source.decode("utf-8"), filename="observatory.py")
+    assignment: ast.AST | None = None
+    for index, node in enumerate(tree.body):
+        if (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            continue
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "STRATEGY_WEIGHTS"
+            and assignment is None
+        ):
+            assignment = node.value
+            continue
+        raise ValueError("mutable Observatory must contain data-only strategy weights")
+    if assignment is None:
+        raise ValueError("mutable Observatory is missing STRATEGY_WEIGHTS")
+    value = ast.literal_eval(assignment)
+    if value != {"primary": 0.75, "exploration": 0.25}:
+        raise ValueError("baseline strategy weights must remain 0.75/0.25")
+    return {key: float(item) for key, item in value.items()}
+
+
+def _top_level_yaml_scalars(data: bytes) -> tuple[dict[str, str], list[str]]:
+    values: dict[str, str] = {}
+    errors: list[str] = []
+    for line_number, raw_line in enumerate(data.decode("utf-8").splitlines(), 1):
+        if not raw_line or raw_line.lstrip().startswith("#") or raw_line[0].isspace():
+            continue
+        match = re.fullmatch(r"([A-Za-z0-9_]+):(?:\s*(.*))?", raw_line)
+        if not match:
+            errors.append(f"invalid top-level safety YAML at line {line_number}")
+            continue
+        key, value = match.group(1), (match.group(2) or "").strip()
+        if key in values:
+            errors.append(f"duplicate top-level safety key: {key}")
+        values[key] = value
+    return values, errors
+
+
+def git_check_ignored(rel_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", rel_path],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _git_read(command: list[str]) -> str:
+    if tuple(command) not in VALIDATOR_FIXED_GIT_READ_COMMANDS:
+        raise ValueError("validator Git command is outside the read-only allowlist")
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(command)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def static_errors() -> list[str]:
+    errors: list[str] = []
+    for rel_path in REQUIRED_FILES:
+        try:
+            _regular_file(REPO_ROOT / rel_path, REPO_ROOT, rel_path)
+        except (OSError, ValueError) as exc:
+            errors.append(str(exc))
+    if errors:
+        return errors
+
+    try:
+        policy = _load_repo_json("config/oal_001.json")
+        if policy != EXPECTED_POLICY:
+            errors.append(
+                "immutable policy does not match the exact first-slice contract"
+            )
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        errors.append(f"invalid immutable policy: {exc}")
+
+    if not git_check_ignored(EXPECTED_POLICY["output_root"]):
+        errors.append("configured local-private output root is not gitignored")
+
+    safety, safety_errors = _top_level_yaml_scalars(
+        _read_repo_file(".codex/safety_policy.yaml")
+    )
+    errors.extend(safety_errors)
+    for key, expected in EXPECTED_SAFETY_SCALARS.items():
+        if safety.get(key) != expected:
+            errors.append(f"safety policy {key} must be exactly {expected}")
+
+    for rel_path in PYTHON_FILES:
+        try:
+            source = _read_repo_file(rel_path).decode("utf-8")
+            tree = ast.parse(source, filename=rel_path, feature_version=(3, 11))
+        except (OSError, UnicodeDecodeError, SyntaxError, ValueError) as exc:
+            errors.append(f"Python 3.11 grammar check failed for {rel_path}: {exc}")
+            continue
+        network_modules = _blocked_network_imports(tree)
+        if network_modules:
+            errors.append(
+                f"network imports are forbidden in {rel_path}: {', '.join(network_modules)}"
+            )
+        if rel_path in PACKAGE_FILES:
+            source_errors = [
+                snippet for snippet in FORBIDDEN_SOURCE_SNIPPETS if snippet in source
+            ]
+            for snippet in source_errors:
+                errors.append(f"forbidden source operation in {rel_path}: {snippet}")
+        errors.extend(_subprocess_boundary_errors(rel_path, tree))
+
+    try:
+        _parse_strategy_static(_read_repo_file("scripts/oal_001/observatory.py"))
+    except (OSError, UnicodeDecodeError, SyntaxError, ValueError) as exc:
+        errors.append(f"invalid baseline mutable Observatory: {exc}")
+
+    for rel_path in (
+        "schemas/oal_001_mutation_trace.schema.json",
+        "tests/fixtures/observatory/synthetic_harmless_cycle.json",
+    ):
+        try:
+            payload = _load_repo_json(rel_path)
+        except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(f"invalid JSON in {rel_path}: {exc}")
+            continue
+        if not isinstance(payload, dict):
+            errors.append(f"JSON root must be an object in {rel_path}")
+
+    try:
+        schema = _load_repo_json("schemas/oal_001_mutation_trace.schema.json")
+        if not isinstance(schema, dict):
+            raise ValueError("schema root must be an object")
+        if schema.get("additionalProperties") is not False:
+            errors.append("trace schema must reject additional properties")
+        if set(schema.get("required", [])) != EXPECTED_TRACE_FIELDS:
+            errors.append(
+                "trace schema required fields do not match the runtime contract"
+            )
+        checks_schema = schema["properties"]["evaluation"]["properties"]["checks"]
+        if (
+            checks_schema.get("additionalProperties") is not False
+            or set(checks_schema.get("required", [])) != EXPECTED_EVALUATION_CHECKS
+        ):
+            errors.append("trace schema evaluation checks are not exact")
+    except (KeyError, TypeError, OSError, ValueError, json.JSONDecodeError) as exc:
+        errors.append(f"invalid trace schema structure: {exc}")
+    return errors
+
+
+def run_unit_tests() -> tuple[int, str, int | None, dict[str, int] | None]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "unittest",
+            "tests.test_oal_001_governor",
+            "tests.test_oal_001_runtime",
+            "-v",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    count_matches = re.findall(
+        r"^Ran (\d+) tests? in [^\r\n]+$", result.stdout, flags=re.MULTILINE
+    )
+    result_matches = re.findall(
+        r"^OK(?: \(([^\r\n()]*)\))?$", result.stdout, flags=re.MULTILINE
+    )
+    count = int(count_matches[0]) if len(count_matches) == 1 else None
+    outcome_details: dict[str, int] | None = None
+    if len(result_matches) == 1:
+        details = result_matches[0]
+        outcome_details = {}
+        if details:
+            for item in details.split(", "):
+                key, separator, value = item.rpartition("=")
+                if (
+                    not separator
+                    or key
+                    not in {"expected failures", "skipped", "unexpected successes"}
+                    or not value.isdigit()
+                    or key in outcome_details
+                ):
+                    outcome_details = None
+                    break
+                outcome_details[key] = int(value)
+    return result.returncode, result.stdout, count, outcome_details
+
+
+def unit_test_gate_errors(
+    return_code: int,
+    count: int | None,
+    outcome_details: Mapping[str, int] | None,
+) -> list[str]:
+    errors: list[str] = []
+    if return_code != 0:
+        errors.append("unit test process returned a non-zero status")
+    if count is None or count < MINIMUM_OAL_TEST_COUNT:
+        errors.append(
+            f"unit test count must be at least {MINIMUM_OAL_TEST_COUNT}, got {count}"
+        )
+    if outcome_details is None:
+        errors.append("unit test result summary is missing or malformed")
+    elif outcome_details:
+        errors.append(
+            "unit tests must end with a clean OK summary, got "
+            + ", ".join(f"{key}={value}" for key, value in outcome_details.items())
+        )
+    return errors
+
+
+def run_dry_run() -> tuple[int, str]:
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.oal_001", "--json"],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    output = (
+        result.stdout.strip()
+        if result.returncode == 0
+        else (result.stderr.strip() or result.stdout.strip())
+    )
+    return result.returncode, output
+
+
+def _validated_output_dir(summary: Mapping[str, object]) -> Path:
+    if set(summary) != {
+        "run_id",
+        "decision",
+        "rollback_status",
+        "external_mutation_count",
+        "output_dir",
+    }:
+        raise ValueError("dry-run summary fields do not match the exact contract")
+    run_id = summary.get("run_id")
+    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError("dry-run summary has an invalid run_id")
+    if summary.get("decision") != "retain":
+        raise ValueError("dry-run evaluator did not retain the harmless candidate")
+    if summary.get("rollback_status") != "verified":
+        raise ValueError("dry-run rollback was not verified")
+    if summary.get("external_mutation_count") != 0:
+        raise ValueError("dry-run external mutation count is not zero")
+    expected_rel = f"{EXPECTED_POLICY['output_root']}/{run_id}"
+    if summary.get("output_dir") != expected_rel:
+        raise ValueError("dry-run output path is not exactly bound to its run_id")
+    output_dir = REPO_ROOT / expected_rel
+    _reject_link_components(REPO_ROOT, output_dir, "output directory")
+    resolved = output_dir.resolve(strict=True)
+    output_root = (REPO_ROOT / str(EXPECTED_POLICY["output_root"])).resolve(strict=True)
+    if (
+        resolved.parent != output_root
+        or resolved.name != run_id
+        or not resolved.is_dir()
+    ):
+        raise ValueError("dry-run output directory is outside the fixed evidence root")
+    if not git_check_ignored(expected_rel):
+        raise ValueError("dry-run output directory is not gitignored")
+    return resolved
+
+
+def _load_artifact_json(output_dir: Path, name: str) -> object:
+    path = _regular_file(output_dir / name, REPO_ROOT, f"artifact {name}")
+    return strict_json_bytes(path.read_bytes())
+
+
+def _artifact_digest_map(output_dir: Path) -> dict[str, str]:
+    digests: dict[str, str] = {}
+    for name in sorted(EVIDENCE_ARTIFACTS - {"validation_complete.json"}):
+        path = _regular_file(output_dir / name, REPO_ROOT, f"artifact {name}")
+        digests[name] = hashlib.sha256(path.read_bytes()).hexdigest().upper()
+    return digests
+
+
+def validate_completion_marker(output_dir: Path) -> list[str]:
+    try:
+        actual_names = {path.name for path in output_dir.iterdir()}
+    except OSError as exc:
+        return [f"could not enumerate completed artifacts: {exc}"]
+    if actual_names != EVIDENCE_ARTIFACTS:
+        return ["completed artifact set does not match the exact evidence contract"]
+    try:
+        marker = _load_artifact_json(output_dir, "validation_complete.json")
+        trace = _load_artifact_json(output_dir, "mutation_trace.json")
+        test_result = _load_artifact_json(output_dir, "test_result.json")
+        current_digests = _artifact_digest_map(output_dir)
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        return [f"could not verify completion marker: {exc}"]
+    if not all(isinstance(item, dict) for item in (marker, trace, test_result)):
+        return [
+            "completion marker, mutation trace and test result must be JSON objects"
+        ]
+    unit_tests = test_result.get("unit_tests")
+    artifact_validation = test_result.get("artifact_validation")
+    semantic_pass = (
+        test_result.get("schema_version") == "OAL-1.0"
+        and test_result.get("run_id") == trace.get("run_id")
+        and test_result.get("status") == "PASS"
+        and test_result.get("evidence_complete") is True
+        and test_result.get("static_checks") == {"status": "PASS"}
+        and isinstance(unit_tests, dict)
+        and unit_tests.get("status") == "PASS"
+        and isinstance(unit_tests.get("count"), int)
+        and unit_tests["count"] >= MINIMUM_OAL_TEST_COUNT
+        and unit_tests.get("skipped") == 0
+        and unit_tests.get("outcome_details") == {}
+        and unit_tests.get("return_code") == 0
+        and test_result.get("dry_run") == {"status": "PASS", "return_code": 0}
+        and isinstance(artifact_validation, dict)
+        and artifact_validation.get("status") == "PASS"
+        and artifact_validation.get("errors") == []
+        and test_result.get("external_mutation_count") == 0
+    )
+    expected_status = "PASS" if semantic_pass else "FAIL"
+    expected = {
+        "schema_version": "OAL-1.0",
+        "run_id": trace.get("run_id"),
+        "status": expected_status,
+        "artifact_sha256": current_digests,
+    }
+    errors: list[str] = []
+    if marker.get("status") != expected_status:
+        errors.append("completion marker status does not match bound test semantics")
+    if marker != expected:
+        errors.append("completion marker artifact digests do not match current bytes")
+    return errors
+
+
+def _expected_diff(target_path: str, baseline: bytes, candidate: str) -> str:
+    baseline_text = baseline.decode("utf-8")
+    return "".join(
+        difflib.unified_diff(
+            baseline_text.splitlines(keepends=True),
+            candidate.splitlines(keepends=True),
+            fromfile=f"a/{target_path}",
+            tofile=f"b/{target_path}",
+        )
+    )
+
+
+def validate_artifacts(output_dir: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        actual_names = {path.name for path in output_dir.iterdir()}
+    except OSError as exc:
+        return [f"could not enumerate artifacts: {exc}"]
+    if actual_names != EVIDENCE_ARTIFACTS:
+        missing = sorted(EVIDENCE_ARTIFACTS - actual_names)
+        extra = sorted(actual_names - EVIDENCE_ARTIFACTS)
+        if missing:
+            errors.append("missing artifacts: " + ", ".join(missing))
+        if extra:
+            errors.append("unexpected artifacts: " + ", ".join(extra))
+        return errors
+
+    try:
+        payload = {
+            name: _load_artifact_json(output_dir, name)
+            for name in EVIDENCE_ARTIFACTS
+            if name.endswith(".json")
+        }
+        report_path = _regular_file(
+            output_dir / "run_report.md", REPO_ROOT, "artifact run_report.md"
+        )
+        run_report = report_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        return [f"could not safely load artifacts: {exc}"]
+
+    trace = payload["mutation_trace.json"]
+    before = payload["replay_before.json"]
+    after = payload["replay_after.json"]
+    comparison = payload["baseline_candidate_comparison.json"]
+    rollback = payload["rollback_proof.json"]
+    boundary = payload["boundary_report.json"]
+    risk = payload["risk_report.json"]
+    manifest = payload["source_manifest.json"]
+    claims = payload["claim_ledger.json"]
+    test_result = payload["test_result.json"]
+    completion = payload["validation_complete.json"]
+    if not all(
+        isinstance(item, dict)
+        for item in (trace, before, after, comparison, rollback, boundary, risk)
+    ):
+        return ["core evidence artifacts must have JSON object roots"]
+
+    from scripts.oal_001.governor import Governor, load_policy
+    from scripts.oal_001.runtime import (
+        CYCLE_ID,
+        EXPECTED_EFFECT,
+        FALLBACK_CRITERION,
+        HYPOTHESIS,
+        NOT_ACTIONS,
+        TARGET_PATH,
+        TRACE_REQUIRED_FIELDS,
+        TRIGGER,
+        ReplayHarness,
+        build_harmless_patch,
+        canonical_json,
+        derive_run_id,
+        load_fixture,
+        read_managed_source,
+        render_run_report,
+        sha256_bytes,
+        sha256_text,
+        source_manifest_for_repo,
+        validate_trace_payload,
+    )
+
+    errors.extend(validate_trace_payload(trace))
+    if TRACE_REQUIRED_FIELDS != EXPECTED_TRACE_FIELDS:
+        errors.append("runtime trace field set diverges from the bootstrap validator")
+
+    try:
+        policy = load_policy(REPO_ROOT)
+        branch = _git_read(["git", "branch", "--show-current"])
+        base_sha = _git_read(["git", "rev-parse", "HEAD"])
+        current_status = _git_read(["git", "status", "--short", "--branch"])
+        baseline_bytes = read_managed_source(REPO_ROOT, TARGET_PATH)
+        baseline_sha = sha256_bytes(baseline_bytes)
+        patch = build_harmless_patch(baseline_bytes.decode("utf-8"), baseline_sha)
+        expected_diff = _expected_diff(
+            TARGET_PATH, baseline_bytes, patch.replacement_text
+        )
+        candidate_bytes = patch.replacement_text.encode("utf-8")
+        candidate_sha = sha256_bytes(candidate_bytes)
+        fixture = load_fixture(REPO_ROOT, policy.fixture_path)
+        harness = ReplayHarness(fixture)
+        expected_before = harness.replay_bytes(baseline_bytes).as_dict()
+        expected_after = harness.replay_bytes(candidate_bytes).as_dict()
+        expected_manifest = source_manifest_for_repo(REPO_ROOT)
+        manifest_sha = sha256_text(canonical_json(expected_manifest))
+        governor = Governor(policy).review(patch, branch).as_dict()
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError) as exc:
+        return errors + [f"could not reconstruct expected evidence: {exc}"]
+
+    trace_git = trace.get("git_status")
+    if not isinstance(trace_git, dict):
+        errors.append("trace git status is not an object")
+        trace_git = {}
+    if trace.get("branch") != branch:
+        errors.append("trace branch does not match the current local branch")
+    if trace.get("base_sha") != base_sha:
+        errors.append("trace base SHA does not match current local HEAD")
+    if (
+        trace_git.get("before") != current_status
+        or trace_git.get("after") != current_status
+    ):
+        errors.append("trace Git snapshots do not match the current worktree status")
+
+    expected_run_id = derive_run_id(
+        base_sha,
+        branch,
+        str(trace_git.get("before", "")),
+        str(trace_git.get("after", "")),
+        CYCLE_ID,
+        TARGET_PATH,
+        baseline_sha,
+        candidate_sha,
+        str(fixture["fixture_id"]),
+        expected_manifest,
+    )
+    run_ids = {
+        trace.get("run_id"),
+        comparison.get("run_id"),
+        rollback.get("run_id"),
+        boundary.get("run_id"),
+        risk.get("run_id"),
+    }
+    if run_ids != {expected_run_id}:
+        errors.append("artifact run IDs do not equal the independently derived run ID")
+    if output_dir.name != expected_run_id:
+        errors.append("artifact directory leaf does not match the derived run ID")
+
+    expected_checks = {name: True for name in EXPECTED_EVALUATION_CHECKS}
+    expected_evaluation = {
+        "decision": "retain",
+        "reasons": ["all_first_slice_checks_passed"],
+        "checks": expected_checks,
+    }
+    expected_comparison = {
+        "run_id": expected_run_id,
+        "baseline": expected_before,
+        "candidate": expected_after,
+        "delta": {"exploration_share": 0.05, "exploration_routes": 1},
+        "evaluation": expected_evaluation,
+    }
+    if before != expected_before:
+        errors.append("baseline replay does not match the reconstructed replay")
+    if after != expected_after:
+        errors.append("candidate replay does not match the reconstructed replay")
+    if comparison != expected_comparison:
+        errors.append(
+            "baseline/candidate comparison is not derivable from replay evidence"
+        )
+
+    expected_trace_values = {
+        "cycle_id": CYCLE_ID,
+        "trigger": TRIGGER,
+        "hypothesis": HYPOTHESIS,
+        "expected_effect": EXPECTED_EFFECT,
+        "fallback_criterion": FALLBACK_CRITERION,
+        "target_path": TARGET_PATH,
+        "changed_paths": [TARGET_PATH],
+        "baseline_sha256": baseline_sha,
+        "candidate_sha256": candidate_sha,
+        "diff": expected_diff,
+        "diff_sha256": sha256_text(expected_diff),
+        "source_manifest_sha256": manifest_sha,
+        "governor": governor,
+        "evaluation": expected_evaluation,
+        "external_mutation_count": 0,
+        "not_actions": list(NOT_ACTIONS),
+    }
+    for key, expected in expected_trace_values.items():
+        if trace.get(key) != expected:
+            errors.append(f"trace {key} does not match reconstructed evidence")
+
+    expected_rollback = {
+        "status": "verified",
+        "candidate_restored": True,
+        "restored_sha256": baseline_sha,
+        "baseline_sha256_before": baseline_sha,
+        "baseline_sha256_after": baseline_sha,
+        "managed_manifest_sha256_before": manifest_sha,
+        "managed_manifest_sha256_after": manifest_sha,
+        "baseline_unchanged": True,
+        "candidate_workspace_removed": True,
+        "run_id": expected_run_id,
+    }
+    if rollback != expected_rollback:
+        errors.append("rollback proof does not match baseline and manifest hashes")
+    if trace.get("rollback") != {
+        "status": "verified",
+        "candidate_restored": True,
+        "baseline_unchanged": True,
+        "candidate_workspace_removed": True,
+    }:
+        errors.append(
+            "trace rollback summary does not match verified rollback evidence"
+        )
+
+    clean_worktree = bool(trace_git.get("clean_worktree"))
+    expected_boundary_checks = {
+        "governor_approved": True,
+        "exact_mutable_allowlist": True,
+        "candidate_workspace_removed": True,
+        "running_version_overwritten": False,
+        "baseline_unchanged": True,
+        "candidate_source_executed": False,
+        "external_mutation_count_zero": True,
+        "historical_claim_fabricated": False,
+        "git_status_unchanged": True,
+        "clean_worktree": clean_worktree,
+    }
+    expected_boundary = {
+        "run_id": expected_run_id,
+        "status": "PASS" if clean_worktree else "PASS_PREPARED",
+        "checks": expected_boundary_checks,
+        "external_mutation_count": 0,
+    }
+    if boundary != expected_boundary:
+        errors.append("boundary status and checks do not match reconstructed evidence")
+
+    remaining_risks = [
+        "No verified historical Hubble or ALMA fixture is admitted to the configured runtime slice.",
+        "Candidate source is AST-parsed but not executed; executable candidate sandboxing is deferred.",
+        "Broad Observatory engines, connector operations and ledger writing are not implemented.",
+        "Cross-platform filesystem checks reduce but cannot eliminate check/open race conditions.",
+        "A retain decision is technical evidence only and does not promote or activate the candidate.",
+    ]
+    if not clean_worktree:
+        remaining_risks.insert(
+            0,
+            "Managed sources are bound by manifest but are not yet represented by the recorded Git HEAD.",
+        )
+    expected_risk = {
+        "run_id": expected_run_id,
+        "status": (
+            "PASS_WITH_DEFERRED_SCOPE"
+            if clean_worktree
+            else "PREPARED_WITH_DEFERRED_SCOPE"
+        ),
+        "remaining_risks": remaining_risks,
+        "deferred_scope": [
+            "continuity_reader",
+            "hubble_engine",
+            "alma_engine",
+            "evidence_classifier",
+            "patch_generator",
+            "ledger_writer",
+            "three_controlled_cycles",
+            "live_ledger_append",
+        ],
+    }
+    if risk != expected_risk:
+        errors.append(
+            "risk report does not match the derived status and deferred scope"
+        )
+    if manifest != expected_manifest:
+        errors.append("source manifest does not match current managed sources")
+
+    expected_claims = [
+        {
+            "claim": "The synthetic candidate increased exploration routing by one observation.",
+            "status": "technical_measurement",
+            "evidence": "baseline_candidate_comparison.json",
+        },
+        {
+            "claim": "The managed running-source manifest remained byte-identical and the candidate workspace was removed.",
+            "status": "technical_measurement",
+            "evidence": "rollback_proof.json",
+        },
+        {
+            "claim": "No historical Hubble or ALMA fixture is admitted to this configured runtime slice.",
+            "status": "configuration_observation",
+            "evidence": "source_manifest.json",
+        },
+    ]
+    if claims != expected_claims:
+        errors.append("claim ledger does not match the narrow evidence claims")
+    expected_report = render_run_report(
+        trace, expected_comparison, expected_rollback, expected_boundary, expected_risk
+    )
+    if run_report != expected_report:
+        errors.append("run report is not exactly reproducible from validated evidence")
+    if test_result != {
+        "schema_version": "OAL-1.0",
+        "run_id": expected_run_id,
+        "status": "NOT_RUN",
+        "evidence_complete": False,
+    }:
+        errors.append("test result placeholder is stale or malformed")
+    if completion != {
+        "schema_version": "OAL-1.0",
+        "run_id": expected_run_id,
+        "status": "INCOMPLETE",
+    }:
+        errors.append("completion marker must remain INCOMPLETE until final validation")
+    return errors
+
+
+def _atomic_write_json(path: Path, payload: object) -> None:
+    _regular_file(path.parent / "mutation_trace.json", REPO_ROOT, "artifact anchor")
+    _reject_link_components(REPO_ROOT, path, path.name)
+    if path.exists():
+        _regular_file(path, REPO_ROOT, path.name)
+    data = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv:
+        error("this validator accepts no arguments")
+        return 2
+
+    errors = static_errors()
+    if errors:
+        for item in errors:
+            error(item)
+        return 1
+
+    test_returncode, test_output, test_count, test_outcomes = run_unit_tests()
+    test_gate_errors = unit_test_gate_errors(test_returncode, test_count, test_outcomes)
+    if test_gate_errors:
+        error(
+            "OAL-001 unit test gate failed, was incomplete or skipped coverage "
+            f"(return_code={test_returncode}, count={test_count}, "
+            f"minimum={MINIMUM_OAL_TEST_COUNT}, outcomes={test_outcomes})"
+        )
+        for item in test_gate_errors:
+            error(item)
+        print(test_output, file=sys.stderr)
+        return 1
+
+    dry_run_returncode, dry_run_output = run_dry_run()
+    if dry_run_returncode != 0:
+        error("OAL-001 dry-run failed: " + dry_run_output)
+        return 1
+    try:
+        summary = strict_json_bytes(dry_run_output.encode("utf-8"))
+        if not isinstance(summary, dict):
+            raise ValueError("dry-run summary root must be an object")
+        output_dir = _validated_output_dir(summary)
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        error(f"dry-run summary is invalid: {exc}")
+        return 1
+
+    errors = validate_artifacts(output_dir)
+    runtime_status = "PASS" if sys.version_info[:2] == (3, 11) else "NOT_RUN"
+    test_result = {
+        "schema_version": "OAL-1.0",
+        "run_id": summary["run_id"],
+        "status": "PASS" if not errors else "FAIL",
+        "evidence_complete": not errors,
+        "static_checks": {"status": "PASS"},
+        "unit_tests": {
+            "status": "PASS",
+            "command": "python -m unittest tests.test_oal_001_governor tests.test_oal_001_runtime -v",
+            "count": test_count,
+            "skipped": (test_outcomes or {}).get("skipped", 0),
+            "outcome_details": test_outcomes,
+            "return_code": test_returncode,
+        },
+        "python_runtime": {
+            "version": sys.version.split()[0],
+            "status": "PASS",
+        },
+        "python_3_11_target": {
+            "grammar": "PASS",
+            "runtime": runtime_status,
+            "reason": (
+                None
+                if runtime_status == "PASS"
+                else "validator interpreter is not Python 3.11"
+            ),
+        },
+        "dry_run": {"status": "PASS", "return_code": dry_run_returncode},
+        "artifact_validation": {
+            "status": "PASS" if not errors else "FAIL",
+            "errors": errors,
+        },
+        "external_mutation_count": 0,
+    }
+    try:
+        _validated_output_dir(summary)
+        _atomic_write_json(output_dir / "test_result.json", test_result)
+        completion = {
+            "schema_version": "OAL-1.0",
+            "run_id": summary["run_id"],
+            "status": "PASS" if not errors else "FAIL",
+            "artifact_sha256": _artifact_digest_map(output_dir),
+        }
+        _atomic_write_json(output_dir / "validation_complete.json", completion)
+        completion_errors = validate_completion_marker(output_dir)
+        errors.extend(completion_errors)
+    except (OSError, ValueError) as exc:
+        errors.append(f"could not atomically finalize evidence: {exc}")
+
+    if errors:
+        for item in errors:
+            error(item)
+        return 1
+
+    print(
+        f"[validate-oal-001] OK run_id={summary['run_id']} "
+        f"tests={test_count} skipped={(test_outcomes or {}).get('skipped', 0)}"
+    )
+    print(f"[validate-oal-001] output_dir={summary['output_dir']}")
+    print("[validate-oal-001] external_mutation_count=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -144,7 +144,28 @@ EXPECTED_VALIDATOR_SYS_PATH_STATEMENTS = (
 """,
 )
 FORBIDDEN_REFLECTIVE_ATTRIBUTES = frozenset(
-    {"__dict__", "__getattr__", "__getattribute__", "__globals__"}
+    {"__builtins__", "__dict__", "__getattr__", "__getattribute__", "__globals__"}
+)
+EXPECTED_REPARSE_POINT_GETATTR_FILES = frozenset(
+    {
+        "scripts/oal_001/git_read.py",
+        "scripts/oal_001/governor.py",
+        "scripts/oal_001/runtime.py",
+        "scripts/validate_oal_001.py",
+    }
+)
+EXPECTED_REPARSE_POINT_FUNCTION_AST = ast.dump(
+    ast.parse(
+        """def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+""",
+        feature_version=(3, 11),
+    ).body[0],
+    include_attributes=False,
 )
 PACKAGE_FILES = (
     "scripts/oal_001/__init__.py",
@@ -283,7 +304,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 64
+MINIMUM_OAL_TEST_COUNT = 66
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -628,17 +649,137 @@ def _module_statement(
     return None
 
 
-def _is_allowlisted_getattr_call(node: ast.Call) -> bool:
-    return (
-        isinstance(node.func, ast.Name)
-        and node.func.id == "getattr"
-        and not node.keywords
-        and len(node.args) == 3
-        and isinstance(node.args[0], ast.Name)
-        and node.args[0].id == "stat"
-        and isinstance(node.args[1], ast.Constant)
-        and node.args[1].value == "FILE_ATTRIBUTE_REPARSE_POINT"
+def _has_forbidden_name_binding(
+    tree: ast.AST, name: str, *, allowed_import: ast.Import | None = None
+) -> bool:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Name)
+            and node.id == name
+            and not isinstance(node.ctx, ast.Load)
+        ):
+            return True
+        if isinstance(node, ast.arg) and node.arg == name:
+            return True
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            and node.name == name
+        ):
+            return True
+        if isinstance(node, ast.Import):
+            if node is allowed_import:
+                continue
+            for alias in node.names:
+                if (alias.asname or alias.name.partition(".")[0]) == name:
+                    return True
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "*" or (alias.asname or alias.name) == name:
+                    return True
+        if isinstance(node, ast.ExceptHandler) and node.name == name:
+            return True
+        if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name == name:
+            return True
+        if isinstance(node, ast.MatchMapping) and node.rest == name:
+            return True
+        if isinstance(node, (ast.Global, ast.Nonlocal)) and name in node.names:
+            return True
+    return False
+
+
+def _canonical_reparse_getattr_contract(
+    rel_path: str, tree: ast.AST
+) -> tuple[frozenset[ast.Call], list[str]]:
+    if rel_path not in EXPECTED_REPARSE_POINT_GETATTR_FILES:
+        return frozenset(), []
+
+    contract_error = (
+        f"canonical reparse-point getattr contract does not match in {rel_path}"
     )
+    if not isinstance(tree, ast.Module):
+        return frozenset(), [contract_error]
+
+    top_level_functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_is_reparse_point"
+    ]
+    all_named_functions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_is_reparse_point"
+    ]
+    direct_getattr_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+    ]
+    stat_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Import)
+        and len(node.names) == 1
+        and node.names[0].name == "stat"
+        and node.names[0].asname is None
+    ]
+    if not (
+        len(top_level_functions) == 1
+        and all_named_functions == top_level_functions
+        and len(direct_getattr_calls) == 1
+        and len(stat_imports) == 1
+    ):
+        return frozenset(), [contract_error]
+
+    function = top_level_functions[0]
+    call = direct_getattr_calls[0]
+    stat_import = stat_imports[0]
+    getattr_names = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id == "getattr"
+    ]
+    stat_names = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id == "stat"
+    ]
+    exact_call = (
+        isinstance(call.func, ast.Name)
+        and call.func.id == "getattr"
+        and not call.keywords
+        and len(call.args) == 3
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "stat"
+        and isinstance(call.args[1], ast.Constant)
+        and type(call.args[1].value) is str
+        and call.args[1].value == "FILE_ATTRIBUTE_REPARSE_POINT"
+        and isinstance(call.args[2], ast.Constant)
+        and type(call.args[2].value) is int
+        and call.args[2].value == 0
+    )
+    contract_matches = (
+        ast.dump(function, include_attributes=False)
+        == EXPECTED_REPARSE_POINT_FUNCTION_AST
+        and exact_call
+        and len(getattr_names) == 1
+        and getattr_names[0] is call.func
+        and len(stat_names) == 1
+        and stat_names[0] is call.args[0]
+        and not _has_forbidden_name_binding(tree, "getattr")
+        and not _has_forbidden_name_binding(tree, "stat", allowed_import=stat_import)
+    )
+    if not contract_matches:
+        return frozenset(), [contract_error]
+    return frozenset({call}), []
+
+
+def _is_allowlisted_getattr_call(
+    node: ast.Call, allowed_calls: frozenset[ast.Call]
+) -> bool:
+    return node in allowed_calls
 
 
 def _validator_sys_path_context(
@@ -700,6 +841,12 @@ def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         for parent in ast.walk(tree)
         for child in ast.iter_child_nodes(parent)
     }
+    allowed_getattr_calls, getattr_contract_errors = (
+        _canonical_reparse_getattr_contract(rel_path, tree)
+    )
+    errors.extend(getattr_contract_errors)
+    if _has_forbidden_name_binding(tree, "getattr"):
+        errors.append(f"getattr rebinding is forbidden in {rel_path}")
     import_state_references: list[ast.Attribute] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -751,9 +898,21 @@ def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id in {"getattr", "setattr"}
-            and not _is_allowlisted_getattr_call(node)
+            and not _is_allowlisted_getattr_call(node, allowed_getattr_calls)
         ):
             errors.append(f"reflective attribute call is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Name)
+            and node.id == "getattr"
+            and isinstance(node.ctx, ast.Load)
+        ):
+            parent = parents.get(node)
+            if not (
+                isinstance(parent, ast.Call)
+                and parent.func is node
+                and _is_allowlisted_getattr_call(parent, allowed_getattr_calls)
+            ):
+                errors.append(f"indirect getattr reference is forbidden in {rel_path}")
         elif isinstance(node, ast.arg) and node.arg == "sys":
             errors.append(f"sys rebinding is forbidden in {rel_path}")
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -871,6 +1030,9 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         for parent in ast.walk(tree)
         for child in ast.iter_child_nodes(parent)
     }
+    allowed_getattr_calls, _ = _canonical_reparse_getattr_contract(rel_path, tree)
+    if _has_forbidden_name_binding(tree, "getattr"):
+        errors.append(f"getattr rebinding is forbidden in {rel_path}")
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -917,10 +1079,29 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
                 errors.append(
                     f"dynamic execution or namespace access is forbidden in {rel_path}"
                 )
-            if node.func.id == "getattr" and not _is_allowlisted_getattr_call(node):
+            if node.func.id == "getattr" and not _is_allowlisted_getattr_call(
+                node, allowed_getattr_calls
+            ):
+                errors.append(f"indirect process API access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Name)
+            and node.id == "getattr"
+            and isinstance(node.ctx, ast.Load)
+        ):
+            parent = parents.get(node)
+            if not (
+                isinstance(parent, ast.Call)
+                and parent.func is node
+                and _is_allowlisted_getattr_call(parent, allowed_getattr_calls)
+            ):
                 errors.append(f"indirect process API access is forbidden in {rel_path}")
         elif isinstance(node, ast.Name) and node.id == "__builtins__":
             errors.append(f"__builtins__ access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Attribute)
+            and node.attr in FORBIDDEN_REFLECTIVE_ATTRIBUTES
+        ):
+            errors.append(f"reflective process access is forbidden in {rel_path}")
         elif (
             isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -23,6 +23,10 @@ sys.dont_write_bytecode = True
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+OAL_CI_WORKFLOW_PATH = ".github/workflows/oal-001-validate.yml"
+EXPECTED_OAL_CI_WORKFLOW_SHA256 = (
+    "6BE9AB1C40ADE2EEFA2949EEBEBEB064870905D0D842B5D0CC00F106628EB3DB"
+)
 PACKAGE_FILES = (
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
@@ -39,6 +43,7 @@ PYTHON_FILES = (
 )
 REQUIRED_FILES = (
     ".codex/safety_policy.yaml",
+    OAL_CI_WORKFLOW_PATH,
     ".gitignore",
     "config/oal_001.json",
     "docs/governance/oal_001_self_modification_policy.md",
@@ -64,6 +69,7 @@ EXPECTED_MUTABLE_PATHS = ["scripts/oal_001/observatory.py"]
 EXPECTED_PROTECTED_PATHS = [
     ".codex",
     ".git",
+    ".github/workflows/oal-001-validate.yml",
     ".gitignore",
     "config/oal_001.json",
     "docs/governance",
@@ -156,12 +162,13 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 47
+MINIMUM_OAL_TEST_COUNT = 54
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
 STATUS_FAIL = "FAIL"
 EXIT_RUNTIME_GAP = 3
+EXIT_NOT_PROMOTION_READY = 4
 ArtifactSnapshot = tuple[tuple[str, bytes], ...]
 
 
@@ -425,7 +432,13 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         if fixed_commands != {
             ("branch", "--show-current"),
             ("rev-parse", "HEAD"),
-            ("status", "--short", "--branch"),
+            (
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--ignore-submodules=none",
+                "--no-renames",
+            ),
         }:
             errors.append("typed Git reads do not match the exact fixed allowlist")
     return errors
@@ -489,7 +502,14 @@ def _git_read(command: list[str]) -> str:
     readers = {
         ("git", "branch", "--show-current"): current_branch,
         ("git", "rev-parse", "HEAD"): head_sha,
-        ("git", "status", "--short", "--branch"): worktree_status,
+        (
+            "git",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+            "--no-renames",
+        ): worktree_status,
     }
     reader = readers.get(tuple(command))
     if reader is None:
@@ -506,6 +526,15 @@ def static_errors() -> list[str]:
             errors.append(str(exc))
     if errors:
         return errors
+
+    workflow_source = _read_repo_file(OAL_CI_WORKFLOW_PATH)
+    normalized_workflow = workflow_source.replace(b"\r\n", b"\n")
+    if (
+        b"\r" in normalized_workflow
+        or hashlib.sha256(normalized_workflow).hexdigest().upper()
+        != EXPECTED_OAL_CI_WORKFLOW_SHA256
+    ):
+        errors.append("OAL Python 3.11 workflow does not match the exact contract")
 
     try:
         policy = _load_repo_json("config/oal_001.json")
@@ -580,6 +609,30 @@ def static_errors() -> list[str]:
             or set(checks_schema.get("required", [])) != EXPECTED_EVALUATION_CHECKS
         ):
             errors.append("trace schema evaluation checks are not exact")
+        expected_git_status_snapshots = {
+            "before": {
+                "type": "string",
+                "description": (
+                    "Branch-header-free Git porcelain v1 dirty entries before "
+                    "the cycle; empty means clean."
+                ),
+                "not": {"pattern": "(^|\\n)## "},
+            },
+            "after": {
+                "type": "string",
+                "description": (
+                    "Branch-header-free Git porcelain v1 dirty entries after "
+                    "the cycle; empty means clean."
+                ),
+                "not": {"pattern": "(^|\\n)## "},
+            },
+        }
+        git_status_properties = schema["properties"]["git_status"]["properties"]
+        if any(
+            git_status_properties.get(name) != expected
+            for name, expected in expected_git_status_snapshots.items()
+        ):
+            errors.append("trace schema Git status snapshots are not canonical")
     except (KeyError, TypeError, OSError, ValueError, json.JSONDecodeError) as exc:
         errors.append(f"invalid trace schema structure: {exc}")
     return errors
@@ -775,6 +828,25 @@ def _load_snapshot_json(snapshot: ArtifactSnapshot, name: str) -> object:
     return strict_json_bytes(_snapshot_bytes(snapshot, name))
 
 
+def _snapshot_promotion_eligible(snapshot: ArtifactSnapshot) -> bool:
+    """Derive promotion eligibility only from one captured evidence snapshot."""
+
+    try:
+        trace = _load_snapshot_json(snapshot, "mutation_trace.json")
+        boundary = _load_snapshot_json(snapshot, "boundary_report.json")
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(trace, dict) or not isinstance(boundary, dict):
+        return False
+    git_status = trace.get("git_status")
+    return (
+        boundary.get("status") == STATUS_PASS
+        and trace.get("source_state") == "clean_commit"
+        and isinstance(git_status, dict)
+        and git_status.get("clean_worktree") is True
+    )
+
+
 def _validation_status(artifact_errors: list[str], runtime_status: str) -> str:
     if artifact_errors:
         return STATUS_FAIL
@@ -794,10 +866,11 @@ def _build_test_result(
     artifact_errors: list[str],
     python_version: str,
     python_version_info: tuple[int, int],
+    promotion_eligible: bool,
 ) -> dict[str, object]:
     runtime_status = STATUS_PASS if python_version_info == TARGET_PYTHON else "NOT_RUN"
     status = _validation_status(artifact_errors, runtime_status)
-    promotion_ready = status == STATUS_PASS
+    promotion_ready = status == STATUS_PASS and promotion_eligible is True
     return {
         "schema_version": "OAL-1.0",
         "run_id": run_id,
@@ -835,7 +908,9 @@ def _build_test_result(
     }
 
 
-def _final_test_result_errors(test_result: object, expected_run_id: str) -> list[str]:
+def _final_test_result_errors(
+    test_result: object, expected_run_id: str, promotion_eligible: bool
+) -> list[str]:
     if not isinstance(test_result, dict):
         return ["final test result must be a JSON object"]
     errors: list[str] = []
@@ -943,7 +1018,7 @@ def _final_test_result_errors(test_result: object, expected_run_id: str) -> list
     )
     if test_result.get("status") != expected_status:
         errors.append("final validation status does not match Python 3.11 execution")
-    promotion_ready = expected_status == STATUS_PASS
+    promotion_ready = expected_status == STATUS_PASS and promotion_eligible is True
     if test_result.get("promotion_ready") is not promotion_ready:
         errors.append("final promotion readiness does not match validation status")
     if test_result.get("evidence_complete") is not promotion_ready:
@@ -1039,7 +1114,16 @@ def validate_artifact_snapshot(
         policy = load_policy(REPO_ROOT)
         branch = _git_read(["git", "branch", "--show-current"])
         base_sha = _git_read(["git", "rev-parse", "HEAD"])
-        current_status = _git_read(["git", "status", "--short", "--branch"])
+        current_status = _git_read(
+            [
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--ignore-submodules=none",
+                "--no-renames",
+            ]
+        )
         baseline_bytes = read_managed_source(REPO_ROOT, TARGET_PATH)
         baseline_sha = sha256_bytes(baseline_bytes)
         patch = build_harmless_patch(baseline_bytes.decode("utf-8"), baseline_sha)
@@ -1072,18 +1156,22 @@ def validate_artifact_snapshot(
     ):
         errors.append("trace Git snapshots do not match the current worktree status")
 
-    expected_run_id = derive_run_id(
-        base_sha,
-        branch,
-        str(trace_git.get("before", "")),
-        str(trace_git.get("after", "")),
-        CYCLE_ID,
-        TARGET_PATH,
-        baseline_sha,
-        candidate_sha,
-        str(fixture["fixture_id"]),
-        expected_manifest,
-    )
+    try:
+        expected_run_id = derive_run_id(
+            base_sha,
+            branch,
+            str(trace_git.get("before", "")),
+            str(trace_git.get("after", "")),
+            CYCLE_ID,
+            TARGET_PATH,
+            baseline_sha,
+            candidate_sha,
+            str(fixture["fixture_id"]),
+            expected_manifest,
+        )
+    except RuntimeError as exc:
+        errors.append(f"trace Git status cannot derive a run ID: {exc}")
+        return errors
     run_ids = {
         trace.get("run_id"),
         comparison.get("run_id"),
@@ -1265,7 +1353,16 @@ def validate_artifact_snapshot(
                 "completion marker must remain INCOMPLETE until final validation"
             )
     else:
-        errors.extend(_final_test_result_errors(test_result, expected_run_id))
+        promotion_eligible = (
+            expected_boundary["status"] == STATUS_PASS
+            and clean_worktree
+            and trace.get("source_state") == "clean_commit"
+        )
+        errors.extend(
+            _final_test_result_errors(
+                test_result, expected_run_id, promotion_eligible
+            )
+        )
         final_status = (
             test_result.get("status") if isinstance(test_result, dict) else STATUS_FAIL
         )
@@ -1439,6 +1536,12 @@ def _verify_existing(run_id: str) -> int:
     if status != STATUS_PASS:
         error("final evidence status is not recognized")
         return 1
+    if test_result.get("promotion_ready") is not True:
+        print(
+            f"[validate-oal-001] VERIFIED_NOT_PROMOTION_READY run_id={run_id} "
+            f"status={status}"
+        )
+        return EXIT_NOT_PROMOTION_READY
     print(f"[validate-oal-001] VERIFIED run_id={run_id} status={status}")
     return 0
 
@@ -1485,20 +1588,22 @@ def _run_validation() -> int:
     errors = validate_artifact_snapshot(
         prepared_snapshot, output_dir, lifecycle="prepared"
     )
+    if errors:
+        for item in errors:
+            error(item)
+        return 1
+    promotion_eligible = _snapshot_promotion_eligible(prepared_snapshot)
     test_result = _build_test_result(
         run_id=str(summary["run_id"]),
         test_count=int(test_count),
         test_outcomes=test_outcomes or {},
         test_returncode=test_returncode,
         dry_run_returncode=dry_run_returncode,
-        artifact_errors=errors,
+        artifact_errors=[],
         python_version=sys.version.split()[0],
         python_version_info=sys.version_info[:2],
+        promotion_eligible=promotion_eligible,
     )
-    if errors:
-        for item in errors:
-            error(item)
-        return 1
     errors = _finalize_evidence(output_dir, prepared_snapshot, test_result)
 
     if errors:
@@ -1507,14 +1612,23 @@ def _run_validation() -> int:
         return 1
 
     status = str(test_result["status"])
-    label = "OK" if status == STATUS_PASS else "OK_WITH_RUNTIME_GAP"
+    if status == STATUS_RUNTIME_GAP:
+        label = "OK_WITH_RUNTIME_GAP"
+    elif test_result["promotion_ready"] is True:
+        label = "OK"
+    else:
+        label = "OK_NOT_PROMOTION_READY"
     print(
         f"[validate-oal-001] {label} run_id={summary['run_id']} status={status} "
         f"tests={test_count} skipped={(test_outcomes or {}).get('skipped', 0)}"
     )
     print(f"[validate-oal-001] output_dir={summary['output_dir']}")
     print("[validate-oal-001] external_mutation_count=0")
-    return 0 if status == STATUS_PASS else EXIT_RUNTIME_GAP
+    if status == STATUS_RUNTIME_GAP:
+        return EXIT_RUNTIME_GAP
+    if test_result["promotion_ready"] is not True:
+        return EXIT_NOT_PROMOTION_READY
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+import argparse
 import difflib
 import hashlib
 import json
@@ -14,16 +15,18 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Mapping
+from typing import Literal, Mapping
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.dont_write_bytecode = True
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 PACKAGE_FILES = (
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
+    "scripts/oal_001/git_read.py",
     "scripts/oal_001/governor.py",
     "scripts/oal_001/observatory.py",
     "scripts/oal_001/runtime.py",
@@ -68,6 +71,7 @@ EXPECTED_PROTECTED_PATHS = [
     "schemas/oal_001_mutation_trace.schema.json",
     "scripts/oal_001/__init__.py",
     "scripts/oal_001/__main__.py",
+    "scripts/oal_001/git_read.py",
     "scripts/oal_001/governor.py",
     "scripts/oal_001/runtime.py",
     "scripts/validate_oal_001.py",
@@ -152,12 +156,13 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 37
-VALIDATOR_FIXED_GIT_READ_COMMANDS = {
-    ("git", "branch", "--show-current"),
-    ("git", "rev-parse", "HEAD"),
-    ("git", "status", "--short", "--branch"),
-}
+MINIMUM_OAL_TEST_COUNT = 47
+TARGET_PYTHON = (3, 11)
+STATUS_PASS = "PASS"
+STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
+STATUS_FAIL = "FAIL"
+EXIT_RUNTIME_GAP = 3
+ArtifactSnapshot = tuple[tuple[str, bytes], ...]
 
 
 class DuplicateJsonKeyError(ValueError):
@@ -390,14 +395,10 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
             errors.append(f"process execution API is forbidden in {rel_path}")
 
     expected: dict[str, list[tuple[str, ...]]] = {
-        "scripts/oal_001/__main__.py": [("$command",)],
-        "scripts/oal_001/runtime.py": [
-            ("git", "check-ignore", "-q", "$rel_path"),
-            ("git", "status", "--short", "--branch"),
-        ],
+        "scripts/oal_001/__main__.py": [],
+        "scripts/oal_001/git_read.py": [("$command",)],
+        "scripts/oal_001/runtime.py": [],
         "scripts/validate_oal_001.py": [
-            ("git", "check-ignore", "-q", "$rel_path"),
-            ("$command",),
             (
                 "$sys.executable",
                 "-m",
@@ -413,34 +414,20 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         errors.append(
             f"subprocess calls do not match the fixed read-only allowlist in {rel_path}"
         )
-    if rel_path == "scripts/oal_001/__main__.py":
+    if rel_path == "scripts/oal_001/git_read.py":
         fixed_commands: object | None = None
         for node in tree.body:
             if isinstance(node, ast.Assign) and any(
-                isinstance(target, ast.Name) and target.id == "FIXED_GIT_READ_COMMANDS"
+                isinstance(target, ast.Name) and target.id == "FIXED_GIT_READ_ARGUMENTS"
                 for target in node.targets
             ):
                 fixed_commands = ast.literal_eval(node.value)
         if fixed_commands != {
-            ("git", "branch", "--show-current"),
-            ("git", "rev-parse", "HEAD"),
+            ("branch", "--show-current"),
+            ("rev-parse", "HEAD"),
+            ("status", "--short", "--branch"),
         }:
-            errors.append("CLI Git reads do not match the exact fixed allowlist")
-    if rel_path == "scripts/validate_oal_001.py":
-        fixed_commands = None
-        for node in tree.body:
-            if isinstance(node, ast.Assign) and any(
-                isinstance(target, ast.Name)
-                and target.id == "VALIDATOR_FIXED_GIT_READ_COMMANDS"
-                for target in node.targets
-            ):
-                fixed_commands = ast.literal_eval(node.value)
-        if fixed_commands != {
-            ("git", "branch", "--show-current"),
-            ("git", "rev-parse", "HEAD"),
-            ("git", "status", "--short", "--branch"),
-        }:
-            errors.append("validator Git reads do not match the exact fixed allowlist")
+            errors.append("typed Git reads do not match the exact fixed allowlist")
     return errors
 
 
@@ -491,30 +478,23 @@ def _top_level_yaml_scalars(data: bytes) -> tuple[dict[str, str], list[str]]:
 
 
 def git_check_ignored(rel_path: str) -> bool:
-    result = subprocess.run(
-        ["git", "check-ignore", "-q", rel_path],
-        cwd=REPO_ROOT,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
-    return result.returncode == 0
+    from scripts.oal_001.git_read import is_ignored
+
+    return is_ignored(REPO_ROOT, rel_path)
 
 
 def _git_read(command: list[str]) -> str:
-    if tuple(command) not in VALIDATOR_FIXED_GIT_READ_COMMANDS:
-        raise ValueError("validator Git command is outside the read-only allowlist")
-    result = subprocess.run(
-        command,
-        cwd=REPO_ROOT,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"{' '.join(command)} failed: {result.stderr.strip()}")
-    return result.stdout.strip()
+    from scripts.oal_001.git_read import current_branch, head_sha, worktree_status
+
+    readers = {
+        ("git", "branch", "--show-current"): current_branch,
+        ("git", "rev-parse", "HEAD"): head_sha,
+        ("git", "status", "--short", "--branch"): worktree_status,
+    }
+    reader = readers.get(tuple(command))
+    if reader is None:
+        raise ValueError("validator Git command is outside the typed read-only API")
+    return reader(REPO_ROOT)
 
 
 def static_errors() -> list[str]:
@@ -535,9 +515,6 @@ def static_errors() -> list[str]:
             )
     except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
         errors.append(f"invalid immutable policy: {exc}")
-
-    if not git_check_ignored(EXPECTED_POLICY["output_root"]):
-        errors.append("configured local-private output root is not gitignored")
 
     safety, safety_errors = _top_level_yaml_scalars(
         _read_repo_file(".codex/safety_policy.yaml")
@@ -566,6 +543,9 @@ def static_errors() -> list[str]:
             for snippet in source_errors:
                 errors.append(f"forbidden source operation in {rel_path}: {snippet}")
         errors.extend(_subprocess_boundary_errors(rel_path, tree))
+
+    if not errors and not git_check_ignored(str(EXPECTED_POLICY["output_root"])):
+        errors.append("configured local-private output root is not gitignored")
 
     try:
         _parse_strategy_static(_read_repo_file("scripts/oal_001/observatory.py"))
@@ -723,70 +703,260 @@ def _validated_output_dir(summary: Mapping[str, object]) -> Path:
     return resolved
 
 
-def _load_artifact_json(output_dir: Path, name: str) -> object:
-    path = _regular_file(output_dir / name, REPO_ROOT, f"artifact {name}")
-    return strict_json_bytes(path.read_bytes())
-
-
-def _artifact_digest_map(output_dir: Path) -> dict[str, str]:
-    digests: dict[str, str] = {}
-    for name in sorted(EVIDENCE_ARTIFACTS - {"validation_complete.json"}):
-        path = _regular_file(output_dir / name, REPO_ROOT, f"artifact {name}")
-        digests[name] = hashlib.sha256(path.read_bytes()).hexdigest().upper()
-    return digests
-
-
-def validate_completion_marker(output_dir: Path) -> list[str]:
-    try:
-        actual_names = {path.name for path in output_dir.iterdir()}
-    except OSError as exc:
-        return [f"could not enumerate completed artifacts: {exc}"]
-    if actual_names != EVIDENCE_ARTIFACTS:
-        return ["completed artifact set does not match the exact evidence contract"]
-    try:
-        marker = _load_artifact_json(output_dir, "validation_complete.json")
-        trace = _load_artifact_json(output_dir, "mutation_trace.json")
-        test_result = _load_artifact_json(output_dir, "test_result.json")
-        current_digests = _artifact_digest_map(output_dir)
-    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
-        return [f"could not verify completion marker: {exc}"]
-    if not all(isinstance(item, dict) for item in (marker, trace, test_result)):
-        return [
-            "completion marker, mutation trace and test result must be JSON objects"
-        ]
-    unit_tests = test_result.get("unit_tests")
-    artifact_validation = test_result.get("artifact_validation")
-    semantic_pass = (
-        test_result.get("schema_version") == "OAL-1.0"
-        and test_result.get("run_id") == trace.get("run_id")
-        and test_result.get("status") == "PASS"
-        and test_result.get("evidence_complete") is True
-        and test_result.get("static_checks") == {"status": "PASS"}
-        and isinstance(unit_tests, dict)
-        and unit_tests.get("status") == "PASS"
-        and isinstance(unit_tests.get("count"), int)
-        and unit_tests["count"] >= MINIMUM_OAL_TEST_COUNT
-        and unit_tests.get("skipped") == 0
-        and unit_tests.get("outcome_details") == {}
-        and unit_tests.get("return_code") == 0
-        and test_result.get("dry_run") == {"status": "PASS", "return_code": 0}
-        and isinstance(artifact_validation, dict)
-        and artifact_validation.get("status") == "PASS"
-        and artifact_validation.get("errors") == []
-        and test_result.get("external_mutation_count") == 0
-    )
-    expected_status = "PASS" if semantic_pass else "FAIL"
-    expected = {
-        "schema_version": "OAL-1.0",
-        "run_id": trace.get("run_id"),
-        "status": expected_status,
-        "artifact_sha256": current_digests,
-    }
+def _artifact_set_errors(names: set[str]) -> list[str]:
     errors: list[str] = []
-    if marker.get("status") != expected_status:
-        errors.append("completion marker status does not match bound test semantics")
-    if marker != expected:
-        errors.append("completion marker artifact digests do not match current bytes")
+    missing = sorted(EVIDENCE_ARTIFACTS - names)
+    extra = sorted(names - EVIDENCE_ARTIFACTS)
+    if missing:
+        errors.append("missing artifacts: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected artifacts: " + ", ".join(extra))
+    return errors
+
+
+def _capture_artifact_snapshot(output_dir: Path) -> ArtifactSnapshot:
+    try:
+        names = {path.name for path in output_dir.iterdir()}
+    except OSError as exc:
+        raise ValueError(f"could not enumerate artifacts: {exc}") from exc
+    set_errors = _artifact_set_errors(names)
+    if set_errors:
+        raise ValueError("; ".join(set_errors))
+    return tuple(
+        (
+            name,
+            _regular_file(
+                output_dir / name, REPO_ROOT, f"artifact {name}"
+            ).read_bytes(),
+        )
+        for name in sorted(EVIDENCE_ARTIFACTS)
+    )
+
+
+def _snapshot_mapping(snapshot: ArtifactSnapshot) -> dict[str, bytes]:
+    mapping = dict(snapshot)
+    if len(mapping) != len(snapshot) or set(mapping) != EVIDENCE_ARTIFACTS:
+        raise ValueError("artifact snapshot does not match the exact evidence contract")
+    if not all(isinstance(data, bytes) for data in mapping.values()):
+        raise ValueError("artifact snapshot values must be immutable bytes")
+    return mapping
+
+
+def _snapshot_bytes(snapshot: ArtifactSnapshot, name: str) -> bytes:
+    try:
+        return _snapshot_mapping(snapshot)[name]
+    except KeyError as exc:
+        raise ValueError(f"artifact snapshot is missing {name}") from exc
+
+
+def _replace_snapshot_bytes(
+    snapshot: ArtifactSnapshot, name: str, data: bytes
+) -> ArtifactSnapshot:
+    mapping = _snapshot_mapping(snapshot)
+    if name not in mapping or not isinstance(data, bytes):
+        raise ValueError("snapshot replacement must target one evidence artifact")
+    mapping[name] = data
+    return tuple(sorted(mapping.items()))
+
+
+def _json_bytes(payload: object) -> bytes:
+    return (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _artifact_digest_map(snapshot: ArtifactSnapshot) -> dict[str, str]:
+    mapping = _snapshot_mapping(snapshot)
+    return {
+        name: hashlib.sha256(mapping[name]).hexdigest().upper()
+        for name in sorted(EVIDENCE_ARTIFACTS - {"validation_complete.json"})
+    }
+
+
+def _load_snapshot_json(snapshot: ArtifactSnapshot, name: str) -> object:
+    return strict_json_bytes(_snapshot_bytes(snapshot, name))
+
+
+def _validation_status(artifact_errors: list[str], runtime_status: str) -> str:
+    if artifact_errors:
+        return STATUS_FAIL
+    if runtime_status == STATUS_PASS:
+        return STATUS_PASS
+    if runtime_status == "NOT_RUN":
+        return STATUS_RUNTIME_GAP
+    raise ValueError("Python 3.11 runtime status is invalid")
+
+
+def _build_test_result(
+    run_id: str,
+    test_count: int,
+    test_outcomes: Mapping[str, int],
+    test_returncode: int,
+    dry_run_returncode: int,
+    artifact_errors: list[str],
+    python_version: str,
+    python_version_info: tuple[int, int],
+) -> dict[str, object]:
+    runtime_status = STATUS_PASS if python_version_info == TARGET_PYTHON else "NOT_RUN"
+    status = _validation_status(artifact_errors, runtime_status)
+    promotion_ready = status == STATUS_PASS
+    return {
+        "schema_version": "OAL-1.0",
+        "run_id": run_id,
+        "status": status,
+        "evidence_complete": promotion_ready,
+        "promotion_ready": promotion_ready,
+        "static_checks": {"status": STATUS_PASS},
+        "unit_tests": {
+            "status": STATUS_PASS,
+            "command": "python -m unittest tests.test_oal_001_governor tests.test_oal_001_runtime -v",
+            "count": test_count,
+            "skipped": test_outcomes.get("skipped", 0),
+            "outcome_details": dict(test_outcomes),
+            "return_code": test_returncode,
+        },
+        "python_runtime": {
+            "version": python_version,
+            "status": STATUS_PASS,
+        },
+        "python_3_11_target": {
+            "grammar": STATUS_PASS,
+            "runtime": runtime_status,
+            "reason": (
+                None
+                if runtime_status == STATUS_PASS
+                else "validator interpreter is not Python 3.11"
+            ),
+        },
+        "dry_run": {"status": STATUS_PASS, "return_code": dry_run_returncode},
+        "artifact_validation": {
+            "status": STATUS_PASS if not artifact_errors else STATUS_FAIL,
+            "errors": list(artifact_errors),
+        },
+        "external_mutation_count": 0,
+    }
+
+
+def _final_test_result_errors(test_result: object, expected_run_id: str) -> list[str]:
+    if not isinstance(test_result, dict):
+        return ["final test result must be a JSON object"]
+    errors: list[str] = []
+    expected_keys = {
+        "schema_version",
+        "run_id",
+        "status",
+        "evidence_complete",
+        "promotion_ready",
+        "static_checks",
+        "unit_tests",
+        "python_runtime",
+        "python_3_11_target",
+        "dry_run",
+        "artifact_validation",
+        "external_mutation_count",
+    }
+    if set(test_result) != expected_keys:
+        errors.append("final test result fields do not match the exact contract")
+    if test_result.get("schema_version") != "OAL-1.0":
+        errors.append("final test result schema version is invalid")
+    if test_result.get("run_id") != expected_run_id:
+        errors.append("final test result run ID is invalid")
+    if test_result.get("static_checks") != {"status": STATUS_PASS}:
+        errors.append("final static-check result is not PASS")
+
+    unit_tests = test_result.get("unit_tests")
+    expected_unit_keys = {
+        "status",
+        "command",
+        "count",
+        "skipped",
+        "outcome_details",
+        "return_code",
+    }
+    if not isinstance(unit_tests, dict) or set(unit_tests) != expected_unit_keys:
+        errors.append("final unit-test result fields do not match the exact contract")
+    else:
+        if unit_tests.get("status") != STATUS_PASS:
+            errors.append("final unit-test status is not PASS")
+        if unit_tests.get("command") != (
+            "python -m unittest tests.test_oal_001_governor "
+            "tests.test_oal_001_runtime -v"
+        ):
+            errors.append("final unit-test command is invalid")
+        count = unit_tests.get("count")
+        if not isinstance(count, int) or count < MINIMUM_OAL_TEST_COUNT:
+            errors.append("final unit-test count is below the required minimum")
+        if unit_tests.get("skipped") != 0:
+            errors.append("final unit-test result contains skipped tests")
+        if unit_tests.get("outcome_details") != {}:
+            errors.append("final unit-test outcome details are not empty")
+        if unit_tests.get("return_code") != 0:
+            errors.append("final unit-test return code is not zero")
+
+    python_runtime = test_result.get("python_runtime")
+    target_runtime = test_result.get("python_3_11_target")
+    recorded_version: tuple[int, int] | None = None
+    if not isinstance(python_runtime, dict) or set(python_runtime) != {
+        "version",
+        "status",
+    }:
+        errors.append("final Python runtime fields do not match the exact contract")
+    else:
+        version = python_runtime.get("version")
+        if not isinstance(version, str) or not re.fullmatch(
+            r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)?", version
+        ):
+            errors.append("final Python runtime version is invalid")
+        else:
+            major, minor, *_ = version.split(".")
+            recorded_version = (int(major), int(minor))
+        if python_runtime.get("status") != STATUS_PASS:
+            errors.append("final Python runtime status is not PASS")
+    if not isinstance(target_runtime, dict) or set(target_runtime) != {
+        "grammar",
+        "runtime",
+        "reason",
+    }:
+        errors.append("Python 3.11 target fields do not match the exact contract")
+        runtime_status = None
+    else:
+        runtime_status = target_runtime.get("runtime")
+        if target_runtime.get("grammar") != STATUS_PASS:
+            errors.append("Python 3.11 grammar status is not PASS")
+        if runtime_status not in {STATUS_PASS, "NOT_RUN"}:
+            errors.append("Python 3.11 runtime status is invalid")
+        elif runtime_status == STATUS_PASS:
+            if (
+                recorded_version != TARGET_PYTHON
+                or target_runtime.get("reason") is not None
+            ):
+                errors.append(
+                    "Python 3.11 PASS is not supported by the recorded runtime"
+                )
+        elif (
+            recorded_version == TARGET_PYTHON
+            or target_runtime.get("reason")
+            != "validator interpreter is not Python 3.11"
+        ):
+            errors.append("Python 3.11 NOT_RUN reason is inconsistent")
+
+    expected_status = (
+        STATUS_PASS if runtime_status == STATUS_PASS else STATUS_RUNTIME_GAP
+    )
+    if test_result.get("status") != expected_status:
+        errors.append("final validation status does not match Python 3.11 execution")
+    promotion_ready = expected_status == STATUS_PASS
+    if test_result.get("promotion_ready") is not promotion_ready:
+        errors.append("final promotion readiness does not match validation status")
+    if test_result.get("evidence_complete") is not promotion_ready:
+        errors.append("final evidence completeness does not match validation status")
+    if test_result.get("dry_run") != {"status": STATUS_PASS, "return_code": 0}:
+        errors.append("final dry-run result is not PASS")
+    if test_result.get("artifact_validation") != {
+        "status": STATUS_PASS,
+        "errors": [],
+    }:
+        errors.append("final artifact validation result is not PASS")
+    if test_result.get("external_mutation_count") != 0:
+        errors.append("final external mutation count is not zero")
     return errors
 
 
@@ -802,33 +972,24 @@ def _expected_diff(target_path: str, baseline: bytes, candidate: str) -> str:
     )
 
 
-def validate_artifacts(output_dir: Path) -> list[str]:
+def validate_artifact_snapshot(
+    snapshot: ArtifactSnapshot,
+    output_dir: Path,
+    lifecycle: Literal["prepared", "complete"],
+) -> list[str]:
     errors: list[str] = []
+    if lifecycle not in {"prepared", "complete"}:
+        return ["artifact lifecycle must be prepared or complete"]
     try:
-        actual_names = {path.name for path in output_dir.iterdir()}
-    except OSError as exc:
-        return [f"could not enumerate artifacts: {exc}"]
-    if actual_names != EVIDENCE_ARTIFACTS:
-        missing = sorted(EVIDENCE_ARTIFACTS - actual_names)
-        extra = sorted(actual_names - EVIDENCE_ARTIFACTS)
-        if missing:
-            errors.append("missing artifacts: " + ", ".join(missing))
-        if extra:
-            errors.append("unexpected artifacts: " + ", ".join(extra))
-        return errors
-
-    try:
+        _snapshot_mapping(snapshot)
         payload = {
-            name: _load_artifact_json(output_dir, name)
+            name: _load_snapshot_json(snapshot, name)
             for name in EVIDENCE_ARTIFACTS
             if name.endswith(".json")
         }
-        report_path = _regular_file(
-            output_dir / "run_report.md", REPO_ROOT, "artifact run_report.md"
-        )
-        run_report = report_path.read_text(encoding="utf-8")
+        run_report = _snapshot_bytes(snapshot, "run_report.md").decode("utf-8")
     except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
-        return [f"could not safely load artifacts: {exc}"]
+        return [f"could not safely load artifact snapshot: {exc}"]
 
     trace = payload["mutation_trace.json"]
     before = payload["replay_before.json"]
@@ -1087,28 +1248,69 @@ def validate_artifacts(output_dir: Path) -> list[str]:
     )
     if run_report != expected_report:
         errors.append("run report is not exactly reproducible from validated evidence")
-    if test_result != {
-        "schema_version": "OAL-1.0",
-        "run_id": expected_run_id,
-        "status": "NOT_RUN",
-        "evidence_complete": False,
-    }:
-        errors.append("test result placeholder is stale or malformed")
-    if completion != {
-        "schema_version": "OAL-1.0",
-        "run_id": expected_run_id,
-        "status": "INCOMPLETE",
-    }:
-        errors.append("completion marker must remain INCOMPLETE until final validation")
+    if lifecycle == "prepared":
+        if test_result != {
+            "schema_version": "OAL-1.0",
+            "run_id": expected_run_id,
+            "status": "NOT_RUN",
+            "evidence_complete": False,
+        }:
+            errors.append("test result placeholder is stale or malformed")
+        if completion != {
+            "schema_version": "OAL-1.0",
+            "run_id": expected_run_id,
+            "status": "INCOMPLETE",
+        }:
+            errors.append(
+                "completion marker must remain INCOMPLETE until final validation"
+            )
+    else:
+        errors.extend(_final_test_result_errors(test_result, expected_run_id))
+        final_status = (
+            test_result.get("status") if isinstance(test_result, dict) else STATUS_FAIL
+        )
+        expected_completion = {
+            "schema_version": "OAL-1.0",
+            "run_id": expected_run_id,
+            "status": final_status,
+            "artifact_sha256": _artifact_digest_map(snapshot),
+        }
+        if completion != expected_completion:
+            errors.append(
+                "completion marker does not bind the semantically validated snapshot"
+            )
     return errors
 
 
-def _atomic_write_json(path: Path, payload: object) -> None:
+def validate_artifacts(output_dir: Path) -> list[str]:
+    try:
+        snapshot = _capture_artifact_snapshot(output_dir)
+    except (OSError, ValueError) as exc:
+        return [str(exc)]
+    return validate_artifact_snapshot(snapshot, output_dir, lifecycle="prepared")
+
+
+def verify_existing_evidence(output_dir: Path) -> list[str]:
+    """Fully reconstruct one final evidence bundle without writing or executing it."""
+
+    try:
+        snapshot = _capture_artifact_snapshot(output_dir)
+    except (OSError, ValueError) as exc:
+        return [str(exc)]
+    return validate_artifact_snapshot(snapshot, output_dir, lifecycle="complete")
+
+
+def validate_completion_marker(output_dir: Path) -> list[str]:
+    """Compatibility wrapper for the full semantic final-bundle verifier."""
+
+    return verify_existing_evidence(output_dir)
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
     _regular_file(path.parent / "mutation_trace.json", REPO_ROOT, "artifact anchor")
     _reject_link_components(REPO_ROOT, path, path.name)
     if path.exists():
         _regular_file(path, REPO_ROOT, path.name)
-    data = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
     )
@@ -1124,10 +1326,124 @@ def _atomic_write_json(path: Path, payload: object) -> None:
             temporary_path.unlink()
 
 
-def main(argv: list[str] | None = None) -> int:
-    if argv:
-        error("this validator accepts no arguments")
-        return 2
+def _atomic_write_json(path: Path, payload: object) -> None:
+    _atomic_write_bytes(path, _json_bytes(payload))
+
+
+def _finalized_snapshot(
+    prepared_snapshot: ArtifactSnapshot, test_result: Mapping[str, object]
+) -> ArtifactSnapshot:
+    bound_snapshot = _replace_snapshot_bytes(
+        prepared_snapshot, "test_result.json", _json_bytes(test_result)
+    )
+    status = test_result.get("status")
+    if status not in {STATUS_PASS, STATUS_RUNTIME_GAP}:
+        raise ValueError("only successful or runtime-gap evidence can be finalized")
+    trace = _load_snapshot_json(bound_snapshot, "mutation_trace.json")
+    if not isinstance(trace, dict):
+        raise ValueError("mutation trace must be a JSON object")
+    completion = {
+        "schema_version": "OAL-1.0",
+        "run_id": trace.get("run_id"),
+        "status": status,
+        "artifact_sha256": _artifact_digest_map(bound_snapshot),
+    }
+    return _replace_snapshot_bytes(
+        bound_snapshot, "validation_complete.json", _json_bytes(completion)
+    )
+
+
+def _finalize_evidence(
+    output_dir: Path,
+    prepared_snapshot: ArtifactSnapshot,
+    test_result: Mapping[str, object],
+) -> list[str]:
+    try:
+        if _capture_artifact_snapshot(output_dir) != prepared_snapshot:
+            return ["artifact set changed after semantic validation"]
+        finalized_snapshot = _finalized_snapshot(prepared_snapshot, test_result)
+        errors = validate_artifact_snapshot(
+            finalized_snapshot, output_dir, lifecycle="complete"
+        )
+        if errors:
+            return errors
+        _atomic_write_bytes(
+            output_dir / "test_result.json",
+            _snapshot_bytes(finalized_snapshot, "test_result.json"),
+        )
+        _atomic_write_bytes(
+            output_dir / "validation_complete.json",
+            _snapshot_bytes(finalized_snapshot, "validation_complete.json"),
+        )
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        return [f"could not atomically finalize evidence: {exc}"]
+    return verify_existing_evidence(output_dir)
+
+
+def _run_id_argument(value: str) -> str:
+    if not RUN_ID_PATTERN.fullmatch(value):
+        raise argparse.ArgumentTypeError("must be an OAL-001 run ID")
+    return value
+
+
+def _existing_output_dir(run_id: str) -> Path:
+    output_root = REPO_ROOT / str(EXPECTED_POLICY["output_root"])
+    output_dir = output_root / run_id
+    _reject_link_components(REPO_ROOT, output_dir, "existing evidence directory")
+    resolved_root = output_root.resolve(strict=True)
+    resolved = output_dir.resolve(strict=True)
+    if (
+        resolved.parent != resolved_root
+        or resolved.name != run_id
+        or not resolved.is_dir()
+    ):
+        raise ValueError("existing evidence directory is outside the fixed output root")
+    rel_path = resolved.relative_to(REPO_ROOT.resolve()).as_posix()
+    if not git_check_ignored(rel_path):
+        raise ValueError("existing evidence directory is not gitignored")
+    return resolved
+
+
+def _verify_existing(run_id: str) -> int:
+    static_validation_errors = static_errors()
+    if static_validation_errors:
+        for item in static_validation_errors:
+            error(item)
+        return 1
+    try:
+        output_dir = _existing_output_dir(run_id)
+        snapshot = _capture_artifact_snapshot(output_dir)
+        verification_errors = validate_artifact_snapshot(
+            snapshot, output_dir, lifecycle="complete"
+        )
+        test_result = _load_snapshot_json(snapshot, "test_result.json")
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        error(f"could not verify existing evidence: {exc}")
+        return 1
+    if verification_errors:
+        for item in verification_errors:
+            error(item)
+        return 1
+    if not isinstance(test_result, dict):
+        error("final test result must be a JSON object")
+        return 1
+    status = test_result.get("status")
+    target = test_result.get("python_3_11_target")
+    runtime_status = target.get("runtime") if isinstance(target, dict) else None
+    if status == STATUS_RUNTIME_GAP:
+        print(
+            f"[validate-oal-001] VERIFIED_WITH_RUNTIME_GAP run_id={run_id} "
+            f"status={status} python_3_11_runtime={runtime_status}"
+        )
+        return EXIT_RUNTIME_GAP
+    if status != STATUS_PASS:
+        error("final evidence status is not recognized")
+        return 1
+    print(f"[validate-oal-001] VERIFIED run_id={run_id} status={status}")
+    return 0
+
+
+def _run_validation() -> int:
 
     errors = static_errors()
     if errors:
@@ -1161,69 +1477,63 @@ def main(argv: list[str] | None = None) -> int:
         error(f"dry-run summary is invalid: {exc}")
         return 1
 
-    errors = validate_artifacts(output_dir)
-    runtime_status = "PASS" if sys.version_info[:2] == (3, 11) else "NOT_RUN"
-    test_result = {
-        "schema_version": "OAL-1.0",
-        "run_id": summary["run_id"],
-        "status": "PASS" if not errors else "FAIL",
-        "evidence_complete": not errors,
-        "static_checks": {"status": "PASS"},
-        "unit_tests": {
-            "status": "PASS",
-            "command": "python -m unittest tests.test_oal_001_governor tests.test_oal_001_runtime -v",
-            "count": test_count,
-            "skipped": (test_outcomes or {}).get("skipped", 0),
-            "outcome_details": test_outcomes,
-            "return_code": test_returncode,
-        },
-        "python_runtime": {
-            "version": sys.version.split()[0],
-            "status": "PASS",
-        },
-        "python_3_11_target": {
-            "grammar": "PASS",
-            "runtime": runtime_status,
-            "reason": (
-                None
-                if runtime_status == "PASS"
-                else "validator interpreter is not Python 3.11"
-            ),
-        },
-        "dry_run": {"status": "PASS", "return_code": dry_run_returncode},
-        "artifact_validation": {
-            "status": "PASS" if not errors else "FAIL",
-            "errors": errors,
-        },
-        "external_mutation_count": 0,
-    }
     try:
-        _validated_output_dir(summary)
-        _atomic_write_json(output_dir / "test_result.json", test_result)
-        completion = {
-            "schema_version": "OAL-1.0",
-            "run_id": summary["run_id"],
-            "status": "PASS" if not errors else "FAIL",
-            "artifact_sha256": _artifact_digest_map(output_dir),
-        }
-        _atomic_write_json(output_dir / "validation_complete.json", completion)
-        completion_errors = validate_completion_marker(output_dir)
-        errors.extend(completion_errors)
+        prepared_snapshot = _capture_artifact_snapshot(output_dir)
     except (OSError, ValueError) as exc:
-        errors.append(f"could not atomically finalize evidence: {exc}")
+        error(str(exc))
+        return 1
+    errors = validate_artifact_snapshot(
+        prepared_snapshot, output_dir, lifecycle="prepared"
+    )
+    test_result = _build_test_result(
+        run_id=str(summary["run_id"]),
+        test_count=int(test_count),
+        test_outcomes=test_outcomes or {},
+        test_returncode=test_returncode,
+        dry_run_returncode=dry_run_returncode,
+        artifact_errors=errors,
+        python_version=sys.version.split()[0],
+        python_version_info=sys.version_info[:2],
+    )
+    if errors:
+        for item in errors:
+            error(item)
+        return 1
+    errors = _finalize_evidence(output_dir, prepared_snapshot, test_result)
 
     if errors:
         for item in errors:
             error(item)
         return 1
 
+    status = str(test_result["status"])
+    label = "OK" if status == STATUS_PASS else "OK_WITH_RUNTIME_GAP"
     print(
-        f"[validate-oal-001] OK run_id={summary['run_id']} "
+        f"[validate-oal-001] {label} run_id={summary['run_id']} status={status} "
         f"tests={test_count} skipped={(test_outcomes or {}).get('skipped', 0)}"
     )
     print(f"[validate-oal-001] output_dir={summary['output_dir']}")
     print("[validate-oal-001] external_mutation_count=0")
-    return 0
+    return 0 if status == STATUS_PASS else EXIT_RUNTIME_GAP
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate or read-only verify OAL-001 local evidence."
+    )
+    parser.add_argument(
+        "--verify-existing",
+        metavar="RUN_ID",
+        type=_run_id_argument,
+        help="Verify one finalized run without tests, dry-run or writes.",
+    )
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code)
+    if args.verify_existing:
+        return _verify_existing(args.verify_existing)
+    return _run_validation()
 
 
 if __name__ == "__main__":

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -3,6 +3,21 @@
 
 from __future__ import annotations
 
+import sys
+
+
+if __name__ == "__main__" and not (
+    sys.flags.isolated
+    and sys.flags.no_site
+    and sys.flags.safe_path
+    and sys.flags.dont_write_bytecode
+):
+    print(
+        "[validate-oal-001] ERROR: validator requires python -I -S -B",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
 import ast
 import argparse
 import difflib
@@ -12,20 +27,67 @@ import os
 import re
 import stat
 import subprocess
-import sys
 import tempfile
+from importlib.machinery import all_suffixes
 from pathlib import Path
 from typing import Literal, Mapping
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.dont_write_bytecode = True
+VALIDATOR_PATH = Path(__file__).resolve(strict=True)
+REPO_ROOT = VALIDATOR_PATH.parents[1]
+if __name__ == "__main__":
+    forbidden_import_roots = {
+        REPO_ROOT,
+        VALIDATOR_PATH.parent,
+        Path.cwd().resolve(),
+    }
+    unsafe_import_path = False
+    for raw_path in sys.path:
+        if not raw_path:
+            unsafe_import_path = True
+            break
+        try:
+            if Path(raw_path).resolve() in forbidden_import_roots:
+                unsafe_import_path = True
+                break
+        except OSError:
+            unsafe_import_path = True
+            break
+    if unsafe_import_path:
+        print(
+            "[validate-oal-001] ERROR: repository paths precede the isolated import boundary",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.append(str(REPO_ROOT))
+if __name__ == "__main__" and (
+    sys.path.count(str(REPO_ROOT)) != 1 or sys.path[-1] != str(REPO_ROOT)
+):
+    print(
+        "[validate-oal-001] ERROR: repository import root is not isolated",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 OAL_CI_WORKFLOW_PATH = ".github/workflows/oal-001-validate.yml"
 EXPECTED_OAL_CI_WORKFLOW_SHA256 = (
-    "6BE9AB1C40ADE2EEFA2949EEBEBEB064870905D0D842B5D0CC00F106628EB3DB"
+    "719D551B6E2BBE58CFC9CA5581F2B94E518A8331E3923923FB77B6F0F52E2123"
+)
+ISOLATED_UNIT_TEST_COMMAND = (
+    "python -I -S -B scripts/validate_oal_001.py --_internal-unit-tests"
+)
+PYTHON_IMPORT_SUFFIXES = tuple(
+    sorted(
+        {suffix.casefold() for suffix in all_suffixes()}
+        | {".py", ".pyc", ".pyd", ".pyw", ".so"},
+        key=len,
+        reverse=True,
+    )
+)
+PYTHON_SHADOW_MODULES = frozenset(
+    {name.casefold() for name in sys.stdlib_module_names}
+    | {"sitecustomize", "usercustomize"}
 )
 PACKAGE_FILES = (
     "scripts/oal_001/__init__.py",
@@ -41,6 +103,8 @@ PYTHON_FILES = (
     "tests/test_oal_001_governor.py",
     "tests/test_oal_001_runtime.py",
 )
+PROTECTED_IMPORT_DIRECTORIES = ("scripts", "tests", "scripts/oal_001")
+PROTECTED_IMPORT_FILES = PYTHON_FILES
 REQUIRED_FILES = (
     ".codex/safety_policy.yaml",
     OAL_CI_WORKFLOW_PATH,
@@ -162,7 +226,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 54
+MINIMUM_OAL_TEST_COUNT = 58
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -199,6 +263,147 @@ def _is_reparse_point(path: Path) -> bool:
     except (AttributeError, FileNotFoundError, OSError):
         return False
     return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _module_name_from_import_path(name: str) -> str | None:
+    lowered = name.casefold()
+    for suffix in PYTHON_IMPORT_SUFFIXES:
+        if lowered.endswith(suffix) and len(lowered) > len(suffix):
+            return lowered[: -len(suffix)].split(".", 1)[0]
+    return None
+
+
+def _module_name_from_cached_bytecode(name: str) -> str | None:
+    lowered = name.casefold()
+    if not lowered.endswith(".pyc") or len(lowered) <= len(".pyc"):
+        return None
+    return lowered[: -len(".pyc")].split(".", 1)[0]
+
+
+def _has_package_initializer(path: Path) -> bool:
+    try:
+        return any(
+            _module_name_from_import_path(child.name) == "__init__"
+            for child in path.iterdir()
+            if child.is_file() or child.is_symlink() or _is_reparse_point(child)
+        )
+    except OSError:
+        return True
+
+
+def python_shadowing_errors(repo_root: Path) -> list[str]:
+    """Reject import-shadowing files before any repository module is imported."""
+
+    try:
+        root = repo_root.resolve(strict=True)
+    except OSError as exc:
+        return [f"could not resolve Python import root: {exc}"]
+    if not root.is_dir():
+        return ["Python import root is not a directory"]
+
+    layout_errors: list[str] = []
+    for rel_path in PROTECTED_IMPORT_DIRECTORIES:
+        path = root / rel_path
+        if not path.is_dir() or path.is_symlink() or _is_reparse_point(path):
+            layout_errors.append(f"invalid Python import topology: {rel_path}")
+
+    for rel_path in PROTECTED_IMPORT_FILES:
+        path = root / rel_path
+        try:
+            invalid_file = (
+                not path.is_file()
+                or path.is_symlink()
+                or _is_reparse_point(path)
+                or path.stat().st_nlink != 1
+            )
+        except OSError:
+            invalid_file = True
+        if invalid_file:
+            layout_errors.append(f"invalid Python import topology: {rel_path}")
+
+    protected_slots: dict[str, dict[str, str]] = {}
+    for rel_path in PROTECTED_IMPORT_DIRECTORIES:
+        path = Path(rel_path)
+        parent = "" if path.parent.as_posix() == "." else path.parent.as_posix()
+        protected_slots.setdefault(parent, {})[path.name.casefold()] = rel_path
+    for rel_path in PROTECTED_IMPORT_FILES:
+        path = Path(rel_path)
+        parent = "" if path.parent.as_posix() == "." else path.parent.as_posix()
+        protected_slots.setdefault(parent, {})[path.stem.casefold()] = rel_path
+
+    problems: set[str] = set()
+    for base_rel, expected_slots in protected_slots.items():
+        base = root / base_rel
+        if not base.is_dir() or base.is_symlink() or _is_reparse_point(base):
+            continue
+        try:
+            entries = tuple(base.iterdir())
+        except OSError:
+            layout_errors.append(
+                f"could not inspect Python import topology: {base_rel or '.'}"
+            )
+            continue
+        for entry in entries:
+            module_name = _module_name_from_import_path(entry.name)
+            relative = entry.relative_to(root).as_posix()
+            directory_name = entry.name.casefold()
+            if base_rel in {"", "scripts"}:
+                if module_name in PYTHON_SHADOW_MODULES:
+                    problems.add(relative)
+                if directory_name in PYTHON_SHADOW_MODULES and (
+                    entry.is_symlink()
+                    or _is_reparse_point(entry)
+                    or (entry.is_dir() and _has_package_initializer(entry))
+                ):
+                    problems.add(relative)
+
+            slot_candidates = {module_name}
+            if entry.is_dir() or entry.is_symlink() or _is_reparse_point(entry):
+                slot_candidates.add(directory_name)
+            for slot in slot_candidates - {None}:
+                expected_path = expected_slots.get(slot)
+                if expected_path is not None and relative != expected_path:
+                    problems.add(relative)
+
+            if directory_name != "__pycache__":
+                continue
+            if entry.is_symlink() or _is_reparse_point(entry) or not entry.is_dir():
+                problems.add(relative)
+                continue
+            try:
+                cache_entries = tuple(entry.iterdir())
+            except OSError:
+                layout_errors.append(
+                    f"could not inspect Python bytecode cache: {relative}"
+                )
+                continue
+            for cache_entry in cache_entries:
+                cached_module = _module_name_from_cached_bytecode(cache_entry.name)
+                if cached_module in expected_slots:
+                    problems.add(cache_entry.relative_to(root).as_posix())
+
+    for namespace_rel in ("scripts", "tests"):
+        namespace = root / namespace_rel
+        if (
+            not namespace.is_dir()
+            or namespace.is_symlink()
+            or _is_reparse_point(namespace)
+        ):
+            continue
+        try:
+            namespace_entries = tuple(namespace.iterdir())
+        except OSError:
+            layout_errors.append(
+                f"could not inspect Python namespace topology: {namespace_rel}"
+            )
+            continue
+        for entry in namespace_entries:
+            if _module_name_from_import_path(entry.name) == "__init__":
+                problems.add(entry.relative_to(root).as_posix())
+
+    return layout_errors + [
+        f"forbidden Python import-shadowing path: {path}" for path in sorted(problems)
+    ]
 
 
 def _reject_link_components(root: Path, path: Path, label: str) -> None:
@@ -269,6 +474,85 @@ def _call_signature(argument: ast.AST) -> tuple[str, ...] | None:
         else:
             return None
     return tuple(values)
+
+
+def _is_sys_path(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+        and node.attr == "path"
+    )
+
+
+def _is_repo_root_string(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "REPO_ROOT"
+        and not node.keywords
+    )
+
+
+def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
+    method_calls: list[ast.Call] = []
+    assigned = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and _is_sys_path(node.func.value)
+        ):
+            method_calls.append(node)
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
+            targets: list[ast.AST] = []
+            if isinstance(node, ast.Assign):
+                targets.extend(node.targets)
+            elif isinstance(node, ast.Delete):
+                targets.extend(node.targets)
+            else:
+                targets.append(node.target)
+            if any(
+                _is_sys_path(target)
+                or (isinstance(target, ast.Subscript) and _is_sys_path(target.value))
+                for target in targets
+            ):
+                assigned = True
+
+    if rel_path != "scripts/validate_oal_001.py":
+        if method_calls or assigned:
+            return [f"Python import-path mutation is forbidden in {rel_path}"]
+        return []
+
+    append_calls = [
+        node
+        for node in method_calls
+        if node.func.attr == "append"
+        and len(node.args) == 1
+        and _is_repo_root_string(node.args[0])
+        and not node.keywords
+    ]
+    count_calls = [
+        node
+        for node in method_calls
+        if node.func.attr == "count"
+        and len(node.args) == 1
+        and _is_repo_root_string(node.args[0])
+        and not node.keywords
+    ]
+    if (
+        assigned
+        or len(append_calls) != 1
+        or len(count_calls) != 1
+        or len(method_calls) != 2
+    ):
+        return [
+            "validator import path must append REPO_ROOT exactly once after interpreter paths"
+        ]
+    return []
 
 
 def _is_process_api_name(name: str) -> bool:
@@ -408,13 +692,20 @@ def _subprocess_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
         "scripts/validate_oal_001.py": [
             (
                 "$sys.executable",
-                "-m",
-                "unittest",
-                "tests.test_oal_001_governor",
-                "tests.test_oal_001_runtime",
-                "-v",
+                "-I",
+                "-S",
+                "-B",
+                "$VALIDATOR_PATH",
+                "--_internal-unit-tests",
             ),
-            ("$sys.executable", "-m", "scripts.oal_001", "--json"),
+            (
+                "$sys.executable",
+                "-I",
+                "-S",
+                "-B",
+                "$VALIDATOR_PATH",
+                "--_internal-dry-run",
+            ),
         ],
     }
     if signatures != expected.get(rel_path, []):
@@ -518,7 +809,7 @@ def _git_read(command: list[str]) -> str:
 
 
 def static_errors() -> list[str]:
-    errors: list[str] = []
+    errors = python_shadowing_errors(REPO_ROOT)
     for rel_path in REQUIRED_FILES:
         try:
             _regular_file(REPO_ROOT / rel_path, REPO_ROOT, rel_path)
@@ -572,6 +863,7 @@ def static_errors() -> list[str]:
             for snippet in source_errors:
                 errors.append(f"forbidden source operation in {rel_path}: {snippet}")
         errors.extend(_subprocess_boundary_errors(rel_path, tree))
+        errors.extend(_import_path_boundary_errors(rel_path, tree))
 
     if not errors and not git_check_ignored(str(EXPECTED_POLICY["output_root"])):
         errors.append("configured local-private output root is not gitignored")
@@ -638,15 +930,34 @@ def static_errors() -> list[str]:
     return errors
 
 
+def _internal_unit_tests() -> int:
+    import unittest
+
+    suite = unittest.defaultTestLoader.loadTestsFromNames(
+        (
+            "tests.test_oal_001_governor",
+            "tests.test_oal_001_runtime",
+        )
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+def _internal_dry_run() -> int:
+    from scripts.oal_001.__main__ import main as oal_main
+
+    return oal_main(["--json"])
+
+
 def run_unit_tests() -> tuple[int, str, int | None, dict[str, int] | None]:
     result = subprocess.run(
         [
             sys.executable,
-            "-m",
-            "unittest",
-            "tests.test_oal_001_governor",
-            "tests.test_oal_001_runtime",
-            "-v",
+            "-I",
+            "-S",
+            "-B",
+            VALIDATOR_PATH,
+            "--_internal-unit-tests",
         ],
         cwd=REPO_ROOT,
         text=True,
@@ -705,7 +1016,14 @@ def unit_test_gate_errors(
 
 def run_dry_run() -> tuple[int, str]:
     result = subprocess.run(
-        [sys.executable, "-m", "scripts.oal_001", "--json"],
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            VALIDATOR_PATH,
+            "--_internal-dry-run",
+        ],
         cwd=REPO_ROOT,
         text=True,
         stdout=subprocess.PIPE,
@@ -880,7 +1198,7 @@ def _build_test_result(
         "static_checks": {"status": STATUS_PASS},
         "unit_tests": {
             "status": STATUS_PASS,
-            "command": "python -m unittest tests.test_oal_001_governor tests.test_oal_001_runtime -v",
+            "command": ISOLATED_UNIT_TEST_COMMAND,
             "count": test_count,
             "skipped": test_outcomes.get("skipped", 0),
             "outcome_details": dict(test_outcomes),
@@ -951,10 +1269,7 @@ def _final_test_result_errors(
     else:
         if unit_tests.get("status") != STATUS_PASS:
             errors.append("final unit-test status is not PASS")
-        if unit_tests.get("command") != (
-            "python -m unittest tests.test_oal_001_governor "
-            "tests.test_oal_001_runtime -v"
-        ):
+        if unit_tests.get("command") != ISOLATED_UNIT_TEST_COMMAND:
             errors.append("final unit-test command is invalid")
         count = unit_tests.get("count")
         if not isinstance(count, int) or count < MINIMUM_OAL_TEST_COUNT:
@@ -1359,9 +1674,7 @@ def validate_artifact_snapshot(
             and trace.get("source_state") == "clean_commit"
         )
         errors.extend(
-            _final_test_result_errors(
-                test_result, expected_run_id, promotion_eligible
-            )
+            _final_test_result_errors(test_result, expected_run_id, promotion_eligible)
         )
         final_status = (
             test_result.get("status") if isinstance(test_result, dict) else STATUS_FAIL
@@ -1635,16 +1948,36 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate or read-only verify OAL-001 local evidence."
     )
-    parser.add_argument(
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument(
         "--verify-existing",
         metavar="RUN_ID",
         type=_run_id_argument,
         help="Verify one finalized run without tests, dry-run or writes.",
     )
+    modes.add_argument(
+        "--_internal-unit-tests",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    modes.add_argument(
+        "--_internal-dry-run",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     try:
         args = parser.parse_args(argv)
     except SystemExit as exc:
         return int(exc.code)
+    if args._internal_unit_tests or args._internal_dry_run:
+        import_errors = python_shadowing_errors(REPO_ROOT)
+        if import_errors:
+            for item in import_errors:
+                error(item)
+            return 1
+        if args._internal_unit_tests:
+            return _internal_unit_tests()
+        return _internal_dry_run()
     if args.verify_existing:
         return _verify_existing(args.verify_existing)
     return _run_validation()

--- a/scripts/validate_oal_001.py
+++ b/scripts/validate_oal_001.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 """Validate OAL-001 boundaries, tests, dry-run and cross-artifact evidence."""
+# ruff: noqa: E402 -- isolation checks intentionally precede remaining imports
 
 from __future__ import annotations
 
 import sys
 
 
-if __name__ == "__main__" and not (
+INTERPRETER_ISOLATED = (
     sys.flags.isolated
     and sys.flags.no_site
     and sys.flags.safe_path
     and sys.flags.dont_write_bytecode
-):
+)
+if __name__ == "__main__" and not INTERPRETER_ISOLATED:
     print(
         "[validate-oal-001] ERROR: validator requires python -I -S -B",
         file=sys.stderr,
@@ -35,44 +37,47 @@ from typing import Literal, Mapping
 
 VALIDATOR_PATH = Path(__file__).resolve(strict=True)
 REPO_ROOT = VALIDATOR_PATH.parents[1]
-if __name__ == "__main__":
-    forbidden_import_roots = {
-        REPO_ROOT,
-        VALIDATOR_PATH.parent,
-        Path.cwd().resolve(),
-    }
-    unsafe_import_path = False
-    for raw_path in sys.path:
-        if not raw_path:
+forbidden_import_roots = {
+    REPO_ROOT,
+    VALIDATOR_PATH.parent,
+    Path.cwd().resolve(),
+}
+unsafe_import_path = False
+for raw_path in sys.path:
+    if not raw_path:
+        unsafe_import_path = True
+        break
+    try:
+        if Path(raw_path).resolve() in forbidden_import_roots:
             unsafe_import_path = True
             break
-        try:
-            if Path(raw_path).resolve() in forbidden_import_roots:
-                unsafe_import_path = True
-                break
-        except OSError:
-            unsafe_import_path = True
-            break
-    if unsafe_import_path:
-        print(
-            "[validate-oal-001] ERROR: repository paths precede the isolated import boundary",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-if str(REPO_ROOT) not in sys.path:
-    sys.path.append(str(REPO_ROOT))
-if __name__ == "__main__" and (
-    sys.path.count(str(REPO_ROOT)) != 1 or sys.path[-1] != str(REPO_ROOT)
-):
+    except OSError:
+        unsafe_import_path = True
+        break
+if __name__ == "__main__" and unsafe_import_path:
     print(
-        "[validate-oal-001] ERROR: repository import root is not isolated",
+        "[validate-oal-001] ERROR: repository paths precede the isolated import boundary",
         file=sys.stderr,
     )
     raise SystemExit(1)
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+repository_import_root_isolated = True
+if sys.path.count(str(REPO_ROOT)) != 1 or sys.path[-1] != str(REPO_ROOT):
+    repository_import_root_isolated = False
+    if __name__ == "__main__":
+        print(
+            "[validate-oal-001] ERROR: repository import root is not isolated",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+RUNTIME_ISOLATION_READY = (
+    INTERPRETER_ISOLATED and not unsafe_import_path and repository_import_root_isolated
+)
 
 OAL_CI_WORKFLOW_PATH = ".github/workflows/oal-001-validate.yml"
 EXPECTED_OAL_CI_WORKFLOW_SHA256 = (
-    "719D551B6E2BBE58CFC9CA5581F2B94E518A8331E3923923FB77B6F0F52E2123"
+    "FF6C9CFB8CA67235FF91FBEFD37B02876DE248131257450DEACAF0E8FF07F1E9"
 )
 ISOLATED_UNIT_TEST_COMMAND = (
     "python -I -S -B scripts/validate_oal_001.py --_internal-unit-tests"
@@ -88,6 +93,58 @@ PYTHON_IMPORT_SUFFIXES = tuple(
 PYTHON_SHADOW_MODULES = frozenset(
     {name.casefold() for name in sys.stdlib_module_names}
     | {"sitecustomize", "usercustomize"}
+)
+PROTECTED_SYS_IMPORT_STATE = frozenset(
+    {"__dict__", "meta_path", "modules", "path", "path_hooks", "path_importer_cache"}
+)
+ALLOWED_SYS_ATTRIBUTES = frozenset(
+    {
+        "argv",
+        "dont_write_bytecode",
+        "executable",
+        "flags",
+        "path",
+        "stderr",
+        "stdlib_module_names",
+        "version",
+        "version_info",
+    }
+)
+EXPECTED_VALIDATOR_SYS_PATH_CONTEXTS = (
+    "scan",
+    "membership",
+    "append",
+    "count",
+    "last",
+)
+EXPECTED_VALIDATOR_SYS_PATH_STATEMENTS = (
+    """for raw_path in sys.path:
+    if not raw_path:
+        unsafe_import_path = True
+        break
+    try:
+        if Path(raw_path).resolve() in forbidden_import_roots:
+            unsafe_import_path = True
+            break
+    except OSError:
+        unsafe_import_path = True
+        break
+""",
+    """if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+""",
+    """if sys.path.count(str(REPO_ROOT)) != 1 or sys.path[-1] != str(REPO_ROOT):
+    repository_import_root_isolated = False
+    if __name__ == "__main__":
+        print(
+            "[validate-oal-001] ERROR: repository import root is not isolated",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+""",
+)
+FORBIDDEN_REFLECTIVE_ATTRIBUTES = frozenset(
+    {"__dict__", "__getattr__", "__getattribute__", "__globals__"}
 )
 PACKAGE_FILES = (
     "scripts/oal_001/__init__.py",
@@ -226,7 +283,7 @@ FORBIDDEN_SOURCE_SNIPPETS = (
     "exec(",
 )
 RUN_ID_PATTERN = re.compile(r"^OAL-001-[A-F0-9]{16}$")
-MINIMUM_OAL_TEST_COUNT = 58
+MINIMUM_OAL_TEST_COUNT = 61
 TARGET_PYTHON = (3, 11)
 STATUS_PASS = "PASS"
 STATUS_RUNTIME_GAP = "PASS_WITH_RUNTIME_GAP"
@@ -476,13 +533,47 @@ def _call_signature(argument: ast.AST) -> tuple[str, ...] | None:
     return tuple(values)
 
 
-def _is_sys_path(node: ast.AST) -> bool:
-    return (
+def _pull_request_trigger_errors(workflow_source: bytes) -> list[str]:
+    try:
+        lines = workflow_source.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        return [f"OAL workflow is not valid UTF-8: {exc}"]
+
+    top_level_lines = [line for line in lines if line and not line[0].isspace()]
+    if top_level_lines != [
+        "name: Validate OAL-001",
+        "on:",
+        "permissions:",
+        "jobs:",
+    ]:
+        return ["OAL workflow top-level mapping does not match the exact contract"]
+
+    trigger_indexes = [index for index, line in enumerate(lines) if line == "on:"]
+    if len(trigger_indexes) != 1:
+        return ["OAL workflow must define exactly one top-level on block"]
+
+    trigger_lines: list[str] = []
+    for line in lines[trigger_indexes[0] + 1 :]:
+        if line and not line[0].isspace():
+            break
+        if line.strip():
+            trigger_lines.append(line)
+    if trigger_lines != ["  pull_request: {}"]:
+        return [
+            "OAL workflow trigger must be exactly one unfiltered pull_request event"
+        ]
+    return []
+
+
+def _sys_import_state_attribute(node: ast.AST) -> str | None:
+    if (
         isinstance(node, ast.Attribute)
         and isinstance(node.value, ast.Name)
         and node.value.id == "sys"
-        and node.attr == "path"
-    )
+        and node.attr in PROTECTED_SYS_IMPORT_STATE
+    ):
+        return node.attr
+    return None
 
 
 def _is_repo_root_string(node: ast.AST) -> bool:
@@ -497,62 +588,259 @@ def _is_repo_root_string(node: ast.AST) -> bool:
     )
 
 
-def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
-    method_calls: list[ast.Call] = []
-    assigned = False
-    for node in ast.walk(tree):
+def _is_negative_one(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and node.operand.value == 1
+    )
+
+
+def _module_statement(
+    node: ast.AST, parents: Mapping[ast.AST, ast.AST]
+) -> ast.stmt | None:
+    current = node
+    parent = parents.get(current)
+    while parent is not None and not isinstance(parent, ast.Module):
+        current = parent
+        parent = parents.get(current)
+    if isinstance(current, ast.stmt) and isinstance(parent, ast.Module):
+        return current
+    return None
+
+
+def _is_allowlisted_getattr_call(node: ast.Call) -> bool:
+    if not (
+        isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and not node.keywords
+    ):
+        return False
+    if (
+        len(node.args) == 3
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "stat"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value == "FILE_ATTRIBUTE_REPARSE_POINT"
+    ):
+        return True
+    return (
+        len(node.args) == 2
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "policy"
+        and isinstance(node.args[1], ast.Name)
+        and node.args[1].id == "field"
+    )
+
+
+def _validator_sys_path_context(
+    node: ast.Attribute, parents: Mapping[ast.AST, ast.AST]
+) -> str | None:
+    parent = parents.get(node)
+    if (
+        isinstance(parent, ast.For)
+        and parent.iter is node
+        and isinstance(parent.target, ast.Name)
+        and parent.target.id == "raw_path"
+    ):
+        return "scan"
+    if (
+        isinstance(parent, ast.Compare)
+        and _is_repo_root_string(parent.left)
+        and len(parent.ops) == 1
+        and isinstance(parent.ops[0], ast.NotIn)
+        and len(parent.comparators) == 1
+        and parent.comparators[0] is node
+    ):
+        return "membership"
+    if (
+        isinstance(parent, ast.Attribute)
+        and parent.value is node
+        and parent.attr in {"append", "count"}
+    ):
+        call = parents.get(parent)
         if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and _is_sys_path(node.func.value)
+            isinstance(call, ast.Call)
+            and call.func is parent
+            and len(call.args) == 1
+            and _is_repo_root_string(call.args[0])
+            and not call.keywords
         ):
-            method_calls.append(node)
-        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
-            targets: list[ast.AST] = []
-            if isinstance(node, ast.Assign):
-                targets.extend(node.targets)
-            elif isinstance(node, ast.Delete):
-                targets.extend(node.targets)
-            else:
-                targets.append(node.target)
-            if any(
-                _is_sys_path(target)
-                or (isinstance(target, ast.Subscript) and _is_sys_path(target.value))
-                for target in targets
+            return parent.attr
+    if (
+        isinstance(parent, ast.Subscript)
+        and parent.value is node
+        and _is_negative_one(parent.slice)
+    ):
+        comparison = parents.get(parent)
+        if (
+            isinstance(comparison, ast.Compare)
+            and comparison.left is parent
+            and len(comparison.ops) == 1
+            and isinstance(comparison.ops[0], ast.NotEq)
+            and len(comparison.comparators) == 1
+            and _is_repo_root_string(comparison.comparators[0])
+        ):
+            return "last"
+    return None
+
+
+def _import_path_boundary_errors(rel_path: str, tree: ast.AST) -> list[str]:
+    errors: list[str] = []
+    parents: dict[ast.AST, ast.AST] = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    import_state_references: list[ast.Attribute] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bound_name = alias.asname or alias.name.partition(".")[0]
+                if alias.name == "sys":
+                    if alias.asname is not None:
+                        errors.append(f"sys import alias is forbidden in {rel_path}")
+                elif alias.name.startswith("sys.") or bound_name == "sys":
+                    errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "sys" or (
+                node.module is not None and node.module.startswith("sys.")
             ):
-                assigned = True
+                errors.append(f"from-sys imports are forbidden in {rel_path}")
+            if any(
+                alias.name in {"*", "__dict__", "__globals__", "sys", "_sys"}
+                or (alias.asname or alias.name) == "sys"
+                for alias in node.names
+            ):
+                errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, ast.Name) and node.id == "sys":
+            parent = parents.get(node)
+            if not (
+                isinstance(node.ctx, ast.Load)
+                and isinstance(parent, ast.Attribute)
+                and parent.value is node
+            ):
+                errors.append(f"indirect sys access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "sys"
+            and node.attr not in ALLOWED_SYS_ATTRIBUTES
+        ):
+            errors.append(f"sys attribute {node.attr!r} is forbidden in {rel_path}")
+        elif isinstance(node, ast.Attribute) and node.attr in {"sys", "_sys"}:
+            errors.append(f"indirect sys attribute access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Attribute)
+            and node.attr in FORBIDDEN_REFLECTIVE_ATTRIBUTES
+        ):
+            errors.append(f"reflective attribute access is forbidden in {rel_path}")
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in {"getattr", "setattr"}
+            and not _is_allowlisted_getattr_call(node)
+        ):
+            errors.append(f"reflective attribute call is forbidden in {rel_path}")
+        elif isinstance(node, ast.arg) and node.arg == "sys":
+            errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == "sys":
+                errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, ast.ExceptHandler) and node.name == "sys":
+            errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name == "sys":
+            errors.append(f"sys rebinding is forbidden in {rel_path}")
+        elif isinstance(node, (ast.Global, ast.Nonlocal)) and "sys" in node.names:
+            errors.append(f"sys rebinding is forbidden in {rel_path}")
+
+        if isinstance(node, ast.Attribute) and _sys_import_state_attribute(node):
+            import_state_references.append(node)
 
     if rel_path != "scripts/validate_oal_001.py":
-        if method_calls or assigned:
-            return [f"Python import-path mutation is forbidden in {rel_path}"]
-        return []
+        if import_state_references:
+            errors.append(f"Python import-state access is forbidden in {rel_path}")
+        return sorted(set(errors))
 
-    append_calls = [
-        node
-        for node in method_calls
-        if node.func.attr == "append"
-        and len(node.args) == 1
-        and _is_repo_root_string(node.args[0])
-        and not node.keywords
-    ]
-    count_calls = [
-        node
-        for node in method_calls
-        if node.func.attr == "count"
-        and len(node.args) == 1
-        and _is_repo_root_string(node.args[0])
-        and not node.keywords
-    ]
-    if (
-        assigned
-        or len(append_calls) != 1
-        or len(count_calls) != 1
-        or len(method_calls) != 2
+    contexts: list[str] = []
+    context_statements: dict[str, ast.stmt] = {}
+    for node in sorted(
+        import_state_references,
+        key=lambda item: (item.lineno, item.col_offset),
     ):
-        return [
+        attribute = _sys_import_state_attribute(node)
+        context = _validator_sys_path_context(node, parents)
+        if attribute != "path" or context is None:
+            errors.append(
+                "validator may access sys.path only in the exact isolated bootstrap"
+            )
+        else:
+            contexts.append(context)
+            statement = _module_statement(node, parents)
+            if statement is not None:
+                context_statements[context] = statement
+    if tuple(contexts) != EXPECTED_VALIDATOR_SYS_PATH_CONTEXTS:
+        errors.append(
             "validator import path must append REPO_ROOT exactly once after interpreter paths"
-        ]
-    return []
+        )
+    elif isinstance(tree, ast.Module):
+        scan_statement = context_statements.get("scan")
+        membership_statement = context_statements.get("membership")
+        append_statement = context_statements.get("append")
+        count_statement = context_statements.get("count")
+        last_statement = context_statements.get("last")
+        try:
+            statement_indexes = (
+                tree.body.index(scan_statement),
+                tree.body.index(membership_statement),
+                tree.body.index(count_statement),
+            )
+        except ValueError:
+            statement_indexes = (-1, -1, -1)
+        if not (
+            isinstance(scan_statement, ast.For)
+            and isinstance(membership_statement, ast.If)
+            and membership_statement is append_statement
+            and isinstance(count_statement, ast.If)
+            and count_statement is last_statement
+            and len(
+                {
+                    id(item)
+                    for item in (
+                        scan_statement,
+                        membership_statement,
+                        count_statement,
+                    )
+                }
+            )
+            == 3
+            and statement_indexes[0] < statement_indexes[1] < statement_indexes[2]
+        ):
+            errors.append(
+                "validator sys.path bootstrap must use three ordered top-level statements"
+            )
+        else:
+            actual_shapes = tuple(
+                ast.dump(statement, include_attributes=False)
+                for statement in (
+                    scan_statement,
+                    membership_statement,
+                    count_statement,
+                )
+            )
+            expected_shapes = tuple(
+                ast.dump(
+                    ast.parse(source, feature_version=(3, 11)).body[0],
+                    include_attributes=False,
+                )
+                for source in EXPECTED_VALIDATOR_SYS_PATH_STATEMENTS
+            )
+            if actual_shapes != expected_shapes:
+                errors.append(
+                    "validator sys.path bootstrap statements do not match the exact AST contract"
+                )
+    return sorted(set(errors))
 
 
 def _is_process_api_name(name: str) -> bool:
@@ -820,6 +1108,7 @@ def static_errors() -> list[str]:
 
     workflow_source = _read_repo_file(OAL_CI_WORKFLOW_PATH)
     normalized_workflow = workflow_source.replace(b"\r\n", b"\n")
+    errors.extend(_pull_request_trigger_errors(normalized_workflow))
     if (
         b"\r" in normalized_workflow
         or hashlib.sha256(normalized_workflow).hexdigest().upper()
@@ -1944,7 +2233,7 @@ def _run_validation() -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
+def _dispatch(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate or read-only verify OAL-001 local evidence."
     )
@@ -1981,6 +2270,26 @@ def main(argv: list[str] | None = None) -> int:
     if args.verify_existing:
         return _verify_existing(args.verify_existing)
     return _run_validation()
+
+
+def _runtime_isolation_errors() -> list[str]:
+    errors: list[str] = []
+    if not INTERPRETER_ISOLATED:
+        errors.append("validator requires python -I -S -B")
+    if unsafe_import_path:
+        errors.append("repository paths precede the isolated import boundary")
+    if not repository_import_root_isolated:
+        errors.append("repository import root is not isolated")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    isolation_errors = _runtime_isolation_errors()
+    if isolation_errors:
+        for item in isolation_errors:
+            error(item)
+        return 1
+    return _dispatch(argv)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/observatory/synthetic_harmless_cycle.json
+++ b/tests/fixtures/observatory/synthetic_harmless_cycle.json
@@ -1,0 +1,29 @@
+{
+  "fixture_id": "OAL-001-SYNTHETIC-CURRENT-SLICE-001",
+  "fixture_kind": "synthetic_current_slice",
+  "historical_evidence": false,
+  "observations": [
+    "synthetic-signal-01",
+    "synthetic-signal-02",
+    "synthetic-signal-03",
+    "synthetic-signal-04",
+    "synthetic-signal-05",
+    "synthetic-signal-06",
+    "synthetic-signal-07",
+    "synthetic-signal-08",
+    "synthetic-signal-09",
+    "synthetic-signal-10",
+    "synthetic-signal-11",
+    "synthetic-signal-12",
+    "synthetic-signal-13",
+    "synthetic-signal-14",
+    "synthetic-signal-15",
+    "synthetic-signal-16",
+    "synthetic-signal-17",
+    "synthetic-signal-18",
+    "synthetic-signal-19",
+    "synthetic-signal-20"
+  ],
+  "expected_baseline_exploration_share": 0.25,
+  "expected_candidate_exploration_share": 0.3
+}

--- a/tests/test_oal_001_governor.py
+++ b/tests/test_oal_001_governor.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from scripts.oal_001.governor import Governor, PatchSpec, load_policy
+from scripts.oal_001.runtime import (
+    CYCLE_ID,
+    EXPECTED_EFFECT,
+    FALLBACK_CRITERION,
+    TARGET_PATH,
+    TRIGGER,
+    build_harmless_patch,
+    read_managed_source,
+    sha256_bytes,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class Oal001GovernorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy(REPO_ROOT)
+        source = read_managed_source(REPO_ROOT, TARGET_PATH)
+        self.patch = build_harmless_patch(source.decode("utf-8"), sha256_bytes(source))
+        self.governor = Governor(self.policy)
+
+    def test_policy_has_one_exact_mutable_path(self) -> None:
+        self.assertEqual(self.policy.mutable_paths, (TARGET_PATH,))
+        self.assertEqual(self.policy.external_mutation_count, 0)
+        self.assertEqual(self.policy.historical_fixture_status, "unavailable")
+
+    def test_harmless_patch_is_approved_on_allowed_branch(self) -> None:
+        decision = self.governor.review(self.patch, "codex/observatory-selfmod-001")
+
+        self.assertTrue(decision.approved)
+        self.assertEqual(decision.reasons, ())
+
+    def test_governor_change_is_automatically_rejected(self) -> None:
+        patch = replace(
+            self.patch,
+            target_path="scripts/oal_001/governor.py",
+            changed_paths=("scripts/oal_001/governor.py",),
+        )
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn("protected_path:scripts/oal_001/governor.py", decision.reasons)
+        self.assertIn("path_not_mutable:scripts/oal_001/governor.py", decision.reasons)
+
+    def test_every_protected_surface_is_rejected(self) -> None:
+        concrete_paths = {
+            ".codex": ".codex/safety_policy.yaml",
+            ".git": ".git/config",
+            "docs/governance": "docs/governance/proposed.md",
+            "raw/exports": "raw/exports/proposed.json",
+        }
+        for protected in self.policy.protected_paths:
+            path = concrete_paths.get(protected, protected)
+            with self.subTest(path=path):
+                patch = replace(
+                    self.patch,
+                    target_path=path,
+                    changed_paths=(path,),
+                )
+
+                decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+                self.assertFalse(decision.approved)
+                self.assertIn(f"protected_path:{path}", decision.reasons)
+                self.assertIn(f"path_not_mutable:{path}", decision.reasons)
+
+    def test_same_cycle_control_and_authorizing_test_is_rejected(self) -> None:
+        paths = ("scripts/oal_001/governor.py", "tests/test_oal_001_governor.py")
+        patch = replace(self.patch, target_path=paths[0], changed_paths=paths)
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn(
+            "same_cycle_control_and_authorizing_test_change", decision.reasons
+        )
+
+    def test_wrong_branch_is_rejected(self) -> None:
+        decision = self.governor.review(self.patch, "main")
+
+        self.assertFalse(decision.approved)
+        self.assertIn("branch_outside_allowed_lane", decision.reasons)
+
+    def test_traversal_path_is_rejected(self) -> None:
+        patch = replace(
+            self.patch,
+            target_path="../scripts/oal_001/observatory.py",
+            changed_paths=("../scripts/oal_001/observatory.py",),
+        )
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertTrue(
+            any(reason.startswith("invalid_path:") for reason in decision.reasons)
+        )
+
+    def test_absolute_path_is_rejected(self) -> None:
+        path = "C:/candidate/observatory.py"
+        patch = replace(self.patch, target_path=path, changed_paths=(path,))
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn(f"invalid_path:{path}", decision.reasons)
+
+    def test_authorizing_test_alone_is_protected_but_not_same_cycle(self) -> None:
+        path = "tests/test_oal_001_governor.py"
+        patch = replace(self.patch, target_path=path, changed_paths=(path,))
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn(f"protected_path:{path}", decision.reasons)
+        self.assertNotIn(
+            "same_cycle_control_and_authorizing_test_change", decision.reasons
+        )
+
+    def test_missing_required_metadata_is_rejected(self) -> None:
+        patch = PatchSpec(
+            cycle_id=CYCLE_ID,
+            target_path=TARGET_PATH,
+            changed_paths=(TARGET_PATH,),
+            expected_before_sha256=self.patch.expected_before_sha256,
+            replacement_text=self.patch.replacement_text,
+            trigger=TRIGGER,
+            hypothesis="",
+            expected_effect=EXPECTED_EFFECT,
+            fallback_criterion=FALLBACK_CRITERION,
+        )
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn("missing_metadata:hypothesis", decision.reasons)
+
+    def test_secret_like_replacement_is_rejected(self) -> None:
+        secret_like = 'password = "' + ("x" * 12) + '"\n'
+        patch = replace(self.patch, replacement_text=secret_like)
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn("secret_like_content", decision.reasons)
+
+    def test_duplicate_changed_path_is_rejected(self) -> None:
+        patch = replace(self.patch, changed_paths=(TARGET_PATH, TARGET_PATH))
+
+        decision = self.governor.review(patch, "codex/observatory-selfmod-001")
+
+        self.assertFalse(decision.approved)
+        self.assertIn("duplicate_changed_path", decision.reasons)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -4,7 +4,6 @@ import ast
 import copy
 import json
 import os
-import stat
 import sys
 import tempfile
 import unittest
@@ -39,6 +38,7 @@ from scripts.validate_oal_001 import (
     EXIT_RUNTIME_GAP,
     MINIMUM_OAL_TEST_COUNT,
     PROTECTED_IMPORT_FILES,
+    PYTHON_FILES,
     STATUS_PASS,
     STATUS_RUNTIME_GAP,
     VALIDATOR_PATH,
@@ -299,7 +299,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                 read_managed_source(root, TARGET_PATH)
 
     def test_windows_reparse_attribute_is_rejected(self) -> None:
-        attributes = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        attributes = 0x400
         fake_stat = SimpleNamespace(st_file_attributes=attributes)
         with mock_patch.object(Path, "lstat", return_value=fake_stat):
             self.assertTrue(_is_reparse_point(Path("synthetic-junction")))
@@ -1244,28 +1244,179 @@ class Oal001RuntimeTests(unittest.TestCase):
         read_tree = ast.parse("import sys\nexecutable = sys.executable\n")
         self.assertEqual(_import_path_boundary_errors("synthetic.py", read_tree), [])
 
-    def test_reflective_getattr_allowlist_is_bound_to_fixed_call(self) -> None:
-        spoofed_tree = ast.parse(
-            "import os\n"
-            "policy = os\n"
-            "field = 'system'\n"
-            "operation = getattr(policy, field)\n"
+    def test_getattr_allowlist_accepts_only_four_canonical_sites(self) -> None:
+        expected_paths = (
+            "scripts/oal_001/git_read.py",
+            "scripts/oal_001/governor.py",
+            "scripts/oal_001/runtime.py",
+            "scripts/validate_oal_001.py",
         )
-        self.assertIn(
-            "reflective attribute call is forbidden in synthetic.py",
-            _import_path_boundary_errors("synthetic.py", spoofed_tree),
-        )
-        self.assertIn(
-            "indirect process API access is forbidden in synthetic.py",
-            _subprocess_boundary_errors("synthetic.py", spoofed_tree),
-        )
+        actual_paths: list[str] = []
+        for rel_path in PYTHON_FILES:
+            tree = ast.parse(
+                (REPO_ROOT / rel_path).read_text(encoding="utf-8"),
+                filename=rel_path,
+                feature_version=(3, 11),
+            )
+            direct_calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+            ]
+            if direct_calls:
+                actual_paths.append(rel_path)
+            if rel_path in expected_paths:
+                with self.subTest(rel_path=rel_path):
+                    self.assertEqual(len(direct_calls), 1)
+                    self.assertEqual(_import_path_boundary_errors(rel_path, tree), [])
+                    self.assertEqual(_subprocess_boundary_errors(rel_path, tree), [])
+            else:
+                with self.subTest(rel_path=rel_path):
+                    self.assertEqual(direct_calls, [])
 
-        governor_path = "scripts/oal_001/governor.py"
-        governor_tree = ast.parse(
-            (REPO_ROOT / governor_path).read_text(encoding="utf-8")
+        self.assertEqual(tuple(actual_paths), expected_paths)
+
+    def test_getattr_allowlist_rejects_wrong_shapes_and_contexts(self) -> None:
+        canonical_function = """def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+"""
+        canonical_source = f"import stat\n{canonical_function}"
+        canonical_path = "scripts/oal_001/governor.py"
+        mutants = {
+            "legacy dynamic fields": (
+                "import os\npolicy = os\nfield = 'system'\n"
+                "operation = getattr(policy, field)\n"
+            ),
+            "noncanonical path": canonical_source,
+            "module-level call": (
+                "import stat\n"
+                "value = getattr(stat, 'FILE_ATTRIBUTE_REPARSE_POINT', 0)\n"
+            ),
+            "wrong function": canonical_source.replace(
+                "def _is_reparse_point", "def other", 1
+            ),
+            "side-effectful default": canonical_source.replace(
+                ", 0))", ", side_effect()))", 1
+            ),
+            "boolean default": canonical_source.replace(", 0))", ", False))", 1),
+            "alternate integer default": canonical_source.replace(
+                ", 0))", ", 0x400))", 1
+            ),
+            "two arguments": canonical_source.replace(
+                ', "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                ', "FILE_ATTRIBUTE_REPARSE_POINT")',
+                1,
+            ),
+            "four arguments": canonical_source.replace(
+                ', "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                ', "FILE_ATTRIBUTE_REPARSE_POINT", 0, None)',
+                1,
+            ),
+            "keyword arguments": canonical_source.replace(
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                'getattr(stat, name="FILE_ATTRIBUTE_REPARSE_POINT", default=0)',
+                1,
+            ),
+            "wrong receiver": canonical_source.replace(
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                'getattr(os, "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                1,
+            ),
+            "wrong attribute": canonical_source.replace(
+                '"FILE_ATTRIBUTE_REPARSE_POINT"', '"system"', 1
+            ),
+            "duplicate getter": canonical_source.replace(
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0) or '
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)',
+                1,
+            ),
+        }
+        for name, source in mutants.items():
+            rel_path = "synthetic.py" if name == "noncanonical path" else canonical_path
+            with self.subTest(name=name):
+                tree = ast.parse(source, feature_version=(3, 11))
+                self.assertTrue(_import_path_boundary_errors(rel_path, tree))
+                self.assertTrue(_subprocess_boundary_errors(rel_path, tree))
+
+        missing_call_tree = ast.parse(
+            canonical_source.replace(
+                'getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)', "0", 1
+            ),
+            feature_version=(3, 11),
         )
-        self.assertEqual(_import_path_boundary_errors(governor_path, governor_tree), [])
-        self.assertEqual(_subprocess_boundary_errors(governor_path, governor_tree), [])
+        self.assertTrue(_import_path_boundary_errors(canonical_path, missing_call_tree))
+
+    def test_getattr_allowlist_rejects_shadowing_aliases_and_rebinding(self) -> None:
+        canonical_function = """def _is_reparse_point(path: Path) -> bool:
+    try:
+        attributes = path.lstat().st_file_attributes
+    except (AttributeError, FileNotFoundError, OSError):
+        return False
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+"""
+        canonical_source = f"import stat\n{canonical_function}"
+        mutants = {
+            "getattr assignment": canonical_source.replace(
+                "import stat\n", "import stat\ngetattr = helper\n", 1
+            ),
+            "getattr function": canonical_source.replace(
+                "import stat\n",
+                "import stat\ndef getattr(*args):\n    return 0\n",
+                1,
+            ),
+            "getattr import alias": canonical_source.replace(
+                "import stat\n", "import stat\nimport helpers as getattr\n", 1
+            ),
+            "getattr function argument": canonical_source.replace(
+                "def _is_reparse_point(path: Path)",
+                "def _is_reparse_point(path: Path, getattr=getattr)",
+                1,
+            ),
+            "getattr reference alias": canonical_source.replace(
+                "import stat\n", "import stat\nreflect = getattr\n", 1
+            ),
+            "indirect builtins getattr": (
+                f"{canonical_source}import os\nimport codecs\n"
+                "getter = codecs.__builtins__['getattr']\n"
+                "operation = getter(os, 'system')\n"
+            ),
+            "stat assignment": canonical_source.replace(
+                "import stat\n", "import stat\nstat = other\n", 1
+            ),
+            "stat import alias": canonical_source.replace(
+                "import stat\n", "import helpers as stat\n", 1
+            ),
+            "stat reference alias": canonical_source.replace(
+                "import stat\n", "import stat\nstat_alias = stat\n", 1
+            ),
+            "stat attribute write": canonical_source.replace(
+                "import stat\n",
+                "import stat\nstat.FILE_ATTRIBUTE_REPARSE_POINT = 0\n",
+                1,
+            ),
+            "star import": canonical_source.replace(
+                "import stat\n", "import stat\nfrom helpers import *\n", 1
+            ),
+            "duplicate canonical function": (
+                f"import stat\n{canonical_function}{canonical_function}"
+            ),
+        }
+        for name, source in mutants.items():
+            with self.subTest(name=name):
+                tree = ast.parse(source, feature_version=(3, 11))
+                self.assertTrue(
+                    _import_path_boundary_errors("scripts/oal_001/governor.py", tree)
+                )
+                self.assertTrue(
+                    _subprocess_boundary_errors("scripts/oal_001/governor.py", tree)
+                )
 
     def test_import_state_aliases_and_mutations_are_rejected(self) -> None:
         validator_source = (REPO_ROOT / "scripts/validate_oal_001.py").read_text(

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -1072,6 +1072,74 @@ class Oal001RuntimeTests(unittest.TestCase):
                 )
                 self.assertTrue(bypass_errors)
 
+    def test_subprocess_import_is_canonical_and_rebinding_is_rejected(self) -> None:
+        expected_paths = {
+            "scripts/oal_001/git_read.py",
+            "scripts/validate_oal_001.py",
+        }
+        for rel_path in PYTHON_FILES:
+            tree = ast.parse(
+                (REPO_ROOT / rel_path).read_text(encoding="utf-8"),
+                filename=rel_path,
+                feature_version=(3, 11),
+            )
+            canonical_imports = [
+                node
+                for node in tree.body
+                if isinstance(node, ast.Import)
+                and len(node.names) == 1
+                and node.names[0].name == "subprocess"
+                and node.names[0].asname is None
+            ]
+            with self.subTest(rel_path=rel_path):
+                self.assertEqual(
+                    len(canonical_imports), int(rel_path in expected_paths)
+                )
+                self.assertNotIn(
+                    f"canonical subprocess import contract does not match in {rel_path}",
+                    _subprocess_boundary_errors(rel_path, tree),
+                )
+
+        canonical_path = "scripts/validate_oal_001.py"
+        canonical_source = (REPO_ROOT / canonical_path).read_text(encoding="utf-8")
+        rebinding_mutants = {
+            "assignment": canonical_source.replace(
+                "import subprocess\n",
+                "import subprocess\nsubprocess = helper\n",
+                1,
+            ),
+            "argument": canonical_source + "\ndef synthetic(subprocess):\n    pass\n",
+            "mapping pattern": (
+                canonical_source
+                + "\nmatch {}:\n    case {**subprocess}:\n        pass\n"
+            ),
+            "from import": canonical_source.replace(
+                "import subprocess\n",
+                "from helper import run as subprocess\n",
+                1,
+            ),
+        }
+        expected_rebinding = (
+            "subprocess rebinding is forbidden in scripts/validate_oal_001.py"
+        )
+        for name, source in rebinding_mutants.items():
+            with self.subTest(name=name):
+                errors = _subprocess_boundary_errors(
+                    canonical_path,
+                    ast.parse(source, feature_version=(3, 11)),
+                )
+                self.assertIn(expected_rebinding, errors)
+
+        missing_import = canonical_source.replace("import subprocess\n", "", 1)
+        self.assertIn(
+            "canonical subprocess import contract does not match in "
+            "scripts/validate_oal_001.py",
+            _subprocess_boundary_errors(
+                canonical_path,
+                ast.parse(missing_import, feature_version=(3, 11)),
+            ),
+        )
+
     def test_workflow_and_validator_use_isolated_import_bootstrap(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/oal-001-validate.yml").read_text(
             encoding="utf-8"
@@ -1248,6 +1316,19 @@ class Oal001RuntimeTests(unittest.TestCase):
 
         read_tree = ast.parse("import sys\nexecutable = sys.executable\n")
         self.assertEqual(_import_path_boundary_errors("synthetic.py", read_tree), [])
+
+    def test_sys_match_mapping_rebinding_is_rejected(self) -> None:
+        rel_path = "scripts/validate_oal_001.py"
+        validator_source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        modified_tree = ast.parse(
+            validator_source + "\nmatch {}:\n    case {**sys}:\n        pass\n",
+            feature_version=(3, 11),
+        )
+
+        self.assertIn(
+            "sys rebinding is forbidden in scripts/validate_oal_001.py",
+            _import_path_boundary_errors(rel_path, modified_tree),
+        )
 
     def test_getattr_allowlist_accepts_only_four_canonical_sites(self) -> None:
         expected_paths = (

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -72,6 +72,11 @@ from scripts.validate_oal_001 import (
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BASE_SHA = "e" * 40
 BRANCH = "codex/observatory-selfmod-001"
+ABSOLUTE_GIT_EXECUTABLE_FIXTURE = (
+    Path(r"C:\Program Files\Git\cmd\git.exe")
+    if os.name == "nt"
+    else Path("/usr/bin/git")
+)
 
 
 class Oal001RuntimeTests(unittest.TestCase):
@@ -878,7 +883,7 @@ class Oal001RuntimeTests(unittest.TestCase):
             self.assertTrue(any("completion marker" in item for item in errors))
 
     def test_git_read_uses_hardened_absolute_process_context(self) -> None:
-        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        executable = ABSOLUTE_GIT_EXECUTABLE_FIXTURE
         completed = SimpleNamespace(
             returncode=0,
             stdout=BRANCH + "\n",
@@ -908,7 +913,7 @@ class Oal001RuntimeTests(unittest.TestCase):
     def test_worktree_status_preserves_porcelain_columns_without_tracking_data(
         self,
     ) -> None:
-        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        executable = ABSOLUTE_GIT_EXECUTABLE_FIXTURE
         completed = SimpleNamespace(
             returncode=0,
             stdout=" M scripts/oal_001/runtime.py\n?? untracked.txt\n",
@@ -999,7 +1004,7 @@ class Oal001RuntimeTests(unittest.TestCase):
         self.assertTrue(
             git_read.is_ignored(REPO_ROOT, "raw/exports/local-private/oal-001")
         )
-        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        executable = ABSOLUTE_GIT_EXECUTABLE_FIXTURE
         with mock_patch.object(
             git_read, "_resolve_git_executable", return_value=executable
         ):

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -26,6 +26,7 @@ from scripts.oal_001.runtime import (
     _git_status,
     build_harmless_patch,
     execute_cycle,
+    git_status_is_clean,
     load_fixture,
     parse_strategy_source,
     read_managed_source,
@@ -34,6 +35,7 @@ from scripts.oal_001.runtime import (
     write_cycle_artifacts,
 )
 from scripts.validate_oal_001 import (
+    EXIT_NOT_PROMOTION_READY,
     EXIT_RUNTIME_GAP,
     MINIMUM_OAL_TEST_COUNT,
     STATUS_PASS,
@@ -45,6 +47,8 @@ from scripts.validate_oal_001 import (
     _capture_artifact_snapshot,
     _finalize_evidence,
     _finalized_snapshot,
+    _replace_snapshot_bytes,
+    _snapshot_promotion_eligible,
     _subprocess_boundary_errors,
     main as validator_main,
     run_unit_tests,
@@ -71,8 +75,8 @@ class Oal001RuntimeTests(unittest.TestCase):
             self.policy,
             BRANCH,
             BASE_SHA,
-            git_status_before="## synthetic-test",
-            git_status_after="## synthetic-test",
+            git_status_before="",
+            git_status_after="",
             temp_parent=temp_parent,
         )
 
@@ -137,6 +141,37 @@ class Oal001RuntimeTests(unittest.TestCase):
 
         self.assertIn("external_mutation_count must be zero", errors)
 
+    def test_legacy_branch_header_evidence_returns_controlled_errors(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            result = self.execute()
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+            snapshot = _capture_artifact_snapshot(output_dir)
+            legacy_trace = copy.deepcopy(result.trace)
+            legacy_trace["git_status"]["before"] = "## synthetic-test"
+            legacy_trace["git_status"]["after"] = "## synthetic-test"
+            legacy_snapshot = _replace_snapshot_bytes(
+                snapshot,
+                "mutation_trace.json",
+                (json.dumps(legacy_trace, sort_keys=True) + "\n").encode("utf-8"),
+            )
+
+            errors = validate_artifact_snapshot(
+                legacy_snapshot, output_dir, lifecycle="prepared"
+            )
+
+        self.assertTrue(
+            any("trace Git status cannot derive a run ID" in item for item in errors)
+        )
+
     def test_invented_evaluation_check_is_rejected(self) -> None:
         trace = copy.deepcopy(self.execute().trace)
         trace["evaluation"]["checks"] = {"invented_check": True}
@@ -194,8 +229,8 @@ class Oal001RuntimeTests(unittest.TestCase):
                         self.policy,
                         BRANCH,
                         BASE_SHA,
-                        git_status_before="## synthetic-test",
-                        git_status_after="## synthetic-test",
+                        git_status_before="",
+                        git_status_after="",
                         temp_parent=temp_parent,
                     )
 
@@ -343,6 +378,7 @@ class Oal001RuntimeTests(unittest.TestCase):
         run_id: str,
         python_version: str = "3.11.9",
         python_version_info: tuple[int, int] = (3, 11),
+        promotion_eligible: bool = True,
     ) -> dict[str, object]:
         return _build_test_result(
             run_id=run_id,
@@ -353,6 +389,7 @@ class Oal001RuntimeTests(unittest.TestCase):
             artifact_errors=[],
             python_version=python_version,
             python_version_info=python_version_info,
+            promotion_eligible=promotion_eligible,
         )
 
     def test_cross_artifact_replay_tampering_is_rejected(self) -> None:
@@ -416,6 +453,9 @@ class Oal001RuntimeTests(unittest.TestCase):
 
     def test_validation_status_requires_python_3_11_for_pass(self) -> None:
         passing = self._test_result("OAL-001-" + "A" * 16)
+        prepared = self._test_result(
+            "OAL-001-" + "A" * 16, promotion_eligible=False
+        )
         runtime_gap = self._test_result(
             "OAL-001-" + "A" * 16,
             python_version="3.12.10",
@@ -430,14 +470,172 @@ class Oal001RuntimeTests(unittest.TestCase):
             artifact_errors=["synthetic failure"],
             python_version="3.11.9",
             python_version_info=(3, 11),
+            promotion_eligible=True,
         )
 
         self.assertEqual(passing["status"], STATUS_PASS)
         self.assertTrue(passing["promotion_ready"])
+        self.assertEqual(prepared["status"], STATUS_PASS)
+        self.assertFalse(prepared["evidence_complete"])
+        self.assertFalse(prepared["promotion_ready"])
         self.assertEqual(runtime_gap["status"], STATUS_RUNTIME_GAP)
         self.assertFalse(runtime_gap["evidence_complete"])
         self.assertFalse(runtime_gap["promotion_ready"])
         self.assertEqual(failing["status"], "FAIL")
+
+    def test_dirty_final_bundle_is_not_promotion_ready_and_rejects_forgery(
+        self,
+    ) -> None:
+        dirty_status = " M scripts/oal_001/runtime.py"
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+
+        def synthetic_git_read(command: list[str]) -> str:
+            mapping = {
+                ("git", "branch", "--show-current"): BRANCH,
+                ("git", "rev-parse", "HEAD"): BASE_SHA,
+                (
+                    "git",
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                    "--ignore-submodules=none",
+                    "--no-renames",
+                ): dirty_status,
+            }
+            return mapping[tuple(command)]
+
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            result = execute_cycle(
+                REPO_ROOT,
+                policy,
+                BRANCH,
+                BASE_SHA,
+                git_status_before=dirty_status,
+                git_status_after=dirty_status,
+            )
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+            prepared_snapshot = _capture_artifact_snapshot(output_dir)
+            with mock_patch(
+                "scripts.validate_oal_001._git_read",
+                side_effect=synthetic_git_read,
+            ):
+                self.assertEqual(
+                    validate_artifact_snapshot(
+                        prepared_snapshot, output_dir, lifecycle="prepared"
+                    ),
+                    [],
+                )
+
+                promotion_eligible = _snapshot_promotion_eligible(
+                    prepared_snapshot
+                )
+                self.assertFalse(promotion_eligible)
+                test_result = self._test_result(
+                    result.run_id, promotion_eligible=promotion_eligible
+                )
+                finalized = _finalized_snapshot(prepared_snapshot, test_result)
+                self.assertEqual(
+                    validate_artifact_snapshot(
+                        finalized, output_dir, lifecycle="complete"
+                    ),
+                    [],
+                )
+                self.assertEqual(
+                    _finalize_evidence(
+                        output_dir, prepared_snapshot, test_result
+                    ),
+                    [],
+                )
+                with (
+                    mock_patch(
+                        "scripts.validate_oal_001.static_errors", return_value=[]
+                    ),
+                    mock_patch(
+                        "scripts.validate_oal_001._existing_output_dir",
+                        return_value=output_dir,
+                    ),
+                ):
+                    return_code = validator_main(
+                        ["--verify-existing", result.run_id]
+                    )
+                self.assertEqual(return_code, EXIT_NOT_PROMOTION_READY)
+
+                forged = copy.deepcopy(test_result)
+                forged["evidence_complete"] = True
+                forged["promotion_ready"] = True
+                forged_snapshot = _finalized_snapshot(prepared_snapshot, forged)
+                errors = validate_artifact_snapshot(
+                    forged_snapshot, output_dir, lifecycle="complete"
+                )
+
+            self.assertIn(
+                "final promotion readiness does not match validation status", errors
+            )
+            self.assertIn(
+                "final evidence completeness does not match validation status", errors
+            )
+
+    def test_clean_bundle_verifies_without_upstream_tracking_metadata(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+
+        def canonical_git_read(command: list[str]) -> str:
+            mapping = {
+                ("git", "branch", "--show-current"): BRANCH,
+                ("git", "rev-parse", "HEAD"): BASE_SHA,
+                (
+                    "git",
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                    "--ignore-submodules=none",
+                    "--no-renames",
+                ): "",
+            }
+            return mapping[tuple(command)]
+
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            result = self.execute()
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+            prepared_snapshot = _capture_artifact_snapshot(output_dir)
+            test_result = self._test_result(
+                result.run_id,
+                promotion_eligible=_snapshot_promotion_eligible(
+                    prepared_snapshot
+                ),
+            )
+            with mock_patch(
+                "scripts.validate_oal_001._git_read",
+                side_effect=canonical_git_read,
+            ):
+                self.assertEqual(
+                    validate_artifact_snapshot(
+                        prepared_snapshot, output_dir, lifecycle="prepared"
+                    ),
+                    [],
+                )
+                self.assertEqual(
+                    _finalize_evidence(
+                        output_dir, prepared_snapshot, test_result
+                    ),
+                    [],
+                )
+                self.assertEqual(verify_existing_evidence(output_dir), [])
 
     def test_finalized_snapshot_records_runtime_gap_without_pass(self) -> None:
         local_private = REPO_ROOT / "raw" / "exports" / "local-private"
@@ -488,7 +686,12 @@ class Oal001RuntimeTests(unittest.TestCase):
                 side_effect=racing_writer,
             ):
                 errors = _finalize_evidence(
-                    output_dir, prepared, self._test_result(result.run_id)
+                    output_dir,
+                    prepared,
+                    self._test_result(
+                        result.run_id,
+                        promotion_eligible=_snapshot_promotion_eligible(prepared),
+                    ),
                 )
 
             self.assertTrue(any("candidate replay" in item for item in errors))
@@ -505,7 +708,12 @@ class Oal001RuntimeTests(unittest.TestCase):
             result, output_dir, prepared = self._prepared_evidence(temp_dir)
             self.assertEqual(
                 _finalize_evidence(
-                    output_dir, prepared, self._test_result(result.run_id)
+                    output_dir,
+                    prepared,
+                    self._test_result(
+                        result.run_id,
+                        promotion_eligible=_snapshot_promotion_eligible(prepared),
+                    ),
                 ),
                 [],
             )
@@ -620,7 +828,10 @@ class Oal001RuntimeTests(unittest.TestCase):
             prefix="oal-001-test-", dir=local_private
         ) as temp_dir:
             result, output_dir, prepared = self._prepared_evidence(temp_dir)
-            pass_test_result = self._test_result(result.run_id)
+            pass_test_result = self._test_result(
+                result.run_id,
+                promotion_eligible=_snapshot_promotion_eligible(prepared),
+            )
             self.assertEqual(
                 _finalize_evidence(output_dir, prepared, pass_test_result), []
             )
@@ -692,6 +903,84 @@ class Oal001RuntimeTests(unittest.TestCase):
         self.assertEqual(options["env"]["GIT_OPTIONAL_LOCKS"], "0")
         self.assertNotIn("OAL_TEST_SECRET", options["env"])
         self.assertNotIn("shell", options)
+
+    def test_worktree_status_preserves_porcelain_columns_without_tracking_data(
+        self,
+    ) -> None:
+        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout=" M scripts/oal_001/runtime.py\n?? untracked.txt\n",
+            stderr="",
+        )
+        with (
+            mock_patch.object(
+                git_read, "_resolve_git_executable", return_value=executable
+            ),
+            mock_patch.object(
+                git_read.subprocess, "run", return_value=completed
+            ) as mocked_run,
+        ):
+            status = git_read.worktree_status(REPO_ROOT)
+
+        self.assertEqual(
+            status, " M scripts/oal_001/runtime.py\n?? untracked.txt"
+        )
+        self.assertFalse(git_status_is_clean(status))
+        command = mocked_run.call_args.args[0]
+        self.assertIn("--porcelain=v1", command)
+        self.assertIn("--untracked-files=all", command)
+        self.assertIn("--ignore-submodules=none", command)
+        self.assertIn("--no-renames", command)
+        self.assertIn("status.branch=false", command)
+        self.assertNotIn("--branch", command)
+
+    def test_clean_status_is_empty_and_legacy_branch_header_is_rejected(self) -> None:
+        self.assertTrue(git_status_is_clean(""))
+        with self.assertRaisesRegex(RuntimeError, "invalid payload"):
+            git_read.validate_worktree_status(
+                "## codex/observatory-selfmod-001...origin/branch"
+            )
+        with self.assertRaisesRegex(RuntimeError, "invalid payload"):
+            git_read.validate_worktree_status(" M tracked.py\n")
+        with self.assertRaisesRegex(RuntimeError, "invalid payload"):
+            execute_cycle(
+                REPO_ROOT,
+                self.policy,
+                BRANCH,
+                BASE_SHA,
+                git_status_before="## synthetic-test",
+                git_status_after="## synthetic-test",
+            )
+
+    def test_dirty_porcelain_entries_are_prepared_not_clean(self) -> None:
+        for status in ("M  tracked.py", " M tracked.py", "?? untracked.py"):
+            with self.subTest(status=status):
+                result = execute_cycle(
+                    REPO_ROOT,
+                    self.policy,
+                    BRANCH,
+                    BASE_SHA,
+                    git_status_before=status,
+                    git_status_after=status,
+                )
+
+                self.assertFalse(result.trace["git_status"]["clean_worktree"])
+                self.assertEqual(result.trace["source_state"], "working_tree_manifest")
+                self.assertEqual(result.boundary_report["status"], "PASS_PREPARED")
+
+    def test_porcelain_submodule_worktree_states_are_canonical(self) -> None:
+        for status in (
+            " m submodule",
+            " ? submodule",
+            "Mm submodule",
+            "M? submodule",
+        ):
+            with self.subTest(status=status):
+                self.assertEqual(
+                    git_read.validate_worktree_status(status), status
+                )
+                self.assertFalse(git_status_is_clean(status))
 
     def test_git_read_api_rejects_mutation_and_path_traversal(self) -> None:
         with self.assertRaisesRegex(ValueError, "typed read-only API"):

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -47,9 +47,12 @@ from scripts.validate_oal_001 import (
     _atomic_write_json,
     _build_test_result,
     _capture_artifact_snapshot,
+    _dispatch as validator_dispatch,
     _finalize_evidence,
     _finalized_snapshot,
     _import_path_boundary_errors,
+    _pull_request_trigger_errors,
+    _runtime_isolation_errors,
     _replace_snapshot_bytes,
     _snapshot_promotion_eligible,
     _subprocess_boundary_errors,
@@ -562,7 +565,9 @@ class Oal001RuntimeTests(unittest.TestCase):
                         return_value=output_dir,
                     ),
                 ):
-                    return_code = validator_main(["--verify-existing", result.run_id])
+                    return_code = validator_dispatch(
+                        ["--verify-existing", result.run_id]
+                    )
                 self.assertEqual(return_code, EXIT_NOT_PROMOTION_READY)
 
                 forged = copy.deepcopy(test_result)
@@ -804,7 +809,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                     side_effect=AssertionError("verifier must not write"),
                 ),
             ):
-                return_code = validator_main(["--verify-existing", result.run_id])
+                return_code = validator_dispatch(["--verify-existing", result.run_id])
             after = {
                 path.name: sha256_bytes(path.read_bytes())
                 for path in output_dir.iterdir()
@@ -812,7 +817,9 @@ class Oal001RuntimeTests(unittest.TestCase):
 
             self.assertEqual(return_code, EXIT_RUNTIME_GAP)
             self.assertEqual(before, after)
-            self.assertEqual(validator_main(["--verify-existing", "not-a-run-id"]), 2)
+            self.assertEqual(
+                validator_dispatch(["--verify-existing", "not-a-run-id"]), 2
+            )
 
     def test_completion_marker_detects_post_validation_tampering(self) -> None:
         local_private = REPO_ROOT / "raw" / "exports" / "local-private"
@@ -1070,6 +1077,26 @@ class Oal001RuntimeTests(unittest.TestCase):
 
         self.assertIn("python -I -S -B - <<'PY'", workflow)
         self.assertIn("run: python -I -S -B scripts/validate_oal_001.py", workflow)
+        preflight_index = workflow.index("Confirm isolated runtime and import topology")
+        classification_index = workflow.index("Classify governed OAL changes")
+        branch_gate_index = workflow.index("Bind governed changes to an OAL branch")
+        validator_index = workflow.index("Run complete OAL validator")
+        self.assertLess(
+            preflight_index,
+            classification_index,
+        )
+        self.assertLess(classification_index, branch_gate_index)
+        self.assertLess(branch_gate_index, validator_index)
+        self.assertEqual(
+            workflow.count("if: steps.oal_scope.outputs.oal_changed == 'true'"),
+            2,
+        )
+        self.assertIn("scripts/oal_001/*", workflow)
+        self.assertIn("scripts/validate_oal_001.py", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn('merge_base="$(git merge-base ', workflow)
+        self.assertIn('"$merge_base" "$OAL_SOURCE_SHA" --', workflow)
+        self.assertNotIn('"$OAL_BASE_SHA" "$OAL_SOURCE_SHA" -- >', workflow)
         direct_imports = [
             node for node in validator_tree.body if isinstance(node, ast.Import)
         ]
@@ -1087,6 +1114,150 @@ class Oal001RuntimeTests(unittest.TestCase):
         self.assertTrue(
             _import_path_boundary_errors("scripts/validate_oal_001.py", unsafe_tree)
         )
+
+    def test_workflow_trigger_is_unfiltered_and_fail_closed(self) -> None:
+        workflow_source = (
+            REPO_ROOT / ".github/workflows/oal-001-validate.yml"
+        ).read_bytes()
+
+        self.assertEqual(_pull_request_trigger_errors(workflow_source), [])
+        workflow = workflow_source.decode("utf-8")
+        canonical_trigger = "on:\n  pull_request: {}"
+        filtered_or_indirect_triggers = (
+            "on:\n  pull_request:\n    paths:\n      - 'scripts/**'",
+            "on:\n  pull_request:\n    paths-ignore:\n      - 'docs/**'",
+            "on:\n  pull_request:\n    branches:\n      - main",
+            "on:\n  pull_request:\n    branches-ignore:\n      - legacy",
+            "on:\n  pull_request:\n    types: [opened]",
+            "on:\n  pull_request_target: {}",
+            "on:\n  push: {}\n  # pull_request: {}",
+            "on:\n  pull_request:",
+        )
+        trigger_error = [
+            "OAL workflow trigger must be exactly one unfiltered pull_request event"
+        ]
+        for replacement in filtered_or_indirect_triggers:
+            source = workflow.replace(canonical_trigger, replacement, 1).encode()
+            with self.subTest(replacement=replacement):
+                self.assertEqual(_pull_request_trigger_errors(source), trigger_error)
+
+        duplicate_or_alternative_keys = (
+            "on:\n  push: {}",
+            "on: {push: {}}",
+            '"on": {push: {}}',
+            "'on': {push: {}}",
+            "on : {push: {}}",
+            "!!str on: {push: {}}",
+            "? on\n: {push: {}}",
+            "{on: {push: {}}}",
+        )
+        top_level_error = [
+            "OAL workflow top-level mapping does not match the exact contract"
+        ]
+        for extra_key in duplicate_or_alternative_keys:
+            source = workflow.replace(
+                canonical_trigger,
+                f"{canonical_trigger}\n{extra_key}",
+                1,
+            ).encode()
+            with self.subTest(extra_key=extra_key):
+                self.assertEqual(_pull_request_trigger_errors(source), top_level_error)
+        aliased_source = workflow.replace(
+            canonical_trigger,
+            "on: &events\n  pull_request: {}",
+            1,
+        ).encode()
+        self.assertEqual(_pull_request_trigger_errors(aliased_source), top_level_error)
+
+    def test_imported_main_refuses_untrusted_import_state(self) -> None:
+        self.assertTrue(_runtime_isolation_errors())
+        with (
+            mock_patch("scripts.validate_oal_001._dispatch") as dispatch,
+            mock_patch("scripts.validate_oal_001.error") as emit_error,
+        ):
+            return_code = validator_main(
+                ["--verify-existing", "OAL-001-DECOY00000000000"]
+            )
+
+        self.assertEqual(return_code, 1)
+        dispatch.assert_not_called()
+        emit_error.assert_called()
+
+    def test_import_state_aliases_and_mutations_are_rejected(self) -> None:
+        validator_source = (REPO_ROOT / "scripts/validate_oal_001.py").read_text(
+            encoding="utf-8"
+        )
+        bypasses = (
+            "from sys import path\npath.insert(0, 'scripts/oal_001')\n",
+            "import sys\np = sys.path\np.insert(0, 'scripts/oal_001')\n",
+            "import sys\nsys.path_hooks.append(lambda value: None)\n",
+            "import sys\nsys.meta_path.clear()\n",
+            "import sys\nsys.path_importer_cache.clear()\n",
+            "import sys\nsys.modules.clear()\n",
+            "import sys\nforwarded = sys\nforwarded.path.insert(0, '.')\n",
+            "import sys as system\nsystem.path.insert(0, '.')\n",
+            "import sys\nsys.__getattribute__('path').insert(0, '.')\n",
+            "import os\nos.sys.path.insert(0, '.')\n",
+            "from os import sys as system\nsystem.path.insert(0, '.')\n",
+            "from os import *\nsys.path.insert(0, '.')\n",
+            "import pathlib\nsystem = pathlib.__dict__['sys']\n"
+            "system.path.insert(0, '.')\n",
+            "import pathlib\nsystem = pathlib.__getattribute__('sys')\n"
+            "system.path.insert(0, '.')\n",
+            "import pathlib\nsystem = getattr(pathlib, 'sys')\n"
+            "system.path.insert(0, '.')\n",
+        )
+        for bypass in bypasses:
+            with self.subTest(bypass=bypass):
+                modified_tree = ast.parse(f"{validator_source}\n{bypass}")
+                self.assertTrue(
+                    _import_path_boundary_errors(
+                        "scripts/validate_oal_001.py", modified_tree
+                    )
+                )
+        decoy_body = (
+            "for raw_path in sys.path:\n"
+            "    pass\n"
+            "if str(REPO_ROOT) not in sys.path:\n"
+            "    sys.path.append(str(REPO_ROOT))\n"
+            "if sys.path.count(str(REPO_ROOT)) != 1 or "
+            "sys.path[-1] != str(REPO_ROOT):\n"
+            "    pass\n"
+        )
+        decoy_sources = (
+            "import sys\nREPO_ROOT = 'synthetic'\ndef decoy():\n"
+            + "".join(f"    {line}\n" for line in decoy_body.splitlines()),
+            "import sys\nREPO_ROOT = 'synthetic'\nif False:\n"
+            + "".join(f"    {line}\n" for line in decoy_body.splitlines()),
+        )
+        for decoy_source in decoy_sources:
+            with self.subTest(decoy_source=decoy_source):
+                self.assertTrue(
+                    _import_path_boundary_errors(
+                        "scripts/validate_oal_001.py", ast.parse(decoy_source)
+                    )
+                )
+        disabled_bootstraps = (
+            validator_source.replace(
+                "if str(REPO_ROOT) not in sys.path:\n",
+                "if False and str(REPO_ROOT) not in sys.path:\n",
+                1,
+            ),
+            validator_source.replace(
+                "if sys.path.count(str(REPO_ROOT)) != 1 or "
+                "sys.path[-1] != str(REPO_ROOT):\n",
+                "if False and (sys.path.count(str(REPO_ROOT)) != 1 or "
+                "sys.path[-1] != str(REPO_ROOT)):\n",
+                1,
+            ),
+        )
+        for disabled_source in disabled_bootstraps:
+            with self.subTest(disabled_source=disabled_source):
+                self.assertTrue(
+                    _import_path_boundary_errors(
+                        "scripts/validate_oal_001.py", ast.parse(disabled_source)
+                    )
+                )
 
     def test_python_shadowing_paths_are_rejected_before_repo_imports(self) -> None:
         cases = (
@@ -1141,7 +1312,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                         f"scripts.validate_oal_001.{internal_target}"
                     ) as internal,
                 ):
-                    return_code = validator_main([option])
+                    return_code = validator_dispatch([option])
 
                 self.assertEqual(return_code, 1)
                 internal.assert_not_called()

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -51,6 +51,7 @@ from scripts.validate_oal_001 import (
     _finalize_evidence,
     _finalized_snapshot,
     _import_path_boundary_errors,
+    _pull_request_merge_base_errors,
     _pull_request_trigger_errors,
     _runtime_isolation_errors,
     _replace_snapshot_bytes,
@@ -1094,7 +1095,10 @@ class Oal001RuntimeTests(unittest.TestCase):
         self.assertIn("scripts/oal_001/*", workflow)
         self.assertIn("scripts/validate_oal_001.py", workflow)
         self.assertIn("fetch-depth: 0", workflow)
-        self.assertIn('merge_base="$(git merge-base ', workflow)
+        self.assertIn(
+            'merge_base="$(git merge-base --all "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"',
+            workflow,
+        )
         self.assertIn('"$merge_base" "$OAL_SOURCE_SHA" --', workflow)
         self.assertNotIn('"$OAL_BASE_SHA" "$OAL_SOURCE_SHA" -- >', workflow)
         direct_imports = [
@@ -1169,6 +1173,45 @@ class Oal001RuntimeTests(unittest.TestCase):
         ).encode()
         self.assertEqual(_pull_request_trigger_errors(aliased_source), top_level_error)
 
+    def test_workflow_merge_base_contract_rejects_ambiguous_output(self) -> None:
+        workflow_source = (
+            REPO_ROOT / ".github/workflows/oal-001-validate.yml"
+        ).read_bytes()
+        workflow = workflow_source.decode("utf-8")
+        command = (
+            'merge_base="$(git merge-base --all "$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"'
+        )
+        rejection = 'if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then'
+
+        self.assertEqual(workflow.count(command), 1)
+        self.assertEqual(workflow.count(rejection), 1)
+        self.assertIn("Could not resolve exactly one pull-request merge base", workflow)
+        self.assertEqual(_pull_request_merge_base_errors(workflow_source), [])
+
+        weakened_sources = (
+            workflow.replace("git merge-base --all", "git merge-base", 1),
+            workflow.replace(
+                '"$OAL_BASE_SHA" "$OAL_SOURCE_SHA")"',
+                '"$OAL_BASE_SHA" "$OAL_SOURCE_SHA" | head -n 1)"',
+                1,
+            ),
+            workflow.replace(
+                'if [[ ! "$merge_base" =~ ^[0-9a-f]{40}$ ]]; then',
+                'if [[ -z "$merge_base" ]]; then',
+                1,
+            ),
+        )
+        expected_error = [
+            "OAL workflow must fail closed unless exactly one pull-request merge base exists"
+        ]
+        for weakened in weakened_sources:
+            with self.subTest(weakened=weakened):
+                self.assertNotEqual(weakened, workflow)
+                self.assertEqual(
+                    _pull_request_merge_base_errors(weakened.encode("utf-8")),
+                    expected_error,
+                )
+
     def test_imported_main_refuses_untrusted_import_state(self) -> None:
         self.assertTrue(_runtime_isolation_errors())
         with (
@@ -1182,6 +1225,47 @@ class Oal001RuntimeTests(unittest.TestCase):
         self.assertEqual(return_code, 1)
         dispatch.assert_not_called()
         emit_error.assert_called()
+
+    def test_direct_sys_attribute_mutations_are_rejected(self) -> None:
+        mutations = (
+            "sys.executable = 'python'",
+            "sys.executable: str = 'python'",
+            "sys.executable += ''",
+            "del sys.executable",
+        )
+        expected = "sys attribute 'executable' mutation is forbidden in synthetic.py"
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                tree = ast.parse(f"import sys\n{mutation}\n")
+                self.assertIn(
+                    expected, _import_path_boundary_errors("synthetic.py", tree)
+                )
+
+        read_tree = ast.parse("import sys\nexecutable = sys.executable\n")
+        self.assertEqual(_import_path_boundary_errors("synthetic.py", read_tree), [])
+
+    def test_reflective_getattr_allowlist_is_bound_to_fixed_call(self) -> None:
+        spoofed_tree = ast.parse(
+            "import os\n"
+            "policy = os\n"
+            "field = 'system'\n"
+            "operation = getattr(policy, field)\n"
+        )
+        self.assertIn(
+            "reflective attribute call is forbidden in synthetic.py",
+            _import_path_boundary_errors("synthetic.py", spoofed_tree),
+        )
+        self.assertIn(
+            "indirect process API access is forbidden in synthetic.py",
+            _subprocess_boundary_errors("synthetic.py", spoofed_tree),
+        )
+
+        governor_path = "scripts/oal_001/governor.py"
+        governor_tree = ast.parse(
+            (REPO_ROOT / governor_path).read_text(encoding="utf-8")
+        )
+        self.assertEqual(_import_path_boundary_errors(governor_path, governor_tree), [])
+        self.assertEqual(_subprocess_boundary_errors(governor_path, governor_tree), [])
 
     def test_import_state_aliases_and_mutations_are_rejected(self) -> None:
         validator_source = (REPO_ROOT / "scripts/validate_oal_001.py").read_text(

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -38,8 +38,10 @@ from scripts.validate_oal_001 import (
     EXIT_NOT_PROMOTION_READY,
     EXIT_RUNTIME_GAP,
     MINIMUM_OAL_TEST_COUNT,
+    PROTECTED_IMPORT_FILES,
     STATUS_PASS,
     STATUS_RUNTIME_GAP,
+    VALIDATOR_PATH,
     _artifact_digest_map,
     _atomic_write_bytes,
     _atomic_write_json,
@@ -47,10 +49,13 @@ from scripts.validate_oal_001 import (
     _capture_artifact_snapshot,
     _finalize_evidence,
     _finalized_snapshot,
+    _import_path_boundary_errors,
     _replace_snapshot_bytes,
     _snapshot_promotion_eligible,
     _subprocess_boundary_errors,
     main as validator_main,
+    python_shadowing_errors,
+    run_dry_run,
     run_unit_tests,
     unit_test_gate_errors,
     validate_artifact_snapshot,
@@ -453,9 +458,7 @@ class Oal001RuntimeTests(unittest.TestCase):
 
     def test_validation_status_requires_python_3_11_for_pass(self) -> None:
         passing = self._test_result("OAL-001-" + "A" * 16)
-        prepared = self._test_result(
-            "OAL-001-" + "A" * 16, promotion_eligible=False
-        )
+        prepared = self._test_result("OAL-001-" + "A" * 16, promotion_eligible=False)
         runtime_gap = self._test_result(
             "OAL-001-" + "A" * 16,
             python_version="3.12.10",
@@ -534,9 +537,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                     [],
                 )
 
-                promotion_eligible = _snapshot_promotion_eligible(
-                    prepared_snapshot
-                )
+                promotion_eligible = _snapshot_promotion_eligible(prepared_snapshot)
                 self.assertFalse(promotion_eligible)
                 test_result = self._test_result(
                     result.run_id, promotion_eligible=promotion_eligible
@@ -549,9 +550,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                     [],
                 )
                 self.assertEqual(
-                    _finalize_evidence(
-                        output_dir, prepared_snapshot, test_result
-                    ),
+                    _finalize_evidence(output_dir, prepared_snapshot, test_result),
                     [],
                 )
                 with (
@@ -563,9 +562,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                         return_value=output_dir,
                     ),
                 ):
-                    return_code = validator_main(
-                        ["--verify-existing", result.run_id]
-                    )
+                    return_code = validator_main(["--verify-existing", result.run_id])
                 self.assertEqual(return_code, EXIT_NOT_PROMOTION_READY)
 
                 forged = copy.deepcopy(test_result)
@@ -615,9 +612,7 @@ class Oal001RuntimeTests(unittest.TestCase):
             prepared_snapshot = _capture_artifact_snapshot(output_dir)
             test_result = self._test_result(
                 result.run_id,
-                promotion_eligible=_snapshot_promotion_eligible(
-                    prepared_snapshot
-                ),
+                promotion_eligible=_snapshot_promotion_eligible(prepared_snapshot),
             )
             with mock_patch(
                 "scripts.validate_oal_001._git_read",
@@ -630,9 +625,7 @@ class Oal001RuntimeTests(unittest.TestCase):
                     [],
                 )
                 self.assertEqual(
-                    _finalize_evidence(
-                        output_dir, prepared_snapshot, test_result
-                    ),
+                    _finalize_evidence(output_dir, prepared_snapshot, test_result),
                     [],
                 )
                 self.assertEqual(verify_existing_evidence(output_dir), [])
@@ -923,9 +916,7 @@ class Oal001RuntimeTests(unittest.TestCase):
         ):
             status = git_read.worktree_status(REPO_ROOT)
 
-        self.assertEqual(
-            status, " M scripts/oal_001/runtime.py\n?? untracked.txt"
-        )
+        self.assertEqual(status, " M scripts/oal_001/runtime.py\n?? untracked.txt")
         self.assertFalse(git_status_is_clean(status))
         command = mocked_run.call_args.args[0]
         self.assertIn("--porcelain=v1", command)
@@ -977,9 +968,7 @@ class Oal001RuntimeTests(unittest.TestCase):
             "M? submodule",
         ):
             with self.subTest(status=status):
-                self.assertEqual(
-                    git_read.validate_worktree_status(status), status
-                )
+                self.assertEqual(git_read.validate_worktree_status(status), status)
                 self.assertFalse(git_status_is_clean(status))
 
     def test_git_read_api_rejects_mutation_and_path_traversal(self) -> None:
@@ -1070,6 +1059,118 @@ class Oal001RuntimeTests(unittest.TestCase):
                 )
                 self.assertTrue(bypass_errors)
 
+    def test_workflow_and_validator_use_isolated_import_bootstrap(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/oal-001-validate.yml").read_text(
+            encoding="utf-8"
+        )
+        validator_source = (REPO_ROOT / "scripts/validate_oal_001.py").read_text(
+            encoding="utf-8"
+        )
+        validator_tree = ast.parse(validator_source)
+
+        self.assertIn("python -I -S -B - <<'PY'", workflow)
+        self.assertIn("run: python -I -S -B scripts/validate_oal_001.py", workflow)
+        direct_imports = [
+            node for node in validator_tree.body if isinstance(node, ast.Import)
+        ]
+        self.assertEqual(direct_imports[0].names[0].name, "sys")
+        self.assertEqual(
+            _import_path_boundary_errors("scripts/validate_oal_001.py", validator_tree),
+            [],
+        )
+        unsafe_tree = ast.parse(
+            "import sys\n"
+            "REPO_ROOT = 'synthetic'\n"
+            "if str(REPO_ROOT) not in sys.path:\n"
+            "    sys.path.insert(0, str(REPO_ROOT))\n"
+        )
+        self.assertTrue(
+            _import_path_boundary_errors("scripts/validate_oal_001.py", unsafe_tree)
+        )
+
+    def test_python_shadowing_paths_are_rejected_before_repo_imports(self) -> None:
+        cases = (
+            "scripts/ArgParse.py",
+            "hashlib.py",
+            "json.pyc",
+            "fractions/__init__.py",
+            "scripts.py",
+            "tests.py",
+            "scripts/oal_001.py",
+            "scripts/oal_001/git_read/__init__.py",
+            "scripts/oal_001/runtime.pyc",
+            "scripts/oal_001/__pycache__/git_read.cpython-311.pyc",
+            "tests/test_oal_001_runtime/__init__.py",
+            "tests/__pycache__/test_oal_001_runtime.cpython-311.pyc",
+            "scripts/__init__.py",
+            "tests/__init__.py",
+        )
+        for relative_path in cases:
+            with self.subTest(relative_path=relative_path):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    root = Path(temp_dir)
+                    for protected_file in PROTECTED_IMPORT_FILES:
+                        path = root / protected_file
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        path.write_text("", encoding="utf-8")
+                    self.assertEqual(python_shadowing_errors(root), [])
+                    target = root / relative_path
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    if target.suffix == ".pyc":
+                        target.write_bytes(b"synthetic")
+                    else:
+                        target.write_text("raise SystemExit(0)\n", encoding="utf-8")
+
+                    errors = python_shadowing_errors(root)
+
+                expected = relative_path.replace("\\", "/").removesuffix("/__init__.py")
+                self.assertTrue(any(expected in item for item in errors), errors)
+
+    def test_internal_modes_recheck_shadowing_before_repo_imports(self) -> None:
+        for option, internal_target in (
+            ("--_internal-unit-tests", "_internal_unit_tests"),
+            ("--_internal-dry-run", "_internal_dry_run"),
+        ):
+            with self.subTest(option=option):
+                with (
+                    mock_patch(
+                        "scripts.validate_oal_001.python_shadowing_errors",
+                        return_value=["synthetic import shadow"],
+                    ),
+                    mock_patch(
+                        f"scripts.validate_oal_001.{internal_target}"
+                    ) as internal,
+                ):
+                    return_code = validator_main([option])
+
+                self.assertEqual(return_code, 1)
+                internal.assert_not_called()
+
+    def test_dry_run_uses_isolated_validator_child(self) -> None:
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout='{"synthetic": true}\n',
+            stderr="",
+        )
+        with mock_patch(
+            "scripts.validate_oal_001.subprocess.run", return_value=completed
+        ) as mocked_run:
+            return_code, output = run_dry_run()
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(output, '{"synthetic": true}')
+        self.assertEqual(
+            mocked_run.call_args.args[0],
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                "-B",
+                VALIDATOR_PATH,
+                "--_internal-dry-run",
+            ],
+        )
+
     def test_unit_test_gate_rejects_zero_tests(self) -> None:
         errors = unit_test_gate_errors(return_code=0, count=0, outcome_details={})
 
@@ -1088,13 +1189,24 @@ class Oal001RuntimeTests(unittest.TestCase):
         completed = SimpleNamespace(returncode=0, stdout=output)
         with mock_patch(
             "scripts.validate_oal_001.subprocess.run", return_value=completed
-        ):
+        ) as mocked_run:
             return_code, _, count, outcomes = run_unit_tests()
 
         self.assertEqual(return_code, 0)
         self.assertEqual(count, MINIMUM_OAL_TEST_COUNT)
         self.assertEqual(outcomes, {"skipped": 1})
         self.assertTrue(unit_test_gate_errors(return_code, count, outcomes))
+        self.assertEqual(
+            mocked_run.call_args.args[0],
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                "-B",
+                VALIDATOR_PATH,
+                "--_internal-unit-tests",
+            ],
+        )
 
         expected_failure_output = output.replace(
             "OK (skipped=1)",

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -5,6 +5,7 @@ import copy
 import json
 import os
 import stat
+import sys
 import tempfile
 import unittest
 from dataclasses import replace
@@ -12,6 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
+from scripts.oal_001 import git_read
 from scripts.oal_001.governor import Governor, load_policy
 from scripts.oal_001.__main__ import git_branch, git_head
 from scripts.oal_001.runtime import (
@@ -32,13 +34,25 @@ from scripts.oal_001.runtime import (
     write_cycle_artifacts,
 )
 from scripts.validate_oal_001 import (
+    EXIT_RUNTIME_GAP,
+    MINIMUM_OAL_TEST_COUNT,
+    STATUS_PASS,
+    STATUS_RUNTIME_GAP,
     _artifact_digest_map,
+    _atomic_write_bytes,
     _atomic_write_json,
+    _build_test_result,
+    _capture_artifact_snapshot,
+    _finalize_evidence,
+    _finalized_snapshot,
     _subprocess_boundary_errors,
+    main as validator_main,
     run_unit_tests,
     unit_test_gate_errors,
+    validate_artifact_snapshot,
     validate_artifacts,
     validate_completion_marker,
+    verify_existing_evidence,
 )
 
 
@@ -309,6 +323,38 @@ class Oal001RuntimeTests(unittest.TestCase):
             git_status_after=status,
         )
 
+    def _prepared_evidence(self, temp_dir: str):
+        output_root = Path(temp_dir)
+        policy = replace(
+            self.policy,
+            output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+        )
+        result = self._live_cycle()
+        output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+        snapshot = _capture_artifact_snapshot(output_dir)
+        self.assertEqual(
+            validate_artifact_snapshot(snapshot, output_dir, lifecycle="prepared"),
+            [],
+        )
+        return result, output_dir, snapshot
+
+    def _test_result(
+        self,
+        run_id: str,
+        python_version: str = "3.11.9",
+        python_version_info: tuple[int, int] = (3, 11),
+    ) -> dict[str, object]:
+        return _build_test_result(
+            run_id=run_id,
+            test_count=MINIMUM_OAL_TEST_COUNT,
+            test_outcomes={},
+            test_returncode=0,
+            dry_run_returncode=0,
+            artifact_errors=[],
+            python_version=python_version,
+            python_version_info=python_version_info,
+        )
+
     def test_cross_artifact_replay_tampering_is_rejected(self) -> None:
         local_private = REPO_ROOT / "raw" / "exports" / "local-private"
         local_private.mkdir(parents=True, exist_ok=True)
@@ -368,44 +414,216 @@ class Oal001RuntimeTests(unittest.TestCase):
             self.assertFalse(test_result["evidence_complete"])
             self.assertEqual(completion["status"], "INCOMPLETE")
 
+    def test_validation_status_requires_python_3_11_for_pass(self) -> None:
+        passing = self._test_result("OAL-001-" + "A" * 16)
+        runtime_gap = self._test_result(
+            "OAL-001-" + "A" * 16,
+            python_version="3.12.10",
+            python_version_info=(3, 12),
+        )
+        failing = _build_test_result(
+            run_id="OAL-001-" + "A" * 16,
+            test_count=MINIMUM_OAL_TEST_COUNT,
+            test_outcomes={},
+            test_returncode=0,
+            dry_run_returncode=0,
+            artifact_errors=["synthetic failure"],
+            python_version="3.11.9",
+            python_version_info=(3, 11),
+        )
+
+        self.assertEqual(passing["status"], STATUS_PASS)
+        self.assertTrue(passing["promotion_ready"])
+        self.assertEqual(runtime_gap["status"], STATUS_RUNTIME_GAP)
+        self.assertFalse(runtime_gap["evidence_complete"])
+        self.assertFalse(runtime_gap["promotion_ready"])
+        self.assertEqual(failing["status"], "FAIL")
+
+    def test_finalized_snapshot_records_runtime_gap_without_pass(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            runtime_gap = self._test_result(
+                result.run_id,
+                python_version="3.12.10",
+                python_version_info=(3, 12),
+            )
+            finalized = _finalized_snapshot(prepared, runtime_gap)
+
+            self.assertEqual(
+                validate_artifact_snapshot(finalized, output_dir, lifecycle="complete"),
+                [],
+            )
+            completion = json.loads(
+                dict(finalized)["validation_complete.json"].decode("utf-8")
+            )
+            self.assertEqual(completion["status"], STATUS_RUNTIME_GAP)
+            self.assertNotEqual(completion["status"], STATUS_PASS)
+
+    def test_finalization_rejects_tamper_between_validation_and_binding(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            original_writer = _atomic_write_bytes
+
+            def racing_writer(path: Path, data: bytes) -> None:
+                original_writer(path, data)
+                if path.name == "test_result.json":
+                    replay = json.loads(
+                        (output_dir / "replay_after.json").read_text(encoding="utf-8")
+                    )
+                    replay["route_counts"]["exploration"] = 999
+                    (output_dir / "replay_after.json").write_text(
+                        json.dumps(replay, indent=2) + "\n", encoding="utf-8"
+                    )
+
+            with mock_patch(
+                "scripts.validate_oal_001._atomic_write_bytes",
+                side_effect=racing_writer,
+            ):
+                errors = _finalize_evidence(
+                    output_dir, prepared, self._test_result(result.run_id)
+                )
+
+            self.assertTrue(any("candidate replay" in item for item in errors))
+            self.assertNotEqual(verify_existing_evidence(output_dir), [])
+
+    def test_verify_existing_rejects_semantic_tamper_with_matching_digests(
+        self,
+    ) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            self.assertEqual(
+                _finalize_evidence(
+                    output_dir, prepared, self._test_result(result.run_id)
+                ),
+                [],
+            )
+            replay = json.loads(
+                (output_dir / "replay_after.json").read_text(encoding="utf-8")
+            )
+            replay["route_counts"]["exploration"] = 999
+            (output_dir / "replay_after.json").write_text(
+                json.dumps(replay, indent=2) + "\n", encoding="utf-8"
+            )
+            changed = _capture_artifact_snapshot(output_dir)
+            marker = {
+                "schema_version": "OAL-1.0",
+                "run_id": result.run_id,
+                "status": STATUS_PASS,
+                "artifact_sha256": _artifact_digest_map(changed),
+            }
+            _atomic_write_json(output_dir / "validation_complete.json", marker)
+
+            errors = verify_existing_evidence(output_dir)
+
+            self.assertTrue(any("candidate replay" in item for item in errors))
+            self.assertFalse(any("does not bind" in item for item in errors))
+
+    def test_verify_existing_rejects_pass_when_python_3_11_was_not_run(
+        self,
+    ) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            runtime_gap = self._test_result(
+                result.run_id,
+                python_version="3.12.10",
+                python_version_info=(3, 12),
+            )
+            self.assertEqual(_finalize_evidence(output_dir, prepared, runtime_gap), [])
+            forged = copy.deepcopy(runtime_gap)
+            forged["status"] = STATUS_PASS
+            forged["evidence_complete"] = True
+            forged["promotion_ready"] = True
+            _atomic_write_json(output_dir / "test_result.json", forged)
+            changed = _capture_artifact_snapshot(output_dir)
+            marker = {
+                "schema_version": "OAL-1.0",
+                "run_id": result.run_id,
+                "status": STATUS_PASS,
+                "artifact_sha256": _artifact_digest_map(changed),
+            }
+            _atomic_write_json(output_dir / "validation_complete.json", marker)
+
+            errors = verify_existing_evidence(output_dir)
+
+            self.assertIn(
+                "final validation status does not match Python 3.11 execution",
+                errors,
+            )
+
+    def test_verify_existing_mode_is_read_only_and_reports_runtime_gap(self) -> None:
+        self.assertTrue(sys.dont_write_bytecode)
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            runtime_gap = self._test_result(
+                result.run_id,
+                python_version="3.12.10",
+                python_version_info=(3, 12),
+            )
+            self.assertEqual(_finalize_evidence(output_dir, prepared, runtime_gap), [])
+            before = {
+                path.name: sha256_bytes(path.read_bytes())
+                for path in output_dir.iterdir()
+            }
+            with (
+                mock_patch("scripts.validate_oal_001.static_errors", return_value=[]),
+                mock_patch(
+                    "scripts.validate_oal_001._existing_output_dir",
+                    return_value=output_dir,
+                ),
+                mock_patch(
+                    "scripts.validate_oal_001.run_unit_tests",
+                    side_effect=AssertionError("unit tests must not run"),
+                ),
+                mock_patch(
+                    "scripts.validate_oal_001.run_dry_run",
+                    side_effect=AssertionError("dry-run must not run"),
+                ),
+                mock_patch(
+                    "scripts.validate_oal_001._atomic_write_bytes",
+                    side_effect=AssertionError("verifier must not write"),
+                ),
+            ):
+                return_code = validator_main(["--verify-existing", result.run_id])
+            after = {
+                path.name: sha256_bytes(path.read_bytes())
+                for path in output_dir.iterdir()
+            }
+
+            self.assertEqual(return_code, EXIT_RUNTIME_GAP)
+            self.assertEqual(before, after)
+            self.assertEqual(validator_main(["--verify-existing", "not-a-run-id"]), 2)
+
     def test_completion_marker_detects_post_validation_tampering(self) -> None:
         local_private = REPO_ROOT / "raw" / "exports" / "local-private"
         local_private.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(
             prefix="oal-001-test-", dir=local_private
         ) as temp_dir:
-            output_root = Path(temp_dir)
-            policy = replace(
-                self.policy,
-                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            result, output_dir, prepared = self._prepared_evidence(temp_dir)
+            pass_test_result = self._test_result(result.run_id)
+            self.assertEqual(
+                _finalize_evidence(output_dir, prepared, pass_test_result), []
             )
-            result = self._live_cycle()
-            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
-            pass_test_result = {
-                "schema_version": "OAL-1.0",
-                "run_id": result.run_id,
-                "status": "PASS",
-                "evidence_complete": True,
-                "static_checks": {"status": "PASS"},
-                "unit_tests": {
-                    "status": "PASS",
-                    "count": 37,
-                    "skipped": 0,
-                    "outcome_details": {},
-                    "return_code": 0,
-                },
-                "dry_run": {"status": "PASS", "return_code": 0},
-                "artifact_validation": {"status": "PASS", "errors": []},
-                "external_mutation_count": 0,
-            }
-            _atomic_write_json(output_dir / "test_result.json", pass_test_result)
-            completion = {
-                "schema_version": "OAL-1.0",
-                "run_id": result.run_id,
-                "status": "PASS",
-                "artifact_sha256": _artifact_digest_map(output_dir),
-            }
-            _atomic_write_json(output_dir / "validation_complete.json", completion)
             self.assertEqual(validate_completion_marker(output_dir), [])
 
             fail_test_result = copy.deepcopy(pass_test_result)
@@ -416,28 +634,124 @@ class Oal001RuntimeTests(unittest.TestCase):
                 "errors": ["synthetic failure"],
             }
             _atomic_write_json(output_dir / "test_result.json", fail_test_result)
+            changed_snapshot = _capture_artifact_snapshot(output_dir)
             relabelled = {
                 "schema_version": "OAL-1.0",
                 "run_id": result.run_id,
                 "status": "PASS",
-                "artifact_sha256": _artifact_digest_map(output_dir),
+                "artifact_sha256": _artifact_digest_map(changed_snapshot),
             }
             _atomic_write_json(output_dir / "validation_complete.json", relabelled)
-            self.assertIn(
-                "completion marker status does not match bound test semantics",
-                validate_completion_marker(output_dir),
+            self.assertTrue(
+                any(
+                    "final validation status" in item or "completion marker" in item
+                    for item in validate_completion_marker(output_dir)
+                )
             )
 
-            _atomic_write_json(output_dir / "test_result.json", pass_test_result)
-            completion["artifact_sha256"] = _artifact_digest_map(output_dir)
-            _atomic_write_json(output_dir / "validation_complete.json", completion)
+            finalized = _finalized_snapshot(prepared, pass_test_result)
+            _atomic_write_bytes(
+                output_dir / "test_result.json",
+                dict(finalized)["test_result.json"],
+            )
+            _atomic_write_bytes(
+                output_dir / "validation_complete.json",
+                dict(finalized)["validation_complete.json"],
+            )
             (output_dir / "replay_after.json").write_text("{}\n", encoding="utf-8")
 
             errors = validate_completion_marker(output_dir)
 
-            self.assertIn(
-                "completion marker artifact digests do not match current bytes", errors
-            )
+            self.assertTrue(any("candidate replay" in item for item in errors))
+            self.assertTrue(any("completion marker" in item for item in errors))
+
+    def test_git_read_uses_hardened_absolute_process_context(self) -> None:
+        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout=BRANCH + "\n",
+            stderr="",
+        )
+        with (
+            mock_patch.object(
+                git_read, "_resolve_git_executable", return_value=executable
+            ),
+            mock_patch.object(
+                git_read.subprocess, "run", return_value=completed
+            ) as mocked_run,
+            mock_patch.dict(os.environ, {"OAL_TEST_SECRET": "do-not-forward"}),
+        ):
+            self.assertEqual(git_read.current_branch(REPO_ROOT), BRANCH)
+
+        command = mocked_run.call_args.args[0]
+        options = mocked_run.call_args.kwargs
+        self.assertEqual(command[0], str(executable))
+        self.assertTrue(executable.is_absolute())
+        self.assertIn("--no-optional-locks", command)
+        self.assertIn("core.fsmonitor=false", command)
+        self.assertEqual(options["env"]["GIT_OPTIONAL_LOCKS"], "0")
+        self.assertNotIn("OAL_TEST_SECRET", options["env"])
+        self.assertNotIn("shell", options)
+
+    def test_git_read_api_rejects_mutation_and_path_traversal(self) -> None:
+        with self.assertRaisesRegex(ValueError, "typed read-only API"):
+            git_read._run_git(REPO_ROOT, ("push", "origin", "main"))
+        for unsafe_path in (
+            "../escape",
+            "/absolute",
+            r"..\escape",
+            "C:/outside",
+            "C:outside",
+            "raw/*",
+            ":(top)raw/exports",
+        ):
+            with self.subTest(path=unsafe_path):
+                with self.assertRaises(ValueError):
+                    git_read.is_ignored(REPO_ROOT, unsafe_path)
+
+    def test_git_check_ignore_distinguishes_results_and_errors(self) -> None:
+        self.assertTrue(
+            git_read.is_ignored(REPO_ROOT, "raw/exports/local-private/oal-001")
+        )
+        executable = Path(r"C:\Program Files\Git\cmd\git.exe")
+        with mock_patch.object(
+            git_read, "_resolve_git_executable", return_value=executable
+        ):
+            with mock_patch.object(
+                git_read.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+            ) as mocked_run:
+                self.assertTrue(git_read.is_ignored(REPO_ROOT, "raw/exports"))
+                self.assertIn("--", mocked_run.call_args.args[0])
+            with mock_patch.object(
+                git_read.subprocess,
+                "run",
+                return_value=SimpleNamespace(returncode=1, stdout="", stderr=""),
+            ):
+                self.assertFalse(git_read.is_ignored(REPO_ROOT, "README.md"))
+            with mock_patch.object(
+                git_read.subprocess,
+                "run",
+                return_value=SimpleNamespace(
+                    returncode=2, stdout="", stderr="synthetic Git failure"
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "synthetic Git failure"):
+                    git_read.is_ignored(REPO_ROOT, "README.md")
+
+    def test_git_executable_inside_repository_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            synthetic_repo = Path(temp_dir)
+            local_git = synthetic_repo / "git.exe"
+            local_git.write_bytes(b"not an executable")
+            with mock_patch.object(
+                git_read, "TRUSTED_GIT_CANDIDATES", (str(local_git),)
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, "no fixed trusted Git executable"
+                ):
+                    git_read._resolve_git_executable(synthetic_repo)
 
     def test_subprocess_alias_bypass_is_rejected(self) -> None:
         tree = ast.parse(
@@ -470,13 +784,16 @@ class Oal001RuntimeTests(unittest.TestCase):
     def test_unit_test_gate_rejects_zero_tests(self) -> None:
         errors = unit_test_gate_errors(return_code=0, count=0, outcome_details={})
 
-        self.assertIn("unit test count must be at least 37, got 0", errors)
+        self.assertIn(
+            f"unit test count must be at least {MINIMUM_OAL_TEST_COUNT}, got 0",
+            errors,
+        )
 
     def test_unit_test_parser_uses_anchored_final_skip_summary(self) -> None:
         output = (
             "test_noise ... skipped=0\n"
             "----------------------------------------------------------------------\n"
-            "Ran 37 tests in 0.100s\n\n"
+            f"Ran {MINIMUM_OAL_TEST_COUNT} tests in 0.100s\n\n"
             "OK (skipped=1)\n"
         )
         completed = SimpleNamespace(returncode=0, stdout=output)
@@ -486,19 +803,20 @@ class Oal001RuntimeTests(unittest.TestCase):
             return_code, _, count, outcomes = run_unit_tests()
 
         self.assertEqual(return_code, 0)
-        self.assertEqual(count, 37)
+        self.assertEqual(count, MINIMUM_OAL_TEST_COUNT)
         self.assertEqual(outcomes, {"skipped": 1})
         self.assertTrue(unit_test_gate_errors(return_code, count, outcomes))
 
         expected_failure_output = output.replace(
-            "OK (skipped=1)", "OK (expected failures=37)"
+            "OK (skipped=1)",
+            f"OK (expected failures={MINIMUM_OAL_TEST_COUNT})",
         )
         completed = SimpleNamespace(returncode=0, stdout=expected_failure_output)
         with mock_patch(
             "scripts.validate_oal_001.subprocess.run", return_value=completed
         ):
             return_code, _, count, outcomes = run_unit_tests()
-        self.assertEqual(outcomes, {"expected failures": 37})
+        self.assertEqual(outcomes, {"expected failures": MINIMUM_OAL_TEST_COUNT})
         self.assertTrue(unit_test_gate_errors(return_code, count, outcomes))
 
 

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import os
+import stat
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch as mock_patch
+
+from scripts.oal_001.governor import Governor, load_policy
+from scripts.oal_001.__main__ import git_branch, git_head
+from scripts.oal_001.runtime import (
+    CandidateBoundaryError,
+    CandidateWorkspace,
+    PatchEvaluator,
+    ReplayHarness,
+    TARGET_PATH,
+    _is_reparse_point,
+    _git_status,
+    build_harmless_patch,
+    execute_cycle,
+    load_fixture,
+    parse_strategy_source,
+    read_managed_source,
+    sha256_bytes,
+    validate_trace_payload,
+    write_cycle_artifacts,
+)
+from scripts.validate_oal_001 import (
+    _artifact_digest_map,
+    _atomic_write_json,
+    _subprocess_boundary_errors,
+    run_unit_tests,
+    unit_test_gate_errors,
+    validate_artifacts,
+    validate_completion_marker,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_SHA = "e" * 40
+BRANCH = "codex/observatory-selfmod-001"
+
+
+class Oal001RuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = load_policy(REPO_ROOT)
+
+    def execute(self, temp_parent: Path | None = None):
+        return execute_cycle(
+            REPO_ROOT,
+            self.policy,
+            BRANCH,
+            BASE_SHA,
+            git_status_before="## synthetic-test",
+            git_status_after="## synthetic-test",
+            temp_parent=temp_parent,
+        )
+
+    def test_baseline_strategy_is_data_only_and_meets_floor(self) -> None:
+        weights = parse_strategy_source(REPO_ROOT / TARGET_PATH)
+
+        self.assertEqual(weights, {"primary": 0.75, "exploration": 0.25})
+        self.assertGreaterEqual(
+            weights["exploration"], self.policy.minimum_exploration_share
+        )
+
+    def test_fixture_is_explicitly_synthetic_not_historical(self) -> None:
+        fixture = load_fixture(REPO_ROOT, self.policy.fixture_path)
+
+        self.assertEqual(fixture["fixture_kind"], "synthetic_current_slice")
+        self.assertFalse(fixture["historical_evidence"])
+
+    def test_replay_is_deterministic_for_same_input(self) -> None:
+        fixture = load_fixture(REPO_ROOT, self.policy.fixture_path)
+        harness = ReplayHarness(fixture)
+
+        first = harness.replay(REPO_ROOT / TARGET_PATH)
+        second = harness.replay(REPO_ROOT / TARGET_PATH)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.route_counts, {"primary": 15, "exploration": 5})
+
+    def test_end_to_end_candidate_is_retained_then_rolled_back(self) -> None:
+        baseline_before = sha256_bytes(read_managed_source(REPO_ROOT, TARGET_PATH))
+
+        result = self.execute()
+
+        baseline_after = sha256_bytes(read_managed_source(REPO_ROOT, TARGET_PATH))
+        self.assertEqual(result.trace["evaluation"]["decision"], "retain")
+        self.assertEqual(result.replay_after["route_counts"]["exploration"], 6)
+        self.assertEqual(result.comparison["delta"]["exploration_routes"], 1)
+        self.assertEqual(result.rollback_proof["status"], "verified")
+        self.assertTrue(result.rollback_proof["candidate_workspace_removed"])
+        self.assertEqual(baseline_before, baseline_after)
+
+    def test_two_runs_produce_same_id_and_replay(self) -> None:
+        first = self.execute()
+        second = self.execute()
+
+        self.assertEqual(first.run_id, second.run_id)
+        self.assertEqual(first.replay_before, second.replay_before)
+        self.assertEqual(first.replay_after, second.replay_after)
+        self.assertEqual(first.trace["evaluation"], second.trace["evaluation"])
+
+    def test_trace_satisfies_runtime_contract(self) -> None:
+        result = self.execute()
+
+        self.assertEqual(validate_trace_payload(result.trace), [])
+        self.assertEqual(result.trace["external_mutation_count"], 0)
+        self.assertFalse(result.trace["isolation"]["running_version_overwritten"])
+
+    def test_trace_tampering_is_detected(self) -> None:
+        trace = copy.deepcopy(self.execute().trace)
+        trace["external_mutation_count"] = 1
+
+        errors = validate_trace_payload(trace)
+
+        self.assertIn("external_mutation_count must be zero", errors)
+
+    def test_invented_evaluation_check_is_rejected(self) -> None:
+        trace = copy.deepcopy(self.execute().trace)
+        trace["evaluation"]["checks"] = {"invented_check": True}
+
+        errors = validate_trace_payload(trace)
+
+        self.assertIn(
+            "evaluation checks must match the exact first-slice check set", errors
+        )
+
+    def test_rejected_governor_requires_a_reason(self) -> None:
+        trace = copy.deepcopy(self.execute().trace)
+        trace["governor"] = {
+            "approved": False,
+            "reasons": [],
+            "immutable_surface": "baseline_only",
+        }
+        trace["evaluation"]["decision"] = "reject"
+        trace["evaluation"]["reasons"] = ["governor_approved"]
+        trace["evaluation"]["checks"]["governor_approved"] = False
+
+        errors = validate_trace_payload(trace)
+
+        self.assertIn("rejected Governor trace must contain rejection reasons", errors)
+
+    def test_candidate_hash_mismatch_fails_before_write(self) -> None:
+        source = read_managed_source(REPO_ROOT, TARGET_PATH)
+        patch = build_harmless_patch(source.decode("utf-8"), sha256_bytes(source))
+        patch = replace(patch, expected_before_sha256="0" * 64)
+
+        with CandidateWorkspace(REPO_ROOT, TARGET_PATH) as workspace:
+            before = workspace.path.read_bytes()
+            with self.assertRaisesRegex(CandidateBoundaryError, "hash does not match"):
+                workspace.apply(patch)
+            after = workspace.path.read_bytes()
+
+        self.assertEqual(before, after)
+
+    def test_governor_rejection_happens_before_workspace_creation(self) -> None:
+        source = read_managed_source(REPO_ROOT, TARGET_PATH)
+        patch = build_harmless_patch(source.decode("utf-8"), sha256_bytes(source))
+        patch = replace(
+            patch,
+            target_path="scripts/oal_001/governor.py",
+            changed_paths=("scripts/oal_001/governor.py",),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_parent = Path(temp_dir)
+            with mock_patch(
+                "scripts.oal_001.runtime.build_harmless_patch", return_value=patch
+            ):
+                with self.assertRaises(PermissionError):
+                    execute_cycle(
+                        REPO_ROOT,
+                        self.policy,
+                        BRANCH,
+                        BASE_SHA,
+                        git_status_before="## synthetic-test",
+                        git_status_after="## synthetic-test",
+                        temp_parent=temp_parent,
+                    )
+
+            self.assertEqual(list(temp_parent.iterdir()), [])
+
+    def test_candidate_parser_rejects_executable_syntax(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "observatory.py"
+            path.write_text(
+                "import pathlib\nSTRATEGY_WEIGHTS = {'primary': 0.7, 'exploration': 0.3}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "executable or unsupported"):
+                parse_strategy_source(path)
+
+    def test_candidate_parser_rejects_invalid_weight_sum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "observatory.py"
+            path.write_text(
+                "STRATEGY_WEIGHTS = {'primary': 0.8, 'exploration': 0.3}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "sum to one"):
+                parse_strategy_source(path)
+
+    def test_source_symlink_is_rejected_before_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / TARGET_PATH
+            target.parent.mkdir(parents=True)
+            real = root / "real.py"
+            real.write_text(
+                "STRATEGY_WEIGHTS = {'primary': 0.75, 'exploration': 0.25}\n",
+                encoding="utf-8",
+            )
+            try:
+                target.symlink_to(real)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+
+            with self.assertRaisesRegex(CandidateBoundaryError, "links or reparse"):
+                read_managed_source(root, TARGET_PATH)
+
+    def test_broken_source_symlink_is_rejected_before_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / TARGET_PATH
+            target.parent.mkdir(parents=True)
+            try:
+                target.symlink_to(root / "missing.py")
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
+
+            with self.assertRaisesRegex(CandidateBoundaryError, "links or reparse"):
+                read_managed_source(root, TARGET_PATH)
+
+    def test_windows_reparse_attribute_is_rejected(self) -> None:
+        attributes = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        fake_stat = SimpleNamespace(st_file_attributes=attributes)
+        with mock_patch.object(Path, "lstat", return_value=fake_stat):
+            self.assertTrue(_is_reparse_point(Path("synthetic-junction")))
+
+    def test_source_hardlink_is_rejected_before_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / TARGET_PATH
+            target.parent.mkdir(parents=True)
+            real = root / "real.py"
+            real.write_text(
+                "STRATEGY_WEIGHTS = {'primary': 0.75, 'exploration': 0.25}\n",
+                encoding="utf-8",
+            )
+            try:
+                os.link(real, target)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"hardlink creation unavailable: {exc}")
+
+            with self.assertRaisesRegex(CandidateBoundaryError, "hard-linked"):
+                read_managed_source(root, TARGET_PATH)
+
+    def test_evaluator_rejects_candidate_below_exploration_floor(self) -> None:
+        fixture = load_fixture(REPO_ROOT, self.policy.fixture_path)
+        harness = ReplayHarness(fixture)
+        baseline = harness.replay(REPO_ROOT / TARGET_PATH)
+        below_floor = replace(
+            baseline,
+            strategy_weights={"primary": 0.8, "exploration": 0.2},
+            route_counts={"primary": 16, "exploration": 4},
+        )
+        decision = PatchEvaluator(self.policy, fixture).evaluate(
+            Governor(self.policy).review(
+                build_harmless_patch(
+                    read_managed_source(REPO_ROOT, TARGET_PATH).decode("utf-8"),
+                    sha256_bytes(read_managed_source(REPO_ROOT, TARGET_PATH)),
+                ),
+                BRANCH,
+            ),
+            baseline,
+            baseline,
+            below_floor,
+            below_floor,
+            True,
+        )
+
+        self.assertEqual(decision.decision, "reject")
+        self.assertIn("exploration_floor_preserved", decision.reasons)
+
+    def test_boundary_and_risk_reports_mark_deferred_scope(self) -> None:
+        result = self.execute()
+
+        self.assertEqual(result.boundary_report["status"], "PASS")
+        self.assertEqual(result.risk_report["status"], "PASS_WITH_DEFERRED_SCOPE")
+        self.assertIn("ledger_writer", result.risk_report["deferred_scope"])
+
+    def _live_cycle(self):
+        status = _git_status(REPO_ROOT)
+        return execute_cycle(
+            REPO_ROOT,
+            self.policy,
+            git_branch(),
+            git_head(),
+            git_status_before=status,
+            git_status_after=status,
+        )
+
+    def test_cross_artifact_replay_tampering_is_rejected(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, self._live_cycle())
+            self.assertEqual(validate_artifacts(output_dir), [])
+            replay_after = json.loads(
+                (output_dir / "replay_after.json").read_text(encoding="utf-8")
+            )
+            replay_after["route_counts"]["exploration"] = 999
+            (output_dir / "replay_after.json").write_text(
+                json.dumps(replay_after, indent=2) + "\n", encoding="utf-8"
+            )
+
+            errors = validate_artifacts(output_dir)
+
+            self.assertIn(
+                "candidate replay does not match the reconstructed replay", errors
+            )
+
+    def test_rewriting_cycle_resets_stale_completion_state(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            result = self._live_cycle()
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+            (output_dir / "test_result.json").write_text(
+                '{"status":"PASS"}\n', encoding="utf-8"
+            )
+            (output_dir / "validation_complete.json").write_text(
+                '{"status":"PASS"}\n', encoding="utf-8"
+            )
+
+            write_cycle_artifacts(REPO_ROOT, policy, result)
+
+            test_result = json.loads(
+                (output_dir / "test_result.json").read_text(encoding="utf-8")
+            )
+            completion = json.loads(
+                (output_dir / "validation_complete.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(test_result["status"], "NOT_RUN")
+            self.assertFalse(test_result["evidence_complete"])
+            self.assertEqual(completion["status"], "INCOMPLETE")
+
+    def test_completion_marker_detects_post_validation_tampering(self) -> None:
+        local_private = REPO_ROOT / "raw" / "exports" / "local-private"
+        local_private.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="oal-001-test-", dir=local_private
+        ) as temp_dir:
+            output_root = Path(temp_dir)
+            policy = replace(
+                self.policy,
+                output_root=output_root.relative_to(REPO_ROOT).as_posix(),
+            )
+            result = self._live_cycle()
+            output_dir = write_cycle_artifacts(REPO_ROOT, policy, result)
+            pass_test_result = {
+                "schema_version": "OAL-1.0",
+                "run_id": result.run_id,
+                "status": "PASS",
+                "evidence_complete": True,
+                "static_checks": {"status": "PASS"},
+                "unit_tests": {
+                    "status": "PASS",
+                    "count": 37,
+                    "skipped": 0,
+                    "outcome_details": {},
+                    "return_code": 0,
+                },
+                "dry_run": {"status": "PASS", "return_code": 0},
+                "artifact_validation": {"status": "PASS", "errors": []},
+                "external_mutation_count": 0,
+            }
+            _atomic_write_json(output_dir / "test_result.json", pass_test_result)
+            completion = {
+                "schema_version": "OAL-1.0",
+                "run_id": result.run_id,
+                "status": "PASS",
+                "artifact_sha256": _artifact_digest_map(output_dir),
+            }
+            _atomic_write_json(output_dir / "validation_complete.json", completion)
+            self.assertEqual(validate_completion_marker(output_dir), [])
+
+            fail_test_result = copy.deepcopy(pass_test_result)
+            fail_test_result["status"] = "FAIL"
+            fail_test_result["evidence_complete"] = False
+            fail_test_result["artifact_validation"] = {
+                "status": "FAIL",
+                "errors": ["synthetic failure"],
+            }
+            _atomic_write_json(output_dir / "test_result.json", fail_test_result)
+            relabelled = {
+                "schema_version": "OAL-1.0",
+                "run_id": result.run_id,
+                "status": "PASS",
+                "artifact_sha256": _artifact_digest_map(output_dir),
+            }
+            _atomic_write_json(output_dir / "validation_complete.json", relabelled)
+            self.assertIn(
+                "completion marker status does not match bound test semantics",
+                validate_completion_marker(output_dir),
+            )
+
+            _atomic_write_json(output_dir / "test_result.json", pass_test_result)
+            completion["artifact_sha256"] = _artifact_digest_map(output_dir)
+            _atomic_write_json(output_dir / "validation_complete.json", completion)
+            (output_dir / "replay_after.json").write_text("{}\n", encoding="utf-8")
+
+            errors = validate_completion_marker(output_dir)
+
+            self.assertIn(
+                "completion marker artifact digests do not match current bytes", errors
+            )
+
+    def test_subprocess_alias_bypass_is_rejected(self) -> None:
+        tree = ast.parse(
+            "import subprocess as sp\nsp.run(['git', 'push', 'origin', 'main'])\n"
+        )
+
+        errors = _subprocess_boundary_errors("synthetic.py", tree)
+
+        self.assertIn("subprocess import alias is forbidden in synthetic.py", errors)
+        namespace_tree = ast.parse(
+            "globals()['subprocess'].run(['git', 'push', 'origin', 'main'])\n"
+        )
+        namespace_errors = _subprocess_boundary_errors("synthetic.py", namespace_tree)
+        self.assertIn(
+            "dynamic execution or namespace access is forbidden in synthetic.py",
+            namespace_errors,
+        )
+        process_bypasses = (
+            "import sys as s\ns.modules['subprocess'].run(['git', 'push'])\n",
+            "from sys import modules as m\nm['subprocess'].run(['git', 'push'])\n",
+            "import os\nos.spawnlp(os.P_WAIT, 'git', 'git', 'push')\n",
+        )
+        for source in process_bypasses:
+            with self.subTest(source=source):
+                bypass_errors = _subprocess_boundary_errors(
+                    "synthetic.py", ast.parse(source)
+                )
+                self.assertTrue(bypass_errors)
+
+    def test_unit_test_gate_rejects_zero_tests(self) -> None:
+        errors = unit_test_gate_errors(return_code=0, count=0, outcome_details={})
+
+        self.assertIn("unit test count must be at least 37, got 0", errors)
+
+    def test_unit_test_parser_uses_anchored_final_skip_summary(self) -> None:
+        output = (
+            "test_noise ... skipped=0\n"
+            "----------------------------------------------------------------------\n"
+            "Ran 37 tests in 0.100s\n\n"
+            "OK (skipped=1)\n"
+        )
+        completed = SimpleNamespace(returncode=0, stdout=output)
+        with mock_patch(
+            "scripts.validate_oal_001.subprocess.run", return_value=completed
+        ):
+            return_code, _, count, outcomes = run_unit_tests()
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(count, 37)
+        self.assertEqual(outcomes, {"skipped": 1})
+        self.assertTrue(unit_test_gate_errors(return_code, count, outcomes))
+
+        expected_failure_output = output.replace(
+            "OK (skipped=1)", "OK (expected failures=37)"
+        )
+        completed = SimpleNamespace(returncode=0, stdout=expected_failure_output)
+        with mock_patch(
+            "scripts.validate_oal_001.subprocess.run", return_value=completed
+        ):
+            return_code, _, count, outcomes = run_unit_tests()
+        self.assertEqual(outcomes, {"expected failures": 37})
+        self.assertTrue(unit_test_gate_errors(return_code, count, outcomes))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oal_001_runtime.py
+++ b/tests/test_oal_001_runtime.py
@@ -1140,6 +1140,325 @@ class Oal001RuntimeTests(unittest.TestCase):
             ),
         )
 
+    def test_subprocess_calls_are_bound_to_exact_ast_and_call_sites(self) -> None:
+        expected_sites = {
+            "scripts/oal_001/git_read.py": {("_run_git", 6)},
+            "scripts/validate_oal_001.py": {
+                ("run_unit_tests", 0),
+                ("run_dry_run", 0),
+            },
+        }
+        for rel_path in PYTHON_FILES:
+            tree = ast.parse(
+                (REPO_ROOT / rel_path).read_text(encoding="utf-8"),
+                filename=rel_path,
+                feature_version=(3, 11),
+            )
+            actual_sites: set[tuple[str, int]] = set()
+            for function in (
+                node for node in tree.body if isinstance(node, ast.FunctionDef)
+            ):
+                for body_index, statement in enumerate(function.body):
+                    if any(
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == "subprocess"
+                        and node.func.attr == "run"
+                        for node in ast.walk(statement)
+                    ):
+                        actual_sites.add((function.name, body_index))
+            with self.subTest(rel_path=rel_path):
+                self.assertEqual(actual_sites, expected_sites.get(rel_path, set()))
+                self.assertNotIn(
+                    f"canonical subprocess.run contract does not match in {rel_path}",
+                    _subprocess_boundary_errors(rel_path, tree),
+                )
+
+        validator_path = "scripts/validate_oal_001.py"
+        validator_source = (REPO_ROOT / validator_path).read_text(encoding="utf-8")
+
+        def validator_tree() -> ast.Module:
+            return ast.parse(
+                validator_source,
+                filename=validator_path,
+                feature_version=(3, 11),
+            )
+
+        def direct_run(
+            tree: ast.Module, function_name: str
+        ) -> tuple[ast.FunctionDef, ast.Call]:
+            functions = [
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == function_name
+            ]
+            self.assertEqual(len(functions), 1)
+            calls = [
+                node
+                for node in ast.walk(functions[0])
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "subprocess"
+                and node.func.attr == "run"
+            ]
+            self.assertEqual(len(calls), 1)
+            return functions[0], calls[0]
+
+        mutants: list[tuple[str, str, ast.Module]] = []
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        next(
+            keyword for keyword in call.keywords if keyword.arg == "cwd"
+        ).value = ast.Call(
+            func=ast.Name(id="side_effect", ctx=ast.Load()),
+            args=[],
+            keywords=[],
+        )
+        mutants.append(("side effect in cwd", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.keywords.append(ast.keyword(arg="shell", value=ast.Constant(value=True)))
+        mutants.append(("extra keyword", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.keywords.append(
+            ast.keyword(arg=None, value=ast.Name(id="options", ctx=ast.Load()))
+        )
+        mutants.append(("keyword expansion", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.args.append(ast.Constant(value="unexpected"))
+        mutants.append(("extra positional argument", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.args[0] = ast.Starred(value=call.args[0], ctx=ast.Load())
+        mutants.append(("positional expansion", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.keywords.reverse()
+        mutants.append(("keyword order", validator_path, tree))
+
+        tree = validator_tree()
+        _, call = direct_run(tree, "run_unit_tests")
+        call.keywords = [keyword for keyword in call.keywords if keyword.arg != "check"]
+        mutants.append(("missing keyword", validator_path, tree))
+
+        tree = validator_tree()
+        function, _ = direct_run(tree, "run_unit_tests")
+        function.name = "renamed_unit_tests"
+        mutants.append(("wrong function", validator_path, tree))
+
+        tree = validator_tree()
+        function, _ = direct_run(tree, "run_unit_tests")
+        function.body.insert(0, ast.Pass())
+        mutants.append(("wrong body index", validator_path, tree))
+
+        tree = validator_tree()
+        function, _ = direct_run(tree, "run_unit_tests")
+        function.body.append(copy.deepcopy(function.body[0]))
+        mutants.append(("duplicate call", validator_path, tree))
+
+        tree = validator_tree()
+        function, _ = direct_run(tree, "run_unit_tests")
+        statement = function.body[0]
+        self.assertIsInstance(statement, ast.Assign)
+        statement.targets = [ast.Name(id="other_result", ctx=ast.Store())]
+        mutants.append(("changed result target", validator_path, tree))
+
+        git_path = "scripts/oal_001/git_read.py"
+        git_tree = ast.parse(
+            (REPO_ROOT / git_path).read_text(encoding="utf-8"),
+            filename=git_path,
+            feature_version=(3, 11),
+        )
+        _, git_call = direct_run(git_tree, "_run_git")
+        next(
+            keyword for keyword in git_call.keywords if keyword.arg == "env"
+        ).value = ast.Call(
+            func=ast.Name(id="side_effect", ctx=ast.Load()),
+            args=[],
+            keywords=[],
+        )
+        mutants.append(("side effect in git environment", git_path, git_tree))
+
+        for name, rel_path, tree in mutants:
+            with self.subTest(name=name):
+                self.assertIn(
+                    f"canonical subprocess.run contract does not match in {rel_path}",
+                    _subprocess_boundary_errors(rel_path, tree),
+                )
+
+    def test_os_import_is_canonical_and_rebinding_is_rejected(self) -> None:
+        expected_paths = {
+            "scripts/oal_001/git_read.py",
+            "scripts/oal_001/runtime.py",
+            "scripts/validate_oal_001.py",
+            "tests/test_oal_001_runtime.py",
+        }
+        for rel_path in PYTHON_FILES:
+            tree = ast.parse(
+                (REPO_ROOT / rel_path).read_text(encoding="utf-8"),
+                filename=rel_path,
+                feature_version=(3, 11),
+            )
+            canonical_imports = [
+                node
+                for node in tree.body
+                if isinstance(node, ast.Import)
+                and len(node.names) == 1
+                and node.names[0].name == "os"
+                and node.names[0].asname is None
+            ]
+            errors = _subprocess_boundary_errors(rel_path, tree)
+            with self.subTest(rel_path=rel_path):
+                self.assertEqual(
+                    len(canonical_imports), int(rel_path in expected_paths)
+                )
+                self.assertNotIn(
+                    f"canonical os import contract does not match in {rel_path}",
+                    errors,
+                )
+                self.assertNotIn(f"os rebinding is forbidden in {rel_path}", errors)
+                self.assertNotIn(
+                    f"canonical os reference contract does not match in {rel_path}",
+                    errors,
+                )
+
+        canonical_path = "scripts/oal_001/runtime.py"
+        canonical_source = (REPO_ROOT / canonical_path).read_text(encoding="utf-8")
+        rebinding_mutants = {
+            "assignment": canonical_source.replace(
+                "import os\n", "import os\nos = helper\n", 1
+            ),
+            "argument": canonical_source + "\ndef synthetic(os):\n    pass\n",
+            "foreign import": canonical_source.replace(
+                "import os\n", "import os\nimport helper as os\n", 1
+            ),
+            "from import": canonical_source.replace(
+                "import os\n", "import os\nfrom helper import module as os\n", 1
+            ),
+            "mapping pattern": (
+                canonical_source + "\nmatch {}:\n    case {**os}:\n        pass\n"
+            ),
+            "loop target": canonical_source + "\nfor os in ():\n    pass\n",
+        }
+        expected_rebinding = f"os rebinding is forbidden in {canonical_path}"
+        for name, source in rebinding_mutants.items():
+            with self.subTest(name=name):
+                self.assertIn(
+                    expected_rebinding,
+                    _subprocess_boundary_errors(
+                        canonical_path,
+                        ast.parse(source, feature_version=(3, 11)),
+                    ),
+                )
+
+        canonical_mutants = {
+            "missing": canonical_source.replace("import os\n", "", 1),
+            "duplicate": canonical_source.replace(
+                "import os\n", "import os\nimport os\n", 1
+            ),
+            "nested": canonical_source.replace(
+                "import os\n", "if True:\n    import os\n", 1
+            ),
+            "self alias": canonical_source.replace(
+                "import os\n", "import os as os\n", 1
+            ),
+            "combined": canonical_source.replace(
+                "import os\n", "import os, colorsys\n", 1
+            ),
+        }
+        expected_contract = (
+            f"canonical os import contract does not match in {canonical_path}"
+        )
+        for name, source in canonical_mutants.items():
+            with self.subTest(name=name):
+                self.assertIn(
+                    expected_contract,
+                    _subprocess_boundary_errors(
+                        canonical_path,
+                        ast.parse(source, feature_version=(3, 11)),
+                    ),
+                )
+
+        reference_mutants = {
+            "module alias": canonical_source
+            + "\nalias = os\nalias.system('echo unsafe')\n",
+            "process alias": canonical_source
+            + "\nrunner = os.system\nrunner('echo unsafe')\n",
+            "allowed attribute alias": canonical_source
+            + "\nrunner = os.replace\nrunner('source', 'target')\n",
+            "attribute chain": canonical_source
+            + "\nos.path.os.system('echo unsafe')\n",
+            "callback argument": canonical_source + "\ncallback(os)\n",
+            "return module": canonical_source + "\ndef synthetic():\n    return os\n",
+        }
+        expected_reference_error = (
+            f"canonical os reference contract does not match in {canonical_path}"
+        )
+        for name, source in reference_mutants.items():
+            with self.subTest(name=name):
+                self.assertIn(
+                    expected_reference_error,
+                    _subprocess_boundary_errors(
+                        canonical_path,
+                        ast.parse(source, feature_version=(3, 11)),
+                    ),
+                )
+
+        test_path = "tests/test_oal_001_runtime.py"
+        test_source = (REPO_ROOT / test_path).read_text(encoding="utf-8")
+        exact_site_mutants = {
+            "extra replace call": (
+                canonical_path,
+                canonical_source + "\nos.replace('outside', 'target')\n",
+            ),
+            "fdopen result chain": (
+                canonical_path,
+                canonical_source + "\nos.fdopen(descriptor, 'wb').write(b'outside')\n",
+            ),
+            "extra link call": (
+                test_path,
+                test_source + "\nos.link('source', 'target')\n",
+            ),
+            "environment alias": (
+                test_path,
+                test_source + "\nenv_alias = os.environ\nenv_alias['OAL_X'] = '1'\n",
+            ),
+        }
+        for name, (rel_path, source) in exact_site_mutants.items():
+            with self.subTest(name=name):
+                self.assertIn(
+                    f"canonical os reference contract does not match in {rel_path}",
+                    _subprocess_boundary_errors(
+                        rel_path,
+                        ast.parse(source, feature_version=(3, 11)),
+                    ),
+                )
+
+        unexpected_path = "scripts/oal_001/__main__.py"
+        self.assertIn(
+            f"canonical os reference contract does not match in {unexpected_path}",
+            _subprocess_boundary_errors(
+                unexpected_path, ast.parse("os.devnull\n", feature_version=(3, 11))
+            ),
+        )
+        self.assertIn(
+            "from-os imports are forbidden in synthetic.py",
+            _subprocess_boundary_errors(
+                "synthetic.py",
+                ast.parse("from os import path\n", feature_version=(3, 11)),
+            ),
+        )
+
     def test_workflow_and_validator_use_isolated_import_bootstrap(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/oal-001-validate.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

Implements the first reversible slice of OAL-001 for Issue #97: a controlled self-modification sandbox that keeps the running Governor immutable while a single allowlisted Observatory candidate is patched, replayed, evaluated, rolled back, and fully traced.

Nine follow-up hardening commits incorporate independent review and CI findings by binding evidence and digests to immutable snapshots, isolating Git and Python import observations, failing closed on ambiguous merge bases, constraining canonical `getattr`/`subprocess`/`sys`/`os` AST contracts, and making the Git fixture cross-platform under Python 3.11 CI.

## Track Classification

- [x] Track A — Public Canon (public-safe framework implementation and governance)
- [ ] Track B — Evidence / Registry (aggregate indices, redacted)
- [ ] Track C — NOT for public repository (blocked)

## Boundary Check

- [x] No raw Notion URLs, `collection://` handles, or UUID object IDs
- [x] No unredacted PII (email, phone, IBAN, wallet, IP address)
- [x] No API keys, tokens, passwords, or credential-like strings
- [x] No raw transcript excerpts or unredacted XXL export content
- [x] No patent-sensitive TNPX-01 implementation details
- [x] No `GODFATHER_LOCK` personal/intimate logs
- [x] No Track C (Metarotik / private narrative) content

## Runtime behavior

- separates the protected Governor from the single mutable target `scripts/oal_001/observatory.py`
- creates an allowlisted temporary candidate workspace without overwriting the baseline
- applies one deterministic synthetic strategy-weight change
- parses candidate data through an AST-constrained replay path; candidate source is not executed
- compares baseline and candidate, returns `RETAIN`, proves rollback, and removes the candidate workspace
- writes run evidence only below gitignored `raw/exports/local-private/oal-001/`
- performs no connector, Notion, ledger, publication, payment, production, or remote mutation

## Validation

```text
Local CPython 3.11.14 focused OAL suite: 70/70 passed, 0 skipped
Local CPython 3.11.14 repository suite: 104/104 passed
Local OAL validator: PASS, exit 0, run OAL-001-BBE4BA4231DEEE6C
Local write-free --verify-existing: VERIFIED, exit 0
Local evidence fingerprints before/after verification: unchanged (12 files)
GitHub Actions OAL Python 3.11: PASS, 70/70, 0 skipped
GitHub Actions evidence run: OAL-001-BE225B78AA4C37D2
GitHub Actions source SHA: 57b910551d7b48061a6d6095d66ec87c7fa6a395
python scripts/validate_docs.py: OK
Ruff check: PASS
Ruff format --check: PASS
git diff --check: PASS
```

The local clean-commit evidence and the fresh Ubuntu GitHub Actions run both used CPython 3.11.14 and are bound to commit `57b910551d7b48061a6d6095d66ec87c7fa6a395`.

## Evidence outcome

- baseline exploration: `0.25` / 5 of 20 routes
- candidate exploration: `0.30` / 6 of 20 routes
- evaluator: `RETAIN`
- rollback: `VERIFIED`
- boundary: `PASS`
- promotion-ready evidence: `true`
- external mutation count: `0` (static allowlisted runtime-path observation, not independent egress monitoring)

Local-private evidence is intentionally not included in this PR.

## File Changes

| File group | Change | Reason |
|---|---|---|
| `config/oal_001.json` and governance policy | Added | Define immutable/mutable scope and promotion gates |
| `schemas/oal_001_mutation_trace.schema.json` | Added | Provide a machine-readable mutation trace contract |
| `scripts/oal_001/` | Added | Implement Governor, Observatory, trusted Git reads, replay, evaluation, and rollback |
| `scripts/validate_oal_001.py` | Added | Produce and semantically verify bound local evidence |
| OAL fixture and tests | Added | Cover deterministic replay, tamper rejection, boundaries, and rollback |

## Related Issues

Refs #97. This PR implements only the explicitly scoped first slice and does not close the broader Observatory-runtime issue.

## Notes

A retained candidate is technical evidence only; it is not promoted or activated. Historical Hubble/ALMA fixture admission, executable candidate sandboxing, broader Observatory engines, ledger writing, three controlled cycles, live connectors, and promotion remain separate human-gated work.

Completion digests prove local bundle consistency, not authorship, and are not cryptographically signed.
