### PR TITLE
Fix Zenodo collector timeout retries

### DIFF
--- a/scripts/zenodo_v16_read_stats.py
+++ b/scripts/zenodo_v16_read_stats.py
@@ -66,7 +66,7 @@ def request_bytes(url: str, token: str, accept: str, attempts: int = 4) -> bytes
                 body = exc.read().decode("utf-8", errors="replace")
                 raise RuntimeError(f"Zenodo GET failed: HTTP {exc.code}: {body[:500]}") from exc
             time.sleep(2 ** (attempt - 1))
-        except urllib.error.URLError as exc:
+        except (TimeoutError, urllib.error.URLError) as exc:
             if attempt == attempts:
                 raise RuntimeError(f"Zenodo GET failed: {exc}") from exc
             time.sleep(2 ** (attempt - 1))

--- a/tests/test_zenodo_v16_read_stats.py
+++ b/tests/test_zenodo_v16_read_stats.py
@@ -66,6 +66,33 @@ class ZenodoV16ReadStatsTests(unittest.TestCase):
         self.assertEqual(request.get_method(), "GET")
         self.assertEqual(request.headers.get("Authorization"), "Bearer secret-token")
 
+    def test_retries_direct_timeout_error(self) -> None:
+        record = self.sample_record()
+        with patch.object(
+            MODULE.urllib.request,
+            "urlopen",
+            side_effect=[TimeoutError("read timed out"), FakeResponse(record)],
+        ) as mocked, patch.object(MODULE.time, "sleep") as sleep:
+            result = MODULE.request_json(
+                "https://zenodo.org/api/records/20732376", "secret-token", attempts=2
+            )
+        self.assertEqual(result, record)
+        self.assertEqual(mocked.call_count, 2)
+        sleep.assert_called_once_with(1)
+
+    def test_direct_timeout_error_fails_closed_after_retries(self) -> None:
+        with patch.object(
+            MODULE.urllib.request,
+            "urlopen",
+            side_effect=TimeoutError("read timed out"),
+        ) as mocked, patch.object(MODULE.time, "sleep") as sleep:
+            with self.assertRaisesRegex(RuntimeError, "Zenodo GET failed"):
+                MODULE.request_json(
+                    "https://zenodo.org/api/records/20732376", "secret-token", attempts=2
+                )
+        self.assertEqual(mocked.call_count, 2)
+        sleep.assert_called_once_with(1)
+
     def test_validates_current_v16_identity_when_version_is_present(self) -> None:
         MODULE.validate_record(self.sample_record(), "20732376")
 


### PR DESCRIPTION
## Summary
- catch direct `TimeoutError` alongside `URLError` in the read-only Zenodo GET retry loop
- preserve existing GET-only behavior and HTTP retry policy
- add regression tests for retrying a direct read timeout and failing closed as `RuntimeError` after retries

## Why
A direct SSL/socket read timeout can escape `urllib.error.URLError`, bypassing the existing retry logic and causing the authenticated collector job to fail immediately. This patch routes that timeout through the existing bounded retry/backoff path.

No Zenodo mutation behavior is introduced.