### PR TITLE
feat(zenodo): add authenticated read-only v16 stats collector

### DIFF
--- a/.github/workflows/zenodo-v16-read-stats.yml
+++ b/.github/workflows/zenodo-v16-read-stats.yml
@@ -1,13 +1,37 @@
 name: Collect Zenodo v16 read-only stats
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/zenodo-v16-read-stats.yml"
+      - "scripts/zenodo_v16_read_stats.py"
+      - "tests/test_zenodo_v16_read_stats.py"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  collect-stats:
+  validate-read-only-collector:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository without write credentials
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Compile collector
+        run: python -m py_compile scripts/zenodo_v16_read_stats.py
+
+      - name: Verify read-only collector tests
+        run: python -m unittest tests.test_zenodo_v16_read_stats -v
+
+  collect-authenticated-stats:
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate-read-only-collector
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
@@ -22,9 +46,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
-
-      - name: Verify read-only collector tests
-        run: python -m unittest tests.test_zenodo_v16_read_stats -v
 
       - name: Collect authenticated Zenodo v16 statistics
         run: |

--- a/.github/workflows/zenodo-v16-read-stats.yml
+++ b/.github/workflows/zenodo-v16-read-stats.yml
@@ -1,0 +1,42 @@
+name: Collect Zenodo v16 read-only stats
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  collect-stats:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    env:
+      ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_API }}
+      ZENODO_API_BASE: https://zenodo.org/api
+      ZENODO_RECORD_ID: "20732376"
+
+    steps:
+      - name: Check out repository without write credentials
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Verify read-only collector tests
+        run: python -m unittest tests.test_zenodo_v16_read_stats -v
+
+      - name: Collect authenticated Zenodo v16 statistics
+        run: |
+          set -euo pipefail
+          python scripts/zenodo_v16_read_stats.py \
+            --require-auth \
+            --output zenodo-v16-stats.json
+
+      - name: Upload statistics evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenodo-v16-read-stats
+          path: zenodo-v16-stats.json
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/zenodo_v16_read_stats.py
+++ b/scripts/zenodo_v16_read_stats.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Read Zenodo v16 statistics without permitting any remote mutation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_API_BASE = "https://zenodo.org/api"
+DEFAULT_RECORD_ID = "20732376"
+EXPECTED_DOI = "10.5281/zenodo.20732376"
+EXPECTED_CONCEPT_DOI = "10.5281/zenodo.19774446"
+EXPECTED_VERSION = "v16"
+READ_ONLY_METHOD = "GET"
+STAT_KEYS = (
+    "downloads",
+    "unique_downloads",
+    "views",
+    "unique_views",
+    "version_downloads",
+    "version_unique_downloads",
+    "version_views",
+    "version_unique_views",
+)
+
+
+def assert_read_only_method(method: str) -> None:
+    if method.upper() != READ_ONLY_METHOD:
+        raise RuntimeError(f"Remote mutation blocked: HTTP method {method!r} is not allowed")
+
+
+def normalize_token(value: str | None) -> str:
+    if not value:
+        return ""
+    token = value.replace("\r", "").replace("\n", "").strip()
+    if token.lower().startswith("bearer "):
+        token = token[7:].strip()
+    return token
+
+
+def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
+    assert_read_only_method("GET")
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "TerraNova-Zenodo-ReadStats/1.0",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    for attempt in range(1, attempts + 1):
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"Unexpected Zenodo response: HTTP {response.status}")
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code not in {429, 500, 502, 503, 504} or attempt == attempts:
+                body = exc.read().decode("utf-8", errors="replace")
+                raise RuntimeError(f"Zenodo GET failed: HTTP {exc.code}: {body[:500]}") from exc
+            time.sleep(2 ** (attempt - 1))
+        except urllib.error.URLError as exc:
+            if attempt == attempts:
+                raise RuntimeError(f"Zenodo GET failed: {exc}") from exc
+            time.sleep(2 ** (attempt - 1))
+
+    raise RuntimeError("Zenodo GET failed after retries")
+
+
+def validate_record(record: dict[str, Any], record_id: str) -> None:
+    if str(record.get("id")) != record_id:
+        raise RuntimeError(f"Unexpected record id: {record.get('id')!r}")
+    if record.get("doi") != EXPECTED_DOI:
+        raise RuntimeError(f"Unexpected DOI: {record.get('doi')!r}")
+    if record.get("conceptdoi") != EXPECTED_CONCEPT_DOI:
+        raise RuntimeError(f"Unexpected concept DOI: {record.get('conceptdoi')!r}")
+    version = record.get("metadata", {}).get("version")
+    if version != EXPECTED_VERSION:
+        raise RuntimeError(f"Unexpected version: {version!r}")
+
+
+def extract_stats(record: dict[str, Any]) -> dict[str, int]:
+    stats = record.get("stats")
+    if not isinstance(stats, dict):
+        raise RuntimeError("Zenodo response has no stats object")
+
+    result: dict[str, int] = {}
+    missing: list[str] = []
+    for key in STAT_KEYS:
+        value = stats.get(key)
+        if isinstance(value, bool) or not isinstance(value, int):
+            missing.append(key)
+        else:
+            result[key] = value
+
+    if missing:
+        raise RuntimeError(f"Zenodo stats schema drift: missing/non-integer keys: {', '.join(missing)}")
+    return result
+
+
+def build_snapshot(record: dict[str, Any], authenticated: bool) -> dict[str, Any]:
+    stats = extract_stats(record)
+    return {
+        "collector": "ZENODO-V16-READ-STATS-001",
+        "captured_at_utc": datetime.now(timezone.utc).isoformat(),
+        "remote_method": "GET",
+        "read_only": True,
+        "authenticated": authenticated,
+        "record_id": str(record["id"]),
+        "doi": record.get("doi"),
+        "conceptdoi": record.get("conceptdoi"),
+        "version": record.get("metadata", {}).get("version"),
+        "updated": record.get("updated"),
+        "stats": stats,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect authenticated read-only Zenodo v16 statistics.")
+    parser.add_argument("--record-id", default=os.environ.get("ZENODO_RECORD_ID", DEFAULT_RECORD_ID))
+    parser.add_argument("--api-base", default=os.environ.get("ZENODO_API_BASE", DEFAULT_API_BASE))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--require-auth", action="store_true")
+    args = parser.parse_args()
+
+    token = normalize_token(os.environ.get("ZENODO_ACCESS_TOKEN"))
+    if args.require_auth and not token:
+        raise SystemExit("ZENODO_ACCESS_TOKEN is required but empty")
+
+    url = f"{args.api_base.rstrip('/')}/records/{args.record_id}"
+    record = request_json(url, token)
+    validate_record(record, args.record_id)
+    snapshot = build_snapshot(record, authenticated=bool(token))
+    rendered = json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n"
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_zenodo_v16_read_stats.py
+++ b/tests/test_zenodo_v16_read_stats.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "zenodo_v16_read_stats.py"
+SPEC = importlib.util.spec_from_file_location("zenodo_v16_read_stats", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeResponse:
+    status = 200
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class ZenodoV16ReadStatsTests(unittest.TestCase):
+    def sample_record(self) -> dict:
+        return {
+            "id": 20732376,
+            "doi": MODULE.EXPECTED_DOI,
+            "conceptdoi": MODULE.EXPECTED_CONCEPT_DOI,
+            "updated": "2026-08-09T00:00:00+00:00",
+            "metadata": {"version": MODULE.EXPECTED_VERSION},
+            "stats": {
+                "downloads": 686,
+                "unique_downloads": 530,
+                "views": 824,
+                "unique_views": 679,
+                "version_downloads": 39,
+                "version_unique_downloads": 31,
+                "version_views": 123,
+                "version_unique_views": 107,
+            },
+        }
+
+    def test_rejects_every_non_get_method(self) -> None:
+        for method in ("POST", "PUT", "PATCH", "DELETE"):
+            with self.subTest(method=method):
+                with self.assertRaises(RuntimeError):
+                    MODULE.assert_read_only_method(method)
+
+    def test_request_uses_get_and_bearer_without_printing_token(self) -> None:
+        record = self.sample_record()
+        with patch.object(MODULE.urllib.request, "urlopen", return_value=FakeResponse(record)) as mocked:
+            result = MODULE.request_json("https://zenodo.org/api/records/20732376", "secret-token")
+        self.assertEqual(result, record)
+        request = mocked.call_args.args[0]
+        self.assertEqual(request.get_method(), "GET")
+        self.assertEqual(request.headers.get("Authorization"), "Bearer secret-token")
+
+    def test_validates_current_v16_identity(self) -> None:
+        MODULE.validate_record(self.sample_record(), "20732376")
+
+    def test_extracts_exact_eight_statistics(self) -> None:
+        stats = MODULE.extract_stats(self.sample_record())
+        self.assertEqual(tuple(stats), MODULE.STAT_KEYS)
+        self.assertEqual(stats["unique_views"], 679)
+        self.assertEqual(stats["version_unique_downloads"], 31)
+
+    def test_fails_closed_on_stats_schema_drift(self) -> None:
+        record = self.sample_record()
+        del record["stats"]["version_unique_views"]
+        with self.assertRaises(RuntimeError):
+            MODULE.extract_stats(record)
+
+    def test_snapshot_marks_remote_path_read_only(self) -> None:
+        snapshot = MODULE.build_snapshot(self.sample_record(), authenticated=True)
+        self.assertTrue(snapshot["read_only"])
+        self.assertTrue(snapshot["authenticated"])
+        self.assertEqual(snapshot["remote_method"], "GET")
+        self.assertEqual(snapshot["record_id"], "20732376")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add the missing current v16 statistics read path while reusing the existing GitHub Actions secret `ZENODO_API`.

## Scope

- adds `scripts/zenodo_v16_read_stats.py`
- adds focused unit tests for GET-only enforcement, v16 identity validation and stats-schema drift
- adds a GitHub Actions workflow with two separated lanes:
  - pull-request validation without secrets or Zenodo access
  - authenticated manual collection via `workflow_dispatch` using `secrets.ZENODO_API`
- collects the eight tracked family/version statistics for record `20732376`
- writes only a GitHub Actions artifact (`zenodo-v16-stats.json`) during the authenticated collection lane

## Safety boundary

- Zenodo remote method is hard-limited to `GET`
- `POST`, `PUT`, `PATCH` and `DELETE` are explicitly rejected
- pull-request validation does not receive or use the Zenodo secret
- authenticated Zenodo collection runs only on explicit `workflow_dispatch`
- workflow repository permission is `contents: read`
- checkout credentials are not persisted
- token is never written into the output snapshot
- no Zenodo metadata, files, DOI state, drafts or publication state are changed
- no schedule is enabled yet
- no merge is authorized by this PR

## Current source binding

- record: `20732376`
- DOI: `10.5281/zenodo.20732376`
- Concept DOI: `10.5281/zenodo.19774446`
- version: `v16`

## Validation

- `Collect Zenodo v16 read-only stats` pull-request run #1: SUCCESS on head `79009f2c4ecc1925e89209bae0d022a55c917aab`
- PR validation compiles the collector and runs the focused unit suite
- authenticated Zenodo GET has not been executed yet because the workflow is not on the default branch

## Human gate

This PR remains intentionally Draft. Merge remains a separate explicit Human Gate. After merge, the first authenticated `workflow_dispatch` run is the next bounded validation step; publication or Zenodo mutation remains out of scope.