### PR TITLE
fix(zenodo): sync RC01-v12 metadata candidate with the live record and add a v16 pointer

### DIFF
--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo-rc01-v12-metadata-update.yml.proposed
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo-rc01-v12-metadata-update.yml.proposed
@@ -14,6 +14,22 @@
 # into the payload, and do not remove the assembly step. Removing it while the
 # payload has no description would send a PUT without a description and could
 # blank the public landing page text.
+#
+# Review follow-up (Codex review on PR #110):
+#   P1 - Every field that is actually submitted is now compared against the
+#        authenticated deposition metadata, not only an allowlist of seven
+#        fields. creators, access_right, license, upload_type, publication_type
+#        and any other key present on either side must match, otherwise the run
+#        stops before the edit session is opened. Only description and notes are
+#        treated as intended changes. dates and alternate_identifiers are the
+#        documented accepted losses of the legacy deposit shape. custom is
+#        compared against the public record instead, because the legacy
+#        deposition endpoint does not reliably return it.
+#   P2 - Idempotence no longer depends on a byte-identical HTML substring.
+#        Zenodo may re-serialize the prefix (single-quoted href attributes can
+#        come back double-quoted). Detection now uses stable plain-text markers
+#        that survive HTML sanitization. The v16 DOI link is still verified, but
+#        reported instead of aborting after an already published update.
 
 name: Zenodo Metadata Update - RC01 v12
 
@@ -128,6 +144,13 @@ jobs:
           ]
           expected_v16_doi = "10.5281/zenodo.20732376"
 
+          # Plain-text markers, deliberately attribute-free so that they survive
+          # Zenodo's HTML sanitizer and any re-serialization of quotes.
+          description_prefix_markers = (
+              "es existiert eine neuere Version",
+              "a newer version is available",
+          )
+
           with open(patch_path, encoding="utf-8") as f:
               patch = json.load(f)
 
@@ -148,6 +171,9 @@ jobs:
               raise SystemExit("Description prefix does not contain RC01-v12.")
           if expected_v16_doi not in description_prefix:
               raise SystemExit("Description prefix does not contain the v16 DOI.")
+          for marker in description_prefix_markers:
+              if marker not in description_prefix:
+                  raise SystemExit(f"Description prefix is missing the idempotence marker: {marker}")
           if "description" in candidate:
               raise SystemExit(
                   "Candidate must not carry a hand-written description; "
@@ -183,6 +209,23 @@ jobs:
               if status not in ok:
                   return status, text, parsed
               return status, text, parsed
+
+          def normalize(value):
+              """Make public-API and legacy-deposit representations comparable."""
+              if isinstance(value, dict):
+                  if set(value) == {"id"}:
+                      return value["id"]
+                  return {
+                      k: normalize(v)
+                      for k, v in value.items()
+                      if v not in (None, "", [], {})
+                  }
+              if isinstance(value, list):
+                  return [normalize(v) for v in value]
+              return value
+
+          def is_blank(value):
+              return value in (None, "", [], {})
 
           def require_public_record_unchanged(record):
               if str(record.get("id")) != record_id:
@@ -231,19 +274,62 @@ jobs:
               if candidate.get(field) != live_metadata.get(field):
                   raise SystemExit(f"Candidate {field} does not match the live record.")
 
+          live_custom = normalize(live_metadata.get("custom"))
+          if not is_blank(live_custom) and normalize(candidate.get("custom")) != live_custom:
+              raise SystemExit("Candidate custom metadata does not match the live record.")
+
           live_description = live_metadata.get("description", "") or ""
           if not live_description.strip():
               raise SystemExit("Live record description is empty; refusing to assemble a new description.")
-          if description_prefix.strip() in live_description:
+          prefix_already_present = any(m in live_description for m in description_prefix_markers)
+          if prefix_already_present:
               candidate["description"] = live_description
-              prefix_already_present = True
           else:
               candidate["description"] = description_prefix + live_description
-              prefix_already_present = False
 
           status, text, deposition_before = request("GET", f"{base}/deposit/depositions/{record_id}", auth=True, ok=(200,))
           if status != 200:
               raise SystemExit(f"Could not read authenticated deposition before update: HTTP {status}\n{text}")
+
+          deposition_metadata = (deposition_before or {}).get("metadata", {}) or {}
+          if not deposition_metadata:
+              raise SystemExit("Authenticated deposition returned no metadata; refusing to continue.")
+
+          # The PUT below replaces the complete metadata object, so every key that
+          # is submitted has to be verified, not just the seven fields the public
+          # record exposes in a directly comparable shape.
+          intended_changes = ("description", "notes")
+          accepted_drops = ("dates", "alternate_identifiers")
+          bookkeeping_keys = ("doi", "doi_url", "prereserve_doi")
+          not_returned_by_deposition = ("custom",)
+          drifted = []
+          for key in sorted(set(deposition_metadata) | set(candidate)):
+              if key in intended_changes or key in accepted_drops:
+                  continue
+              if key in bookkeeping_keys or key in not_returned_by_deposition:
+                  continue
+              live_value = normalize(deposition_metadata.get(key))
+              candidate_value = normalize(candidate.get(key))
+              if is_blank(live_value) and is_blank(candidate_value):
+                  continue
+              if live_value != candidate_value:
+                  drifted.append(key)
+
+          if drifted:
+              print(json.dumps({
+                  "payload_vs_live_deposition_drift": {
+                      key: {
+                          "live_deposition": deposition_metadata.get(key),
+                          "candidate": candidate.get(key),
+                      }
+                      for key in drifted
+                  }
+              }, ensure_ascii=False, indent=2))
+              raise SystemExit(
+                  "Payload differs from the live deposition in fields that are not an intended "
+                  f"change: {', '.join(drifted)}. Re-sync the patch file against the live record "
+                  "before running this workflow. No edit session was opened."
+              )
 
           status, text, edit_body = request(
               "POST",
@@ -265,6 +351,7 @@ jobs:
                   "has_notes": "notes" in metadata_payload,
                   "description_assembled_from_live_record": True,
                   "description_prefix_already_present": prefix_already_present,
+                  "payload_verified_against_live_deposition": True,
                   "file_payload_included": False,
                   "new_version_requested": False,
               }
@@ -311,7 +398,9 @@ jobs:
               if status != 200:
                   continue
               polled_description = public_after.get("metadata", {}).get("description", "") or ""
-              if "notion-selectable" not in polled_description and expected_v16_doi in polled_description:
+              if "notion-selectable" not in polled_description and all(
+                  m in polled_description for m in description_prefix_markers
+              ):
                   break
           if status != 200:
               raise SystemExit(f"Could not read public record after update: HTTP {status}\n{text}")
@@ -322,8 +411,16 @@ jobs:
               raise SystemExit("Public description still contains Notion wrapper markup.")
           if "RC01-v12" not in description:
               raise SystemExit("Public description does not contain RC01-v12.")
-          if expected_v16_doi not in description:
-              raise SystemExit("Public description does not contain the v16 pointer.")
+          missing_markers = [m for m in description_prefix_markers if m not in description]
+          if missing_markers:
+              raise SystemExit(f"Public description does not contain the v16 pointer text: {missing_markers}")
+          v16_doi_link_present = expected_v16_doi in description
+          if not v16_doi_link_present:
+              print(
+                  "WARNING: the v16 pointer text is present but the DOI link "
+                  f"{expected_v16_doi} was not found in the public description. "
+                  "Zenodo may have stripped the href attribute. Check the landing page."
+              )
           if public_after.get("metadata", {}).get("title") != live_metadata.get("title"):
               raise SystemExit("Public title changed unexpectedly.")
           if public_after.get("metadata", {}).get("publication_date") != live_metadata.get("publication_date"):
@@ -346,8 +443,10 @@ jobs:
               "references": public_after.get("metadata", {}).get("references"),
               "description_contains_notion_wrapper": "notion-selectable" in description,
               "description_contains_rc01_v12": "RC01-v12" in description,
-              "description_contains_v16_pointer": expected_v16_doi in description,
+              "description_contains_v16_pointer": v16_doi_link_present,
+              "description_contains_v16_pointer_text": not missing_markers,
               "description_prefix_already_present_before_update": prefix_already_present,
+              "payload_verified_against_live_deposition": True,
           }
 
           with open("zenodo_rc01_v12_metadata_update_result.json", "w", encoding="utf-8") as f:
@@ -369,7 +468,9 @@ jobs:
               f.write("- DOI reservation: none\n")
               f.write("- GitHub release/tag: none\n")
               f.write("- Description source: live public description, prefixed with the v16 pointer\n")
-              f.write(f"- v16 pointer present: {summary['description_contains_v16_pointer']}\n")
+              f.write(f"- v16 pointer text present: {summary['description_contains_v16_pointer_text']}\n")
+              f.write(f"- v16 DOI link present: {summary['description_contains_v16_pointer']}\n")
+              f.write("- Every submitted field verified against the live deposition: yes\n")
               f.write("- Repository custom field preserved: yes\n")
 
           print(json.dumps(summary, ensure_ascii=False, indent=2))

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo-rc01-v12-metadata-update.yml.proposed
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo-rc01-v12-metadata-update.yml.proposed
@@ -1,0 +1,386 @@
+# PROPOSED REPLACEMENT for .github/workflows/zenodo-rc01-v12-metadata-update.yml
+#
+# This file is intentionally NOT inside .github/workflows, so GitHub does not
+# execute it. Copy its full content into the real workflow file and delete
+# this file afterwards.
+#
+# Coupled with:
+#   releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+#
+# The guard lists below (expected_keywords, expected_related) and the payload in
+# that JSON file must always be changed together. The payload deliberately
+# carries no description: this workflow reads the live public description and
+# prepends proposed_description_prefix_html to it. Do not add a description back
+# into the payload, and do not remove the assembly step. Removing it while the
+# payload has no description would send a PUT without a description and could
+# blank the public landing page text.
+
+name: Zenodo Metadata Update - RC01 v12
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/zenodo-rc01-v12-metadata-update.yml"
+      - "releases/zenodo/rc01-v12-metadata-patch-2026-05-13/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-metadata:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'execute-zenodo-z2-metadata-update')
+    runs-on: ubuntu-latest
+
+    env:
+      ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_API }}
+      ZENODO_API_BASE: https://zenodo.org/api
+      ZENODO_RECORD_ID: "20073579"
+      METADATA_PATCH_PATH: releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+      EXPECTED_DOI: 10.5281/zenodo.20073579
+      EXPECTED_CONCEPT_DOI: 10.5281/zenodo.19774446
+      EXPECTED_VERSION: RC01-v12
+      EXPECTED_FILE_NAME: main (44).pdf
+      EXPECTED_FILE_SIZE: "2943457"
+      EXPECTED_FILE_MD5: md5:d791d480e75f3d89f9a103a28a5c5001
+      EXPECTED_REPOSITORY: https://github.com/Terra-Nova-Restore/TerraNova-s-Framework
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Normalize Zenodo token
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ZENODO_ACCESS_TOKEN}" ]; then
+            echo "GitHub secret ZENODO_API is empty or missing."
+            exit 1
+          fi
+
+          TOKEN="${ZENODO_ACCESS_TOKEN//$'\r'/}"
+          TOKEN="${TOKEN//$'\n'/}"
+          TOKEN="$(printf '%s' "${TOKEN}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^[Bb][Ee][Aa][Rr][Ee][Rr][[:space:]]+//')"
+
+          if [ -z "${TOKEN}" ]; then
+            echo "GitHub secret ZENODO_API is empty after normalization."
+            exit 1
+          fi
+
+          echo "::add-mask::${TOKEN}"
+          {
+            echo "ZENODO_BEARER_TOKEN<<EOF"
+            printf '%s\n' "${TOKEN}"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
+
+      - name: Apply metadata-only update
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.request
+
+          base = os.environ["ZENODO_API_BASE"].rstrip("/")
+          record_id = os.environ["ZENODO_RECORD_ID"]
+          token = os.environ["ZENODO_BEARER_TOKEN"]
+          patch_path = os.environ["METADATA_PATCH_PATH"]
+          expected_repo = os.environ["EXPECTED_REPOSITORY"]
+
+          expected_keywords = [
+              "Human-AI Cooperation",
+              "Cognitive Architecture",
+              "Systems Engineering",
+              "AI Governance",
+              "Codex Framework",
+              "Co-Creation",
+              "Interaction Design",
+              "Knowledge Architecture",
+              "Resonance Systems",
+              "TerraNova",
+              "FerrAI",
+          ]
+          expected_related = [
+              {
+                  "identifier": "10.5281/zenodo.19774446",
+                  "relation": "isVersionOf",
+                  "scheme": "doi",
+                  "resource_type": "publication-other",
+              },
+              {
+                  "identifier": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
+                  "relation": "isSupplementedBy",
+                  "scheme": "url",
+                  "resource_type": "software",
+              },
+          ]
+          expected_references = [
+              "Lenhard, S. (2026). FerrAI / Terra Nova: Dissertationsentwurf. Zenodo. https://doi.org/10.5281/zenodo.19774446"
+          ]
+          expected_v16_doi = "10.5281/zenodo.20732376"
+
+          with open(patch_path, encoding="utf-8") as f:
+              patch = json.load(f)
+
+          review_package = patch.get("review_package", {})
+          if review_package.get("zenodo_mutation_authorized") is not True:
+              raise SystemExit(
+                  "Patch file does not authorize a Zenodo mutation "
+                  "(review_package.zenodo_mutation_authorized is not true)."
+              )
+
+          candidate = patch["proposed_api_payload_candidate"]["metadata"]
+          description_prefix = patch.get("proposed_description_prefix_html") or ""
+          if not description_prefix.strip():
+              raise SystemExit("Patch file is missing proposed_description_prefix_html.")
+          if "notion-selectable" in description_prefix:
+              raise SystemExit("Description prefix contains Notion wrapper markup.")
+          if "RC01-v12" not in description_prefix:
+              raise SystemExit("Description prefix does not contain RC01-v12.")
+          if expected_v16_doi not in description_prefix:
+              raise SystemExit("Description prefix does not contain the v16 DOI.")
+          if "description" in candidate:
+              raise SystemExit(
+                  "Candidate must not carry a hand-written description; "
+                  "the description is assembled from the live record."
+              )
+          if candidate.get("keywords") != expected_keywords:
+              raise SystemExit("Candidate keywords drifted.")
+          if candidate.get("related_identifiers") != expected_related:
+              raise SystemExit("Candidate related_identifiers drifted.")
+          if candidate.get("references") != expected_references:
+              raise SystemExit("Candidate references drifted.")
+          if candidate.get("custom", {}).get("code:codeRepository") != expected_repo:
+              raise SystemExit("Candidate repository custom field missing.")
+
+          def request(method, url, data=None, auth=False, ok=(200,)):
+              headers = {"Accept": "application/json"}
+              body = None
+              if data is not None:
+                  body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+                  headers["Content-Type"] = "application/json"
+              if auth:
+                  headers["Authorization"] = f"Bearer {token}"
+              req = urllib.request.Request(url, data=body, headers=headers, method=method)
+              try:
+                  with urllib.request.urlopen(req, timeout=60) as resp:
+                      text = resp.read().decode("utf-8")
+                      status = resp.status
+              except urllib.error.HTTPError as exc:
+                  text = exc.read().decode("utf-8", errors="replace")
+                  return exc.code, text, None
+
+              parsed = json.loads(text) if text else None
+              if status not in ok:
+                  return status, text, parsed
+              return status, text, parsed
+
+          def require_public_record_unchanged(record):
+              if str(record.get("id")) != record_id:
+                  raise SystemExit("Unexpected record id.")
+              if record.get("doi") != os.environ["EXPECTED_DOI"]:
+                  raise SystemExit("Unexpected DOI.")
+              if record.get("conceptdoi") != os.environ["EXPECTED_CONCEPT_DOI"]:
+                  raise SystemExit("Unexpected concept DOI.")
+              metadata = record.get("metadata", {})
+              if metadata.get("version") != os.environ["EXPECTED_VERSION"]:
+                  raise SystemExit("Unexpected version.")
+              if metadata.get("custom", {}).get("code:codeRepository") != expected_repo:
+                  raise SystemExit("Repository custom field missing on public record.")
+              if metadata.get("keywords") != expected_keywords:
+                  raise SystemExit("Public keywords drifted.")
+              if metadata.get("related_identifiers") != expected_related:
+                  raise SystemExit("Public related_identifiers drifted.")
+              if metadata.get("references") != expected_references:
+                  raise SystemExit("Public references drifted.")
+              files = record.get("files", [])
+              if len(files) != 1:
+                  raise SystemExit("Unexpected file count.")
+              file0 = files[0]
+              if file0.get("key") != os.environ["EXPECTED_FILE_NAME"]:
+                  raise SystemExit("Unexpected file name.")
+              if str(file0.get("size")) != os.environ["EXPECTED_FILE_SIZE"]:
+                  raise SystemExit("Unexpected file size.")
+              if file0.get("checksum") != os.environ["EXPECTED_FILE_MD5"]:
+                  raise SystemExit("Unexpected file checksum.")
+
+          status, text, public_before = request("GET", f"{base}/records/{record_id}", ok=(200,))
+          if status != 200:
+              raise SystemExit(f"Could not read public record before update: HTTP {status}\n{text}")
+          require_public_record_unchanged(public_before)
+
+          live_metadata = public_before.get("metadata", {})
+          for field in (
+              "title",
+              "publication_date",
+              "version",
+              "language",
+              "keywords",
+              "related_identifiers",
+              "references",
+          ):
+              if candidate.get(field) != live_metadata.get(field):
+                  raise SystemExit(f"Candidate {field} does not match the live record.")
+
+          live_description = live_metadata.get("description", "") or ""
+          if not live_description.strip():
+              raise SystemExit("Live record description is empty; refusing to assemble a new description.")
+          if description_prefix.strip() in live_description:
+              candidate["description"] = live_description
+              prefix_already_present = True
+          else:
+              candidate["description"] = description_prefix + live_description
+              prefix_already_present = False
+
+          status, text, deposition_before = request("GET", f"{base}/deposit/depositions/{record_id}", auth=True, ok=(200,))
+          if status != 200:
+              raise SystemExit(f"Could not read authenticated deposition before update: HTTP {status}\n{text}")
+
+          status, text, edit_body = request(
+              "POST",
+              f"{base}/deposit/depositions/{record_id}/actions/edit",
+              auth=True,
+              ok=(200, 201, 202),
+          )
+          if status not in (200, 201, 202):
+              raise SystemExit(f"Could not open metadata edit: HTTP {status}\n{text}")
+
+          edit_id = str((edit_body or {}).get("id") or record_id)
+          metadata_payload = dict(candidate)
+          update_body = {"metadata": metadata_payload}
+
+          print(json.dumps({
+              "zenodo_legacy_deposit_edit_shape": {
+                  "edit_id": edit_id,
+                  "metadata_keys": sorted(metadata_payload),
+                  "has_notes": "notes" in metadata_payload,
+                  "description_assembled_from_live_record": True,
+                  "description_prefix_already_present": prefix_already_present,
+                  "file_payload_included": False,
+                  "new_version_requested": False,
+              }
+          }, ensure_ascii=False, indent=2))
+
+          status, text, update_response = request(
+              "PUT",
+              f"{base}/deposit/depositions/{edit_id}",
+              data=update_body,
+              auth=True,
+              ok=(200,),
+          )
+
+          if status != 200 and "notes" in metadata_payload:
+              metadata_payload = dict(metadata_payload)
+              metadata_payload.pop("notes", None)
+              update_body = {"metadata": metadata_payload}
+              status, text, update_response = request(
+                  "PUT",
+                  f"{base}/deposit/depositions/{edit_id}",
+                  data=update_body,
+                  auth=True,
+                  ok=(200,),
+              )
+
+          if status != 200:
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata PUT failed; edit was discarded. HTTP {status}\n{text}")
+
+          status, text, publish_response = request(
+              "POST",
+              f"{base}/deposit/depositions/{edit_id}/actions/publish",
+              auth=True,
+              ok=(200, 202),
+          )
+          if status not in (200, 202):
+              request("POST", f"{base}/deposit/depositions/{edit_id}/actions/discard", auth=True, ok=(200, 201, 202, 204))
+              raise SystemExit(f"Metadata publish failed; edit discard attempted. HTTP {status}\n{text}")
+
+          public_after = None
+          for _ in range(12):
+              time.sleep(5)
+              status, text, public_after = request("GET", f"{base}/records/{record_id}", ok=(200,))
+              if status != 200:
+                  continue
+              polled_description = public_after.get("metadata", {}).get("description", "") or ""
+              if "notion-selectable" not in polled_description and expected_v16_doi in polled_description:
+                  break
+          if status != 200:
+              raise SystemExit(f"Could not read public record after update: HTTP {status}\n{text}")
+
+          require_public_record_unchanged(public_after)
+          description = public_after.get("metadata", {}).get("description", "") or ""
+          if "notion-selectable" in description:
+              raise SystemExit("Public description still contains Notion wrapper markup.")
+          if "RC01-v12" not in description:
+              raise SystemExit("Public description does not contain RC01-v12.")
+          if expected_v16_doi not in description:
+              raise SystemExit("Public description does not contain the v16 pointer.")
+          if public_after.get("metadata", {}).get("title") != live_metadata.get("title"):
+              raise SystemExit("Public title changed unexpectedly.")
+          if public_after.get("metadata", {}).get("publication_date") != live_metadata.get("publication_date"):
+              raise SystemExit("Public publication date changed unexpectedly.")
+
+          summary = {
+              "status": "ZENODO_METADATA_UPDATED",
+              "record_id": record_id,
+              "doi": public_after.get("doi"),
+              "conceptdoi": public_after.get("conceptdoi"),
+              "version": public_after.get("metadata", {}).get("version"),
+              "title": public_after.get("metadata", {}).get("title"),
+              "publication_date": public_after.get("metadata", {}).get("publication_date"),
+              "revision": public_after.get("revision"),
+              "file_count": len(public_after.get("files", [])),
+              "file": public_after.get("files", [{}])[0],
+              "custom": public_after.get("metadata", {}).get("custom"),
+              "keywords": public_after.get("metadata", {}).get("keywords"),
+              "related_identifiers": public_after.get("metadata", {}).get("related_identifiers"),
+              "references": public_after.get("metadata", {}).get("references"),
+              "description_contains_notion_wrapper": "notion-selectable" in description,
+              "description_contains_rc01_v12": "RC01-v12" in description,
+              "description_contains_v16_pointer": expected_v16_doi in description,
+              "description_prefix_already_present_before_update": prefix_already_present,
+          }
+
+          with open("zenodo_rc01_v12_metadata_update_result.json", "w", encoding="utf-8") as f:
+              json.dump(summary, f, ensure_ascii=False, indent=2)
+
+          with open("zenodo_rc01_v12_metadata_update_result.md", "w", encoding="utf-8") as f:
+              f.write("# Zenodo RC01-v12 Metadata Update Result\n\n")
+              f.write("Status: ZENODO_METADATA_UPDATED\n\n")
+              f.write(f"- Record ID: {summary['record_id']}\n")
+              f.write(f"- DOI: {summary['doi']}\n")
+              f.write(f"- Concept DOI: {summary['conceptdoi']}\n")
+              f.write(f"- Version: {summary['version']}\n")
+              f.write(f"- Title: {summary['title']}\n")
+              f.write(f"- Publication date: {summary['publication_date']}\n")
+              f.write(f"- Revision: {summary['revision']}\n")
+              f.write(f"- File count: {summary['file_count']}\n")
+              f.write("- File update: none\n")
+              f.write("- New version: none\n")
+              f.write("- DOI reservation: none\n")
+              f.write("- GitHub release/tag: none\n")
+              f.write("- Description source: live public description, prefixed with the v16 pointer\n")
+              f.write(f"- v16 pointer present: {summary['description_contains_v16_pointer']}\n")
+              f.write("- Repository custom field preserved: yes\n")
+
+          print(json.dumps(summary, ensure_ascii=False, indent=2))
+          PY
+
+      - name: Upload execution evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenodo-rc01-v12-metadata-update-result
+          path: |
+            zenodo_rc01_v12_metadata_update_result.json
+            zenodo_rc01_v12_metadata_update_result.md
+          if-no-files-found: warn

--- a/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
+++ b/releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json
@@ -1,8 +1,9 @@
 {
   "review_package": {
     "id": "rc01-v12-metadata-patch-2026-05-13",
-    "status": "REVIEW_ONLY_NO_MUTATION",
+    "status": "READY_FOR_OPERATOR_AUTHORIZATION",
     "created_date": "2026-05-13",
+    "last_sync_date": "2026-08-16",
     "target_record_id": "20073579",
     "target_record_url": "https://zenodo.org/records/20073579",
     "specific_doi": "10.5281/zenodo.20073579",
@@ -12,11 +13,31 @@
     "file_update": false,
     "new_version": false,
     "doi_reservation": false,
-    "zenodo_mutation_authorized": false
+    "zenodo_mutation_authorized": false,
+    "authorization_note": "The workflow .github/workflows/zenodo-rc01-v12-metadata-update.yml refuses to run while zenodo_mutation_authorized is false. Set it to true in a separate, deliberate commit when the metadata-only mutation is actually intended."
+  },
+  "live_record_sync": {
+    "synced_on": "2026-08-16",
+    "source": "GET https://zenodo.org/api/records/20073579",
+    "record_revision_at_sync": 12,
+    "record_updated_at_sync": "2026-05-21T17:29:35.963451+00:00",
+    "reason": "The payload of 2026-05-13 predated the live metadata refresh of 2026-05-21 and would have reverted four live fields.",
+    "reverted_fields_prevented": [
+      "title",
+      "description",
+      "keywords",
+      "related_identifiers"
+    ],
+    "intended_change": "Prepend a bilingual pointer to the description that names v16 (10.5281/zenodo.20732376) as the current version. Nothing else changes."
   },
   "current_record_facts": {
-    "title": "FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat",
-    "publication_date": "2026-05-07",
+    "title": "FerrAI–Terra'Nova CIC Framework — System Architecture, State Logic and Governance Boundaries",
+    "publication_date": "2026-05-17",
+    "record_created": "2026-05-07T17:39:34.352179+00:00",
+    "record_updated": "2026-05-21T17:29:35.963451+00:00",
+    "revision": 12,
+    "version_index_in_concept": 11,
+    "is_latest_version": false,
     "status": "published",
     "resource_type": "Book",
     "access_right": "open",
@@ -28,19 +49,30 @@
     "file_name": "main (44).pdf",
     "file_size_bytes": 2943457,
     "file_md5": "d791d480e75f3d89f9a103a28a5c5001",
-    "file_sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40"
+    "file_sha256": "1e9ce2f810b0af8c245887bb3a01ebcb01ca8f90c971bd5cf39da47a6b8dda40",
+    "version_stats_at_sync": {
+      "downloads": 299,
+      "unique_downloads": 258,
+      "views": 309,
+      "unique_views": 273
+    }
   },
   "review_findings": [
-    "The current public Zenodo metadata already has the correct DOI, concept DOI, version, ORCID, custom code repository link, license, and file checksum.",
-    "The current description contains exported Notion wrapper markup and an older reference-snapshot wording that should be reviewed before any metadata edit.",
-    "main (45).pdf is byte-identical to main (44).pdf and must not be used as a new file update or RC01-v13 payload."
+    "Verified against the live record on 2026-08-16: record id, DOI, concept DOI, version label, ORCID, custom code repository field, license, upload type, file name, file size and file checksum are unchanged and correct.",
+    "The exported Notion wrapper markup noted in the 2026-05-13 review is no longer present in the public description. The description was replaced by the framework and persistence-layer wording during the metadata refresh of 2026-05-21 (revision 12).",
+    "main (45).pdf is byte-identical to main (44).pdf and must not be used as a new file update or RC01-v13 payload.",
+    "The 2026-05-13 payload still carried the pre-refresh title, description, keywords and related_identifiers. Applying it unchanged would have reverted those four live fields and deleted the isSupplementedBy relation to this repository. All four are now synchronized with the live record.",
+    "publication_date is now carried explicitly in the payload. The legacy deposit API defaults an omitted publication_date to the current date, which would have silently moved it away from 2026-05-17.",
+    "Known and accepted side effect: the live record carries dates: [{type: updated, description: 'Metadata refresh — Z3 lane, RC01-v12'}] and an alternate_identifiers entry. Neither field is expressible in the legacy deposit payload used by this workflow, so both may be dropped when the metadata-only update is published. Both are cosmetic; the record id, DOI, version label, file and checksum are unaffected."
   ],
+  "description_policy": "The description is deliberately not stored in this payload. The workflow reads the live public description and prepends proposed_description_prefix_html to it byte-for-byte, so a hand-copied description can never overwrite the live wording. The prepend is idempotent: if the prefix is already present, the live description is used unchanged. The workflow rejects any payload that carries its own description field.",
+  "proposed_description_prefix_html": "<p><strong>Hinweis — es existiert eine neuere Version.</strong> Dieser Eintrag ist der RC01-v12-Referenzanker vom Mai 2026; Datei, DOI und Versionslabel bleiben zur Zitierstabilität unverändert. Die aktuelle Fassung dieses Werks ist <a href='https://doi.org/10.5281/zenodo.20732376'>v16 (713 Seiten)</a>. Der Concept-DOI <a href='https://doi.org/10.5281/zenodo.19774446'>10.5281/zenodo.19774446</a> verweist stets auf die neueste Version.</p><p><strong>Note — a newer version is available.</strong> This record is the RC01-v12 reference anchor of May 2026; its file, DOI and version label are intentionally preserved for citation stability. The current version of this work is <a href='https://doi.org/10.5281/zenodo.20732376'>v16 (713 pages)</a>. The concept DOI <a href='https://doi.org/10.5281/zenodo.19774446'>10.5281/zenodo.19774446</a> always resolves to the latest version.</p>",
   "proposed_api_payload_candidate": {
     "metadata": {
-      "title": "FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat",
+      "title": "FerrAI–Terra'Nova CIC Framework — System Architecture, State Logic and Governance Boundaries",
       "upload_type": "publication",
       "publication_type": "book",
-      "description": "<h2>Zenodo Description -- Deutsch</h2><p><strong>FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat</strong></p><p>Diese Veröffentlichung dokumentiert den zitierfähigen Release Candidate <code>RC01-v12</code> einer Werkmonographie mit Evidenzapparat zum FerrAI-/Terra-Nova-/CIC-Komplex. Die Schrift rekonstruiert Terra Nova im sichtbaren lokalen Korpus nicht als einzelnen Prompt, isoliertes Modell oder bloßes Whitepaper, sondern als mehrschichtigen Verbund aus Systemarchitektur, operativer Prozesslogik, Claim/Evidence-Governance, Triggerordnung, dokumentierten Patent- und Rechtsspuren sowie Tokenisierungs- und Verwertungslogik.</p><p>Im Zentrum steht eine quellengebundene editorische Rekonstruktion des gezählten Terra-Nova-/FerrAI-Korpus und der sichtbaren CIC-Dokumentfamilie. Der gezählte Kernkorpus umfasst in dieser Fassung 67 HTML- und CSV-Exporte; Supplemente, Workspace-Spuren, Uploads, Arbeitsnotizen und spätere Rückführungen werden ausdrücklich mitgeführt, aber nicht unmarkiert mit dem Kernkorpus vermischt. Dadurch bleiben Belegbasis, editorische Ableitung und offene Stellen nachvollziehbar getrennt.</p><p>CIC wird in dieser Fassung als <code>Cognitive Intelligent Cooperation</code> normiert, zugleich aber als sichtbare Dokument- und Frameworkschicht vom engeren Primärbegriff der Kooperationslogik unterschieden. Methodisch arbeitet das Manuskript mit expliziten Statusmarkern und einer textbasierten Claim/Evidence-Logik. Die Arbeit ist bewusst als textorientierte Hauptschrift angelegt; ein größerer visueller Diagramm-, Tabellen- und Bildkörper wird methodisch zurückgestellt, bis Begriffe, Mapping-Schichten und Evidenzgrenzen weiter gehärtet sind.</p><p>Das Dokument ist keine abgeschlossene peer-reviewte Dissertation. Es ist ein versioniertes Forschungsmanuskript, eine Werkmonographie mit Evidenzapparat und ein bewusst offen gehaltener Release Candidate, der Haupttext, Appendix, Registerräume und Ausbaukorridor transparent zusammenführt.</p><h2>Zenodo Description -- English</h2><p>This release documents the citable release candidate <code>RC01-v12</code> of a work monograph with evidence apparatus on the FerrAI / Terra Nova / CIC complex. Rather than treating Terra Nova as a single prompt, an isolated model, or a standalone white paper, the manuscript reconstructs it from the visible local corpus as a layered assemblage of system architecture, operational process logic, claim/evidence governance, trigger order, documented patent and rights traces, and tokenization and utilization logic.</p><p>At its core, the work offers a source-bound editorial reconstruction of the counted Terra Nova / FerrAI corpus and the visible CIC document family. In this version, the counted core corpus comprises 67 HTML and CSV exports; supplementary workspace traces, uploads, working notes, and later reintegrations are explicitly retained, but not silently merged with the core corpus. This keeps primary evidence, editorial inference, and open questions clearly distinct.</p><p>In this edition, CIC is normalized as <code>Cognitive Intelligent Cooperation</code> while also being distinguished, as a visible document and framework layer, from the narrower primary term of cooperative logic. Methodologically, the manuscript relies on explicit status markers and a text-based claim/evidence regime. The work is intentionally designed as a text-first main edition; a larger visual body of diagrams, tables, and rendered graphics is deliberately postponed until terminology, mapping layers, and evidence boundaries have been further stabilized.</p><p>This document is not a completed peer-reviewed dissertation. It is a versioned research manuscript, a work monograph with evidence apparatus, and a deliberately open release candidate that transparently brings together the main text, appendices, registers, and an expansion corridor.</p><h2>Version Note</h2><p>Versionierter Forschungsstand / zitierfähiger Release Candidate <code>RC01-v12</code>.</p><p>Publication date: <code>2026-05-07</code>. Current record DOI: <code>10.5281/zenodo.20073579</code>. Concept DOI: <code>10.5281/zenodo.19774446</code>.</p><h2>Additional Notes</h2><p><strong>English:</strong> This release represents a citable RC state within a versioned publication chain. Later releases may include expanded source registers, revised matrices, additional chapters, a broadened visual apparatus, and further hardened terminology and evidence boundaries.</p><p><strong>Deutsch:</strong> Diese Veröffentlichung markiert einen zitierfähigen RC-Stand innerhalb einer versionierten Publikationskette. Spätere Releases können erweiterte Quellenregister, überarbeitete Matrizen, zusätzliche Kapitel, einen ausgebauten visuellen Apparat sowie weiter gehärtete Terminologie- und Evidenzgrenzen enthalten.</p>",
+      "publication_date": "2026-05-17",
       "creators": [
         {
           "name": "Lenhard, Silvan",
@@ -53,16 +85,17 @@
       "version": "RC01-v12",
       "language": "deu",
       "keywords": [
-        "CIC",
-        "Zenodo",
-        "Github",
-        "Notion",
-        "audit trail",
-        "complex systems",
-        "AI ethics",
-        "FerrAI",
-        "Terra'Nova'Restore",
-        "human-AI interaction"
+        "Human-AI Cooperation",
+        "Cognitive Architecture",
+        "Systems Engineering",
+        "AI Governance",
+        "Codex Framework",
+        "Co-Creation",
+        "Interaction Design",
+        "Knowledge Architecture",
+        "Resonance Systems",
+        "TerraNova",
+        "FerrAI"
       ],
       "related_identifiers": [
         {
@@ -70,6 +103,12 @@
           "relation": "isVersionOf",
           "scheme": "doi",
           "resource_type": "publication-other"
+        },
+        {
+          "identifier": "https://github.com/Terra-Nova-Restore/TerraNova-s-Framework",
+          "relation": "isSupplementedBy",
+          "scheme": "url",
+          "resource_type": "software"
         }
       ],
       "custom": {
@@ -78,7 +117,7 @@
       "references": [
         "Lenhard, S. (2026). FerrAI / Terra Nova: Dissertationsentwurf. Zenodo. https://doi.org/10.5281/zenodo.19774446"
       ],
-      "notes": "Metadata-only v0.2 review candidate for the existing RC01-v12 record. It preserves the current custom code repository field, current keywords, current concept DOI reference, and current isVersionOf relation. No file update, new version, DOI reservation, upload, or publish action is authorized by this file."
+      "notes": "Metadata-only refresh candidate for the existing RC01-v12 record, synchronized with the live record on 2026-08-16 (revision 12). It preserves record id, DOI, concept DOI, version label, publication date, title, keywords, related identifiers, references, license, upload type, custom code repository field and the single file. The only intended change is a bilingual pointer paragraph prepended to the description, naming v16 (10.5281/zenodo.20732376) as the current version and the concept DOI as the resolver that always points to the latest version. No file upload, new version, DOI reservation, license change or upload type change is authorized by this file."
     }
   }
 }


### PR DESCRIPTION
## Why

The review payload in `releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo_metadata_patch.rc01-v12.review.json` was written on **2026-05-13**. The live record `20073579` was refreshed on **2026-05-21** (revision 12). Applied unchanged, the payload would have **reverted four live fields** and **deleted the `isSupplementedBy` relation pointing at this repository**.

Verified against `GET https://zenodo.org/api/records/20073579` on 2026-08-16.

| Field | Live record (revision 12) | Payload before this PR |
| --- | --- | --- |
| `title` | `FerrAI–Terra'Nova CIC Framework — System Architecture, State Logic and Governance Boundaries` | `FerrAI / Terra Nova / CIC: Werkmonographie mit Evidenzapparat` |
| `description` | framework / persistence-layer wording, no Notion wrapper markup | May work-monograph wording, different text |
| `keywords` | 11 entries, `Human-AI Cooperation` … `FerrAI` | 10 entries, `CIC` … `human-AI interaction` |
| `related_identifiers` | **2** entries: `isVersionOf` + `isSupplementedBy` (this repo) | **1** entry: `isVersionOf` only |

The payload's own `notes` claimed it "preserves the current custom code repository field, current keywords, current concept DOI reference, and current isVersionOf relation". That has been factually wrong since 2026-05-21.

## What this PR changes

1. `title`, `keywords` and `related_identifiers` now mirror the live record exactly.
2. `publication_date: "2026-05-17"` is now carried explicitly. The legacy deposit API defaults an omitted `publication_date` to the current date, so leaving it out could have silently moved the record's publication date to the day of the run.
3. `description` is **removed** from the payload and replaced by `proposed_description_prefix_html`. The workflow reads the live description and prepends the prefix byte-for-byte. Rationale: the live description is long sanitized HTML; a hand-copied version would silently overwrite the real wording. The prepend is idempotent — if the prefix is already present, the live description is used unchanged.
4. `review_package.status`, `live_record_sync`, `current_record_facts` and `review_findings` now describe the verified state instead of the May state.
5. `zenodo_mutation_authorized` deliberately stays `false`.

The only intended visible change on the landing page is this block, prepended to the existing description:

> **Hinweis — es existiert eine neuere Version.** Dieser Eintrag ist der RC01-v12-Referenzanker vom Mai 2026; Datei, DOI und Versionslabel bleiben zur Zitierstabilität unverändert. Die aktuelle Fassung dieses Werks ist v16 (713 Seiten). Der Concept-DOI 10.5281/zenodo.19774446 verweist stets auf die neueste Version.
>
> **Note — a newer version is available.** This record is the RC01-v12 reference anchor of May 2026; its file, DOI and version label are intentionally preserved for citation stability. The current version of this work is v16 (713 pages). The concept DOI 10.5281/zenodo.19774446 always resolves to the latest version.

## Required second step, not contained in this PR

The matching change to `.github/workflows/zenodo-rc01-v12-metadata-update.yml` **could not be pushed**: the GitHub App that opened this PR has no `workflows` permission (`403 refusing to allow a GitHub App to create or update workflow ... without workflows permission`).

The complete proposed replacement content is included in this PR as a plain file:

`releases/zenodo/rc01-v12-metadata-patch-2026-05-13/zenodo-rc01-v12-metadata-update.yml.proposed`

To land it, either copy that file's full content into the real workflow file by hand and delete the `.proposed` file, or grant the `workflows` permission and let it be pushed directly.

What it changes:

- `expected_keywords`: the 11 live keywords instead of the May snapshot
- `expected_related`: two entries including `isSupplementedBy`
- refuses to run unless `review_package.zenodo_mutation_authorized` is `true`
- assembles the description from the live record plus the pointer, and rejects any payload that carries its own `description`
- checks `title`, `publication_date`, `version`, `language`, `keywords`, `related_identifiers` and `references` against the live record before mutating anything
- polls until the pointer is actually visible on the public record, then verifies it, the title and the publication date

## Safety state right now

If the workflow were dispatched with this PR merged but the workflow file unchanged, it exits at `Candidate keywords drifted.` **before the first Zenodo request**. Nothing is mutated. The current state is fail-closed.

> [!WARNING]
> Do **not** fix only `expected_keywords` and `expected_related` in the workflow. The payload deliberately carries no `description`. Without the assembly step, the PUT would be sent without a description and could blank the public landing page text. Replace the whole workflow file.

## Order of operations

1. Review and merge this PR (payload first).
2. Apply the proposed workflow file (guards second).
3. Set `zenodo_mutation_authorized` to `true` in a separate, deliberate commit.
4. Run `Zenodo Metadata Update - RC01 v12` via `workflow_dispatch`.
5. Check the `zenodo-rc01-v12-metadata-update-result` artifact.

Expected on success: `ZENODO_METADATA_UPDATED`, `file_count: 1`, DOI, concept DOI, version label, file name, size and checksum unchanged, revision 12 → 13.

Never loosen the guards on their own. The guards are the only thing currently preventing the four-field regression described above.

## Known and accepted side effects

The live record carries `dates: [{type: updated, description: "Metadata refresh — Z3 lane, RC01-v12"}]` and an `alternate_identifiers` entry. Neither field is expressible in the legacy deposit payload this workflow uses, so both may be dropped when the metadata-only update is published. Both are cosmetic. Record id, DOI, concept DOI, version label, file and checksum are unaffected.

## Not done here

No merge, no `workflow_dispatch`, no Zenodo request was performed while preparing this PR. All Zenodo access was read-only.