### PR TITLE
Zenodo collector: capture data volume read-only

### DIFF
--- a/scripts/zenodo_v16_read_stats.py
+++ b/scripts/zenodo_v16_read_stats.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
+import re
 import time
 import urllib.error
 import urllib.request
@@ -14,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_API_BASE = "https://zenodo.org/api"
+DEFAULT_LANDING_BASE = "https://zenodo.org/records"
 DEFAULT_RECORD_ID = "20732376"
 EXPECTED_DOI = "10.5281/zenodo.20732376"
 EXPECTED_CONCEPT_DOI = "10.5281/zenodo.19774446"
@@ -28,6 +31,10 @@ STAT_KEYS = (
     "version_unique_downloads",
     "version_views",
     "version_unique_views",
+)
+DATA_VOLUME_PATTERN = re.compile(
+    r"Data\s+volume\s+All\s+versions\s+([0-9][0-9.,]*\s*[KMGTPE]?B)\s+This\s+version\s+([0-9][0-9.,]*\s*[KMGTPE]?B)",
+    re.IGNORECASE,
 )
 
 
@@ -45,11 +52,11 @@ def normalize_token(value: str | None) -> str:
     return token
 
 
-def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
+def request_bytes(url: str, token: str, accept: str, attempts: int = 4) -> bytes:
     assert_read_only_method("GET")
     headers = {
-        "Accept": "application/json",
-        "User-Agent": "TerraNova-Zenodo-ReadStats/1.1",
+        "Accept": accept,
+        "User-Agent": "TerraNova-Zenodo-ReadStats/1.2",
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
@@ -60,7 +67,7 @@ def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
             with urllib.request.urlopen(req, timeout=30) as response:
                 if response.status != 200:
                     raise RuntimeError(f"Unexpected Zenodo response: HTTP {response.status}")
-                return json.loads(response.read().decode("utf-8"))
+                return response.read()
         except urllib.error.HTTPError as exc:
             if exc.code not in {429, 500, 502, 503, 504} or attempt == attempts:
                 body = exc.read().decode("utf-8", errors="replace")
@@ -72,6 +79,14 @@ def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
             time.sleep(2 ** (attempt - 1))
 
     raise RuntimeError("Zenodo GET failed after retries")
+
+
+def request_json(url: str, token: str, attempts: int = 4) -> dict[str, Any]:
+    return json.loads(request_bytes(url, token, "application/json", attempts).decode("utf-8"))
+
+
+def request_text(url: str, token: str, attempts: int = 4) -> str:
+    return request_bytes(url, token, "text/html", attempts).decode("utf-8", errors="replace")
 
 
 def metadata_version(record: dict[str, Any]) -> str | None:
@@ -121,12 +136,39 @@ def extract_stats(record: dict[str, Any]) -> dict[str, int]:
     return result
 
 
-def build_snapshot(record: dict[str, Any], authenticated: bool) -> dict[str, Any]:
+def extract_data_volume(page_html: str) -> dict[str, Any]:
+    """Extract Zenodo's directly displayed data-volume metric.
+
+    Zenodo's record JSON currently exposes view/download counters but not the
+    landing-page data-volume values used by the UI. Preserve the displayed
+    values verbatim instead of reconstructing them from file sizes/downloads.
+    """
+    text = html.unescape(re.sub(r"<[^>]+>", " ", page_html))
+    text = re.sub(r"\s+", " ", text).strip()
+    match = DATA_VOLUME_PATTERN.search(text)
+    if not match:
+        return {
+            "available": False,
+            "all_versions": None,
+            "this_version": None,
+            "source": "zenodo_record_landing_page",
+        }
+    return {
+        "available": True,
+        "all_versions": match.group(1).strip(),
+        "this_version": match.group(2).strip(),
+        "source": "zenodo_record_landing_page",
+    }
+
+
+def build_snapshot(
+    record: dict[str, Any], authenticated: bool, data_volume: dict[str, Any] | None = None
+) -> dict[str, Any]:
     stats = extract_stats(record)
     observed_version = metadata_version(record)
     return {
         "collector": "ZENODO-V16-READ-STATS-001",
-        "collector_schema": "1.1",
+        "collector_schema": "1.2",
         "captured_at_utc": datetime.now(timezone.utc).isoformat(),
         "remote_method": "GET",
         "read_only": True,
@@ -139,6 +181,13 @@ def build_snapshot(record: dict[str, Any], authenticated: bool) -> dict[str, Any
         "version_binding": "metadata.version" if observed_version else "record_id+doi+conceptdoi",
         "updated": record.get("updated"),
         "stats": stats,
+        "data_volume": data_volume
+        or {
+            "available": False,
+            "all_versions": None,
+            "this_version": None,
+            "source": "zenodo_record_landing_page",
+        },
     }
 
 
@@ -146,6 +195,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Collect authenticated read-only Zenodo v16 statistics.")
     parser.add_argument("--record-id", default=os.environ.get("ZENODO_RECORD_ID", DEFAULT_RECORD_ID))
     parser.add_argument("--api-base", default=os.environ.get("ZENODO_API_BASE", DEFAULT_API_BASE))
+    parser.add_argument("--landing-base", default=os.environ.get("ZENODO_LANDING_BASE", DEFAULT_LANDING_BASE))
     parser.add_argument("--output", type=Path)
     parser.add_argument("--require-auth", action="store_true")
     args = parser.parse_args()
@@ -154,10 +204,22 @@ def main() -> int:
     if args.require_auth and not token:
         raise SystemExit("ZENODO_ACCESS_TOKEN is required but empty")
 
-    url = f"{args.api_base.rstrip('/')}/records/{args.record_id}"
-    record = request_json(url, token)
+    api_url = f"{args.api_base.rstrip('/')}/records/{args.record_id}"
+    record = request_json(api_url, token)
     validate_record(record, args.record_id)
-    snapshot = build_snapshot(record, authenticated=bool(token))
+
+    landing_url = f"{args.landing_base.rstrip('/')}/{args.record_id}"
+    try:
+        data_volume = extract_data_volume(request_text(landing_url, token))
+    except RuntimeError:
+        data_volume = {
+            "available": False,
+            "all_versions": None,
+            "this_version": None,
+            "source": "zenodo_record_landing_page",
+        }
+
+    snapshot = build_snapshot(record, authenticated=bool(token), data_volume=data_volume)
     rendered = json.dumps(snapshot, ensure_ascii=False, indent=2) + "\n"
 
     if args.output:

--- a/tests/test_zenodo_v16_read_stats.py
+++ b/tests/test_zenodo_v16_read_stats.py
@@ -16,7 +16,7 @@ SPEC.loader.exec_module(MODULE)
 class FakeResponse:
     status = 200
 
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: dict | str) -> None:
         self.payload = payload
 
     def __enter__(self):
@@ -26,6 +26,8 @@ class FakeResponse:
         return False
 
     def read(self) -> bytes:
+        if isinstance(self.payload, str):
+            return self.payload.encode("utf-8")
         return json.dumps(self.payload).encode("utf-8")
 
 
@@ -49,6 +51,15 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
             },
         }
 
+    def sample_landing_html(self) -> str:
+        return """
+        <section>
+          <span>Data volume</span>
+          <div>All versions</div><strong>1.8 GB</strong>
+          <div>This version</div><strong>115.4 MB</strong>
+        </section>
+        """
+
     def test_rejects_every_non_get_method(self) -> None:
         for method in ("POST", "PUT", "PATCH", "DELETE"):
             with self.subTest(method=method):
@@ -60,6 +71,15 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
         with patch.object(MODULE.urllib.request, "urlopen", return_value=FakeResponse(record)) as mocked:
             result = MODULE.request_json("https://zenodo.org/api/records/20732376", "secret-token")
         self.assertEqual(result, record)
+        request = mocked.call_args.args[0]
+        self.assertEqual(request.get_method(), "GET")
+        self.assertEqual(request.headers.get("Authorization"), "Bearer secret-token")
+
+    def test_landing_request_is_also_get_only(self) -> None:
+        page = self.sample_landing_html()
+        with patch.object(MODULE.urllib.request, "urlopen", return_value=FakeResponse(page)) as mocked:
+            result = MODULE.request_text("https://zenodo.org/records/20732376", "secret-token")
+        self.assertIn("Data volume", result)
         request = mocked.call_args.args[0]
         self.assertEqual(request.get_method(), "GET")
         self.assertEqual(request.headers.get("Authorization"), "Bearer secret-token")
@@ -94,13 +114,30 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             MODULE.extract_stats(record)
 
+    def test_extracts_directly_displayed_data_volume_without_reconstruction(self) -> None:
+        volume = MODULE.extract_data_volume(self.sample_landing_html())
+        self.assertTrue(volume["available"])
+        self.assertEqual(volume["all_versions"], "1.8 GB")
+        self.assertEqual(volume["this_version"], "115.4 MB")
+        self.assertEqual(volume["source"], "zenodo_record_landing_page")
+
+    def test_data_volume_unavailable_is_explicit_not_invented(self) -> None:
+        volume = MODULE.extract_data_volume("<html><body>No usage block</body></html>")
+        self.assertFalse(volume["available"])
+        self.assertIsNone(volume["all_versions"])
+        self.assertIsNone(volume["this_version"])
+
     def test_snapshot_marks_remote_path_read_only(self) -> None:
-        snapshot = MODULE.build_snapshot(self.sample_record(), authenticated=True)
+        data_volume = MODULE.extract_data_volume(self.sample_landing_html())
+        snapshot = MODULE.build_snapshot(self.sample_record(), authenticated=True, data_volume=data_volume)
         self.assertTrue(snapshot["read_only"])
         self.assertTrue(snapshot["authenticated"])
         self.assertEqual(snapshot["remote_method"], "GET")
         self.assertEqual(snapshot["record_id"], "20732376")
         self.assertEqual(snapshot["version_binding"], "metadata.version")
+        self.assertEqual(snapshot["collector_schema"], "1.2")
+        self.assertEqual(snapshot["data_volume"]["all_versions"], "1.8 GB")
+        self.assertEqual(snapshot["data_volume"]["this_version"], "115.4 MB")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope
Extend the existing read-only Zenodo v16 statistics collector with Zenodo's directly displayed **Data volume** metric.

## Method
- Keep the authenticated Zenodo record API GET as the primary source for the eight existing usage counters.
- Add a second **GET-only** read of the public Zenodo record landing page for the UI-exposed `Data volume` values.
- Preserve the displayed values verbatim (`all_versions`, `this_version`) instead of reconstructing them from file sizes/download counts.
- If the landing-page metric cannot be parsed, mark it explicitly unavailable rather than inventing/deriving a value.
- Collector schema advances from 1.1 to 1.2.

## Safety
No Zenodo mutation methods are introduced. POST/PUT/PATCH/DELETE remain blocked. `main` and published Zenodo artifacts are untouched pending the human gate.

## Tests
Adds coverage for:
- GET-only landing-page request
- extraction of `1.8 GB` / `115.4 MB` fixture values
- explicit unavailable state when the metric is absent
- schema 1.2 snapshot inclusion

## Evidence note
Zenodo/InvenioRDM documents data volume as a tracked usage statistic; this patch treats Zenodo's displayed value as the authoritative metric rather than estimating it.