### PR TITLE
fix(zenodo): handle absent publication version metadata

### DIFF
--- a/scripts/zenodo_v16_read_stats.py
+++ b/scripts/zenodo_v16_read_stats.py
@@ -49,7 +49,7 @@ def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
     assert_read_only_method("GET")
     headers = {
         "Accept": "application/json",
-        "User-Agent": "TerraNova-Zenodo-ReadStats/1.0",
+        "User-Agent": "TerraNova-Zenodo-ReadStats/1.1",
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
@@ -74,15 +74,31 @@ def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
     raise RuntimeError("Zenodo GET failed after retries")
 
 
+def metadata_version(record: dict[str, Any]) -> str | None:
+    metadata = record.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get("version")
+    return value if isinstance(value, str) and value.strip() else None
+
+
 def validate_record(record: dict[str, Any], record_id: str) -> None:
+    """Validate immutable v16 identity anchors.
+
+    Zenodo publication records do not necessarily expose ``metadata.version``.
+    The record is therefore bound primarily by the exact record id, DOI and
+    concept DOI. If Zenodo does expose a version string, it must still match
+    the expected v16 label; a conflicting value fails closed.
+    """
     if str(record.get("id")) != record_id:
         raise RuntimeError(f"Unexpected record id: {record.get('id')!r}")
     if record.get("doi") != EXPECTED_DOI:
         raise RuntimeError(f"Unexpected DOI: {record.get('doi')!r}")
     if record.get("conceptdoi") != EXPECTED_CONCEPT_DOI:
         raise RuntimeError(f"Unexpected concept DOI: {record.get('conceptdoi')!r}")
-    version = record.get("metadata", {}).get("version")
-    if version != EXPECTED_VERSION:
+
+    version = metadata_version(record)
+    if version is not None and version != EXPECTED_VERSION:
         raise RuntimeError(f"Unexpected version: {version!r}")
 
 
@@ -107,8 +123,10 @@ def extract_stats(record: dict[str, Any]) -> dict[str, int]:
 
 def build_snapshot(record: dict[str, Any], authenticated: bool) -> dict[str, Any]:
     stats = extract_stats(record)
+    observed_version = metadata_version(record)
     return {
         "collector": "ZENODO-V16-READ-STATS-001",
+        "collector_schema": "1.1",
         "captured_at_utc": datetime.now(timezone.utc).isoformat(),
         "remote_method": "GET",
         "read_only": True,
@@ -116,7 +134,9 @@ def build_snapshot(record: dict[str, Any], authenticated: bool) -> dict[str, Any
         "record_id": str(record["id"]),
         "doi": record.get("doi"),
         "conceptdoi": record.get("conceptdoi"),
-        "version": record.get("metadata", {}).get("version"),
+        "expected_version": EXPECTED_VERSION,
+        "metadata_version": observed_version,
+        "version_binding": "metadata.version" if observed_version else "record_id+doi+conceptdoi",
         "updated": record.get("updated"),
         "stats": stats,
     }

--- a/tests/test_zenodo_v16_read_stats.py
+++ b/tests/test_zenodo_v16_read_stats.py
@@ -64,8 +64,23 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
         self.assertEqual(request.get_method(), "GET")
         self.assertEqual(request.headers.get("Authorization"), "Bearer secret-token")
 
-    def test_validates_current_v16_identity(self) -> None:
+    def test_validates_current_v16_identity_when_version_is_present(self) -> None:
         MODULE.validate_record(self.sample_record(), "20732376")
+
+    def test_allows_missing_optional_metadata_version_with_strong_identity_anchors(self) -> None:
+        record = self.sample_record()
+        record["metadata"].pop("version")
+        MODULE.validate_record(record, "20732376")
+        snapshot = MODULE.build_snapshot(record, authenticated=True)
+        self.assertIsNone(snapshot["metadata_version"])
+        self.assertEqual(snapshot["expected_version"], "v16")
+        self.assertEqual(snapshot["version_binding"], "record_id+doi+conceptdoi")
+
+    def test_rejects_conflicting_metadata_version_when_present(self) -> None:
+        record = self.sample_record()
+        record["metadata"]["version"] = "v15"
+        with self.assertRaises(RuntimeError):
+            MODULE.validate_record(record, "20732376")
 
     def test_extracts_exact_eight_statistics(self) -> None:
         stats = MODULE.extract_stats(self.sample_record())
@@ -85,6 +100,7 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
         self.assertTrue(snapshot["authenticated"])
         self.assertEqual(snapshot["remote_method"], "GET")
         self.assertEqual(snapshot["record_id"], "20732376")
+        self.assertEqual(snapshot["version_binding"], "metadata.version")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The first authenticated run of `Collect Zenodo v16 read-only stats` reached Zenodo successfully with `ZENODO_API`, but failed closed because record `20732376` returned no `metadata.version` field.

## Fix

- keep exact record ID, DOI and concept DOI as mandatory identity anchors
- accept an absent `metadata.version` field for this publication record
- still fail closed if Zenodo exposes a conflicting version value
- record both `expected_version` and observed `metadata_version` plus the `version_binding` method in the JSON evidence
- add tests for missing and conflicting version metadata

## Safety

No Zenodo write path is introduced. HTTP method remains hard-limited to GET. No schedule or publication mutation is added.

## Human gate

Draft PR only. Merge remains behind explicit approval.